### PR TITLE
Add pre-commit workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install dependencies
-        run: pip install -r requirements.txt
-      - name: Lint
-        run: ruff check .
-      - name: Test
-        run: pytest
+        run: pip install -r requirements.txt -r requirements-dev.txt
+      - name: Run pre-commit
+        run: pre-commit run --show-diff-on-failure --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: local
+    hooks:
+      - id: ruff
+        name: ruff
+        entry: ruff check
+        language: system
+        types: [python]
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: system
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -47,11 +47,17 @@ print(price_at_S0)
 
 ## Development
 
-Run the linter and tests locally:
+Install the development tools and activate the pre-commit hooks:
 
 ```bash
-ruff .
-pytest
+pip install -r requirements.txt -r requirements-dev.txt
+pre-commit install
+```
+
+Run formatting, linting and tests in one go:
+
+```bash
+pre-commit run --all-files
 ```
 
 ## License

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+pre-commit==4.3.0
 pytest==8.4.1
 ruff==0.12.9
 scipy==1.16.1


### PR DESCRIPTION
## Summary
- add local pre-commit configuration running ruff and pytest
- document development setup using pre-commit
- run `pre-commit run --show-diff-on-failure --all-files` in CI

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a141fddab88326a60daf4eab2834a8