### PR TITLE
Refactor PDE solver with pluggable time steppers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ the Black--Scholes partial differential equation (PDE) with
 
 - Clean object‑oriented design following SOLID principles.
 - Modular boundary condition builder for easy extension.
+- Pluggable time-stepping schemes (Explicit Euler, Crank--Nicolson).
 - Unit tests covering calls and puts.
 - Continuous integration with linting (`ruff`), type checking (`mypy`) and tests (`pytest`).
 

--- a/src/models.py
+++ b/src/models.py
@@ -12,6 +12,8 @@ import numpy as np
 from numpy.typing import NDArray
 import findiff as fd
 
+from .spatial_operator import SpatialOperator
+
 
 @dataclass
 class Market:
@@ -39,18 +41,13 @@ class GeometricBrownianMotion:
     def generator(self, s: NDArray[np.float64]) -> fd.FinDiff:
         """Return the discretised infinitesimal generator.
 
+        This delegates to :class:`~src.spatial_operator.SpatialOperator` for
+        construction of the finite difference operator.  The original method is
+        retained for backward compatibility.
+
         Parameters
         ----------
         s:
             Spatial grid for the asset price.
         """
-        ds = s[1] - s[0]
-        d1 = fd.FinDiff(0, ds, 1)
-        d2 = fd.FinDiff(0, ds, 2)
-
-        # Black–Scholes generator L = 0.5*sigma^2*s^2*d2 + r*s*d1 - r*I
-        return (
-            fd.Coef(self.diffusion * s ** 2) * d2
-            + fd.Coef(self.rate * s) * d1
-            - self.rate * fd.Identity()
-        )
+        return SpatialOperator(self).build(s)

--- a/src/spatial_operator.py
+++ b/src/spatial_operator.py
@@ -1,0 +1,31 @@
+"""Construction of spatial differential operators."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+from numpy.typing import NDArray
+import findiff as fd
+
+if TYPE_CHECKING:  # pragma: no cover - runtime import only for typing
+    from .models import GeometricBrownianMotion
+
+
+@dataclass
+class SpatialOperator:
+    """Build finite difference operators for diffusion models."""
+
+    model: "GeometricBrownianMotion"
+
+    def build(self, s: NDArray[np.float64]) -> fd.FinDiff:
+        """Return the discretised infinitesimal generator."""
+        ds = s[1] - s[0]
+        d1 = fd.FinDiff(0, ds, 1)
+        d2 = fd.FinDiff(0, ds, 2)
+        m = self.model
+        return (
+            fd.Coef(m.diffusion * s ** 2) * d2
+            + fd.Coef(m.rate * s) * d1
+            - m.rate * fd.Identity()
+        )

--- a/src/time_steppers.py
+++ b/src/time_steppers.py
@@ -1,0 +1,58 @@
+"""Time stepping schemes for finite difference PDE solvers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from abc import ABC, abstractmethod
+
+import numpy as np
+from numpy.typing import NDArray
+import findiff as fd
+from findiff import PDE
+
+
+class TimeStepper(ABC):
+    """Abstract base class for time stepping schemes."""
+
+    @abstractmethod
+    def step(
+        self,
+        u: NDArray[np.float64],
+        operator: fd.FinDiff,
+        bc,
+        dt: float,
+    ) -> NDArray[np.float64]:
+        """Advance the solution ``u`` by one time step of size ``dt``."""
+
+
+@dataclass
+class ThetaMethod(TimeStepper):
+    """Generic :math:`\theta`-method time integrator."""
+
+    theta: float
+
+    def step(
+        self,
+        u: NDArray[np.float64],
+        operator: fd.FinDiff,
+        bc,
+        dt: float,
+    ) -> NDArray[np.float64]:
+        A = fd.Identity() - self.theta * dt * operator
+        B = fd.Identity() + (1 - self.theta) * dt * operator
+        rhs = B(u)
+        pde = PDE(lhs=A, rhs=rhs, bcs=bc)
+        return pde.solve()
+
+
+class ExplicitEuler(ThetaMethod):
+    """Explicit Euler scheme (:math:`\theta=0`)."""
+
+    def __init__(self) -> None:  # pragma: no cover - trivial
+        super().__init__(theta=0.0)
+
+
+class CrankNicolson(ThetaMethod):
+    """Crank--Nicolson scheme (:math:`\theta=0.5`)."""
+
+    def __init__(self) -> None:  # pragma: no cover - trivial
+        super().__init__(theta=0.5)

--- a/tests/test_pde_pricer.py
+++ b/tests/test_pde_pricer.py
@@ -9,6 +9,7 @@ import numpy as np
 from src.models import Market, GeometricBrownianMotion
 from src.options import EuropeanCall, EuropeanPut
 from src.pde_pricer import BlackScholesPDE
+from src.time_steppers import ExplicitEuler
 
 
 def black_scholes_call(s, k, r, sigma, T):
@@ -81,3 +82,31 @@ def test_put_matches_analytical():
     analytical = black_scholes_put(1.0, K, rate, sigma, T)
 
     assert abs(pde_price - analytical) < 1e-2
+
+
+def test_call_matches_analytical_explicit_euler():
+    rate = 0.05
+    sigma = 0.2
+    T = 1.0
+    K = 1.0
+    S_max = 3.0
+    ns = 50
+    nt = 4000
+
+    s = np.linspace(0.0, S_max, ns)
+    t = np.linspace(0.0, T, nt)
+
+    market = Market(rate=rate)
+    model = GeometricBrownianMotion(rate=rate, sigma=sigma)
+    option = EuropeanCall(strike=K)
+
+    pricer = BlackScholesPDE(
+        model=model, market=market, time_stepper=ExplicitEuler()
+    )
+    grid = pricer.price(option, s, t)
+
+    idx = np.searchsorted(s, 1.0)
+    pde_price = grid[-1, idx]
+    analytical = black_scholes_call(1.0, K, rate, sigma, T)
+
+    assert abs(pde_price - analytical) < 5e-2


### PR DESCRIPTION
## Summary
- add `TimeStepper` abstractions for Explicit Euler and Crank–Nicolson
- extract spatial operator construction into `SpatialOperator`
- refactor `BlackScholesPDE` to compose spatial operators, time steppers and boundary conditions
- exercise explicit Euler in tests and document pluggable schemes

## Testing
- `ruff check src/time_steppers.py src/spatial_operator.py src/models.py src/pde_pricer.py tests/test_pde_pricer.py`
- `pre-commit run --files src/time_steppers.py src/spatial_operator.py src/models.py src/pde_pricer.py tests/test_pde_pricer.py README.md`

------
https://chatgpt.com/codex/tasks/task_e_68a2612d3bbc8326a66aa8d666f256af