### PR TITLE
Refactor option pricing architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,18 +29,21 @@ pip install -r requirements.txt -r requirements-dev.txt
 
 ```python
 import numpy as np
-from src.models import Market, GeometricBrownianMotion
+from src.option_pricer import OptionPricer
 from src.options import EuropeanCall
-from src.pde_pricer import BlackScholesPDE
 
-market = Market(rate=0.05)
-model = GeometricBrownianMotion(rate=0.05, sigma=0.2)
+pricer = OptionPricer(rate=0.05, sigma=0.2)
 option = EuropeanCall(strike=1.0)
-
 s = np.linspace(0, 3, 100)
 t = np.linspace(0, 1, 100)
-pricer = BlackScholesPDE(model=model, market=market)
-values = pricer.price(option, s, t)
+_, _, values = pricer.compute_grid(
+    strike=option.strike,
+    maturity=t[-1],
+    option_type="Call",
+    s_max=s[-1],
+    s_steps=len(s),
+    t_steps=len(t),
+)
 price_at_S0 = values[-1, np.searchsorted(s, 1.0)]
 print(price_at_S0)
 ```

--- a/src/greeks.py
+++ b/src/greeks.py
@@ -1,0 +1,28 @@
+"""Interfaces for computing option Greeks from price grids."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+import numpy as np
+from numpy.typing import NDArray
+
+
+class GreeksCalculator(ABC):
+    """Abstract base class for computing option Greeks."""
+
+    @abstractmethod
+    def delta(
+        self, grid: NDArray[np.float64], s: NDArray[np.float64]
+    ) -> NDArray[np.float64]:
+        """Return Delta values across the price grid."""
+
+    @abstractmethod
+    def gamma(
+        self, grid: NDArray[np.float64], s: NDArray[np.float64]
+    ) -> NDArray[np.float64]:
+        """Return Gamma values across the price grid."""
+
+    @abstractmethod
+    def theta(
+        self, grid: NDArray[np.float64], t: NDArray[np.float64]
+    ) -> NDArray[np.float64]:
+        """Return Theta values across the price grid."""

--- a/src/option_pricer.py
+++ b/src/option_pricer.py
@@ -1,0 +1,61 @@
+"""High-level option pricing interface."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .models import GeometricBrownianMotion, Market
+from .options import EuropeanCall, EuropeanOption, EuropeanPut
+from .pde_pricer import BlackScholesPDE
+
+
+@dataclass
+class OptionPricer:
+    """Compute option value grids using finite difference methods."""
+
+    rate: float
+    sigma: float
+
+    def __post_init__(self) -> None:
+        """Initialize market, model and PDE pricer from inputs."""
+        self.market = Market(rate=self.rate)
+        self.model = GeometricBrownianMotion(rate=self.rate, sigma=self.sigma)
+        self._pricer = BlackScholesPDE(model=self.model, market=self.market)
+
+    def compute_grid(
+        self,
+        strike: float,
+        maturity: float,
+        option_type: str,
+        s_max: float,
+        s_steps: int,
+        t_steps: int,
+    ) -> Tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]]:
+        """Return asset and time grids with option values.
+
+        Parameters
+        ----------
+        strike:
+            Strike price of the option.
+        maturity:
+            Time to maturity in years.
+        option_type:
+            "Call" for call option, "Put" for put option.
+        s_max:
+            Maximum underlying asset price to consider.
+        s_steps:
+            Number of discrete asset price steps.
+        t_steps:
+            Number of discrete time steps.
+        """
+        option_cls: type[EuropeanOption]
+        option_cls = EuropeanCall if option_type == "Call" else EuropeanPut
+        option = option_cls(strike=strike)
+
+        s = np.linspace(0, s_max, s_steps)
+        t = np.linspace(0, maturity, t_steps)
+        values = self._pricer.price(option=option, s=s, t=t)
+        return s, t, values

--- a/src/plotter.py
+++ b/src/plotter.py
@@ -1,0 +1,30 @@
+"""Plotting interfaces for option pricing results."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+class Plotter(ABC):
+    """Abstract interface for rendering option pricing grids."""
+
+    @abstractmethod
+    def heatmap(
+        self,
+        grid: NDArray[np.float64],
+        s: NDArray[np.float64],
+        t: NDArray[np.float64],
+    ) -> Any:
+        """Return a 2-D heatmap figure."""
+
+    @abstractmethod
+    def surface(
+        self,
+        grid: NDArray[np.float64],
+        s: NDArray[np.float64],
+        t: NDArray[np.float64],
+    ) -> Any:
+        """Return a 3-D surface figure."""

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -6,31 +6,7 @@ import seaborn as sns
 import matplotlib.pyplot as plt
 import streamlit as st
 
-from src.models import Market, GeometricBrownianMotion
-from src.options import EuropeanCall, EuropeanPut
-from src.pde_pricer import BlackScholesPDE
-
-
-def compute_grid(
-    rate: float,
-    sigma: float,
-    strike: float,
-    maturity: float,
-    option_type: str,
-    s_max: float,
-    s_steps: int,
-    t_steps: int,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Return asset and time grids with option values."""
-    market = Market(rate=rate)
-    model = GeometricBrownianMotion(rate=rate, sigma=sigma)
-    option_cls = EuropeanCall if option_type == "Call" else EuropeanPut
-    option = option_cls(strike=strike)
-    s = np.linspace(0, s_max, s_steps)
-    t = np.linspace(0, maturity, t_steps)
-    pricer = BlackScholesPDE(model=model, market=market)
-    values = pricer.price(option=option, s=s, t=t)
-    return s, t, values
+from src.option_pricer import OptionPricer
 
 
 def main() -> None:
@@ -46,9 +22,8 @@ def main() -> None:
     t_steps = st.number_input("Time steps", value=100, min_value=10, step=10)
 
     if st.button("Compute"):
-        s, t, grid = compute_grid(
-            rate=rate,
-            sigma=sigma,
+        pricer = OptionPricer(rate=rate, sigma=sigma)
+        s, t, grid = pricer.compute_grid(
             strike=strike,
             maturity=maturity,
             option_type=option_type,


### PR DESCRIPTION
## Summary
- encapsulate grid computation in new `OptionPricer` class
- introduce `Plotter` and `GreeksCalculator` interfaces for future extensions
- update Streamlit app and README to use the refactored pricing API

## Testing
- `ruff check .`
- `mypy src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1568eda2483268c29d1449ababc77