### PR TITLE
Make EuropeanOption abstract and add tests

### DIFF
--- a/src/options.py
+++ b/src/options.py
@@ -1,17 +1,20 @@
 """Option contract definitions."""
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 import numpy as np
 
 
 @dataclass
-class EuropeanOption:
+class EuropeanOption(ABC):
     """Base class for European options."""
 
     strike: float
 
+    @abstractmethod
     def payoff(self, s: np.ndarray) -> np.ndarray:  # pragma: no cover - abstract
+        """Return the payoff at expiry for underlying prices ``s``."""
         raise NotImplementedError
 
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,0 +1,31 @@
+"""Tests for option base class and subclasses."""
+import pathlib
+import sys
+
+# Ensure project root on path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import numpy as np
+import pytest
+from src.options import EuropeanOption, EuropeanCall, EuropeanPut
+
+
+def test_base_class_is_abstract():
+    """EuropeanOption cannot be instantiated directly."""
+    with pytest.raises(TypeError):
+        EuropeanOption(strike=1.0)
+
+
+def test_subclasses_behave_correctly():
+    """Subclasses inherit from EuropeanOption and compute correct payoffs."""
+    s = np.array([0.5, 1.0, 1.5])
+    call = EuropeanCall(strike=1.0)
+    put = EuropeanPut(strike=1.0)
+
+    assert issubclass(EuropeanCall, EuropeanOption)
+    assert issubclass(EuropeanPut, EuropeanOption)
+    assert isinstance(call, EuropeanOption)
+    assert isinstance(put, EuropeanOption)
+
+    np.testing.assert_allclose(call.payoff(s), np.array([0.0, 0.0, 0.5]))
+    np.testing.assert_allclose(put.payoff(s), np.array([0.5, 0.0, 0.0]))


### PR DESCRIPTION
## Summary
- make `EuropeanOption` an abstract base class using `ABC` and `@abstractmethod`
- add tests ensuring the base class is abstract and subclasses compute payoffs

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a13dce464c83268237d6273fc3b9a0