### PR TITLE
Add Matplotlib plotter and refactor Streamlit demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ pre-commit run --all-files
 Launch an interactive application to explore option prices:
 
 ```bash
-streamlit run streamlit_app.py
+streamlit run apps/streamlit_app.py
 ```
 
 ## License

--- a/apps/streamlit_app.py
+++ b/apps/streamlit_app.py
@@ -1,12 +1,22 @@
 """Streamlit demo for the Black--Scholes PDE option pricer."""
 from __future__ import annotations
 
-import numpy as np
-import seaborn as sns
-import matplotlib.pyplot as plt
+import logging
+import sys
+from pathlib import Path
+
 import streamlit as st
 
-from src.option_pricer import OptionPricer
+# Ensure repository root is on the Python path when executed via Streamlit.
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:  # pragma: no cover - runtime path fix
+    sys.path.append(str(ROOT))
+
+from src.option_pricer import OptionPricer  # noqa: E402
+from src.plotter import MatplotlibSeabornPlotter  # noqa: E402
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 def main() -> None:
@@ -22,6 +32,7 @@ def main() -> None:
     t_steps = st.number_input("Time steps", value=100, min_value=10, step=10)
 
     if st.button("Compute"):
+        logger.info("Computing option price grid")
         pricer = OptionPricer(rate=rate, sigma=sigma)
         s, t, grid = pricer.compute_grid(
             strike=strike,
@@ -31,15 +42,8 @@ def main() -> None:
             s_steps=int(s_steps),
             t_steps=int(t_steps),
         )
-        fig, ax = plt.subplots()
-        sns.heatmap(
-            grid,
-            xticklabels=np.round(s, 2),
-            yticklabels=np.round(t, 2),
-            ax=ax,
-        )
-        ax.set_xlabel("Asset price")
-        ax.set_ylabel("Time")
+        plotter = MatplotlibSeabornPlotter()
+        fig = plotter.heatmap(grid=grid, s=s, t=t)
         st.pyplot(fig)
 
 

--- a/src/plotter.py
+++ b/src/plotter.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
 
+import matplotlib.pyplot as plt
 import numpy as np
+import seaborn as sns
+from matplotlib.figure import Figure
 from numpy.typing import NDArray
 
 
@@ -28,3 +31,54 @@ class Plotter(ABC):
         t: NDArray[np.float64],
     ) -> Any:
         """Return a 3-D surface figure."""
+
+
+class MatplotlibSeabornPlotter(Plotter):
+    """Plotter implementation using Matplotlib and Seaborn."""
+
+    def heatmap(
+        self,
+        grid: NDArray[np.float64],
+        s: NDArray[np.float64],
+        t: NDArray[np.float64],
+    ) -> Figure:
+        """Return a heatmap figure of option values.
+
+        Parameters
+        ----------
+        grid:
+            2-D array of option values where rows correspond to time and
+            columns to asset prices.
+        s:
+            Discretized asset prices.
+        t:
+            Discretized times to maturity.
+        """
+
+        fig, ax = plt.subplots()
+        sns.heatmap(
+            grid,
+            xticklabels=np.round(s, 2),
+            yticklabels=np.round(t, 2),
+            ax=ax,
+        )
+        ax.set_xlabel("Asset price")
+        ax.set_ylabel("Time")
+        return fig
+
+    def surface(
+        self,
+        grid: NDArray[np.float64],
+        s: NDArray[np.float64],
+        t: NDArray[np.float64],
+    ) -> Figure:
+        """Return a 3-D surface plot of option values."""
+
+        s_mesh, t_mesh = np.meshgrid(s, t)
+        fig = plt.figure()
+        ax = fig.add_subplot(111, projection="3d")
+        ax.plot_surface(s_mesh, t_mesh, grid, cmap="viridis")
+        ax.set_xlabel("Asset price")
+        ax.set_ylabel("Time")
+        ax.set_zlabel("Option value")
+        return fig


### PR DESCRIPTION
## Summary
- implement `MatplotlibSeabornPlotter` with heatmap and 3D surface support
- relocate and refactor Streamlit app to `apps/` using `OptionPricer` and the new plotter
- document new app path in README

## Testing
- `pre-commit run --files src/plotter.py apps/streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2611b6a9c832680eb4b612583d079