### PR TITLE
Add finite difference Greeks calculator and optional output

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ the Black--Scholes partial differential equation (PDE) with
 - Clean object‑oriented design following SOLID principles.
 - Modular boundary condition builder for easy extension.
 - Unit tests covering calls and puts.
+- Finite difference Greeks (Delta, Gamma, Theta).
 - Continuous integration with linting (`ruff`), type checking (`mypy`) and tests (`pytest`).
 
 ## Installation
@@ -36,13 +37,14 @@ pricer = OptionPricer(rate=0.05, sigma=0.2)
 option = EuropeanCall(strike=1.0)
 s = np.linspace(0, 3, 100)
 t = np.linspace(0, 1, 100)
-_, _, values = pricer.compute_grid(
+_, _, values, delta, gamma, theta = pricer.compute_grid(
     strike=option.strike,
     maturity=t[-1],
     option_type="Call",
     s_max=s[-1],
     s_steps=len(s),
     t_steps=len(t),
+    return_greeks=True,
 )
 price_at_S0 = values[-1, np.searchsorted(s, 1.0)]
 print(price_at_S0)

--- a/src/greeks.py
+++ b/src/greeks.py
@@ -26,3 +26,54 @@ class GreeksCalculator(ABC):
         self, grid: NDArray[np.float64], t: NDArray[np.float64]
     ) -> NDArray[np.float64]:
         """Return Theta values across the price grid."""
+
+
+class FiniteDifferenceGreeks(GreeksCalculator):
+    """Compute option Greeks using finite difference approximations.
+
+    The price grid is assumed to have shape ``(len(t), len(s))`` where the first
+    axis represents time to maturity and the second axis the underlying asset
+    price.  Central differences are used in the interior of the grid and
+    one–sided second order approximations are applied at the boundaries.
+    """
+
+    def _first_derivative(
+        self, grid: NDArray[np.float64], spacing: NDArray[np.float64], axis: int
+    ) -> NDArray[np.float64]:
+        """Return first derivative along ``axis`` using central differences."""
+
+        return np.gradient(grid, spacing, axis=axis, edge_order=2)
+
+    def _second_derivative(
+        self, grid: NDArray[np.float64], spacing: NDArray[np.float64], axis: int
+    ) -> NDArray[np.float64]:
+        """Return second derivative along ``axis`` using central differences."""
+
+        first = np.gradient(grid, spacing, axis=axis, edge_order=2)
+        return np.gradient(first, spacing, axis=axis, edge_order=2)
+
+    def delta(
+        self, grid: NDArray[np.float64], s: NDArray[np.float64]
+    ) -> NDArray[np.float64]:
+        """Return Delta of the option across the grid."""
+
+        return self._first_derivative(grid, s, axis=1)
+
+    def gamma(
+        self, grid: NDArray[np.float64], s: NDArray[np.float64]
+    ) -> NDArray[np.float64]:
+        """Return Gamma of the option across the grid."""
+
+        return self._second_derivative(grid, s, axis=1)
+
+    def theta(
+        self, grid: NDArray[np.float64], t: NDArray[np.float64]
+    ) -> NDArray[np.float64]:
+        """Return Theta of the option across the grid.
+
+        The grid is defined with the time to maturity as the first axis.  Theta
+        (the derivative with respect to calendar time) is therefore the negative
+        derivative with respect to time to maturity.
+        """
+
+        return -self._first_derivative(grid, t, axis=0)

--- a/tests/test_greeks.py
+++ b/tests/test_greeks.py
@@ -1,0 +1,58 @@
+"""Tests for finite difference Greek calculations."""
+import pathlib
+import sys
+
+# Ensure project root on path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import numpy as np
+from scipy.stats import norm
+
+from src.option_pricer import OptionPricer
+
+
+def bs_call_greeks(
+    s: float, k: float, r: float, sigma: float, T: float
+) -> tuple[float, float, float]:
+    """Return analytical Delta, Gamma and Theta for a call option."""
+
+    from math import log, sqrt, exp
+
+    d1 = (log(s / k) + (r + 0.5 * sigma**2) * T) / (sigma * sqrt(T))
+    d2 = d1 - sigma * sqrt(T)
+    delta = norm.cdf(d1)
+    gamma = norm.pdf(d1) / (s * sigma * sqrt(T))
+    theta = (
+        -s * norm.pdf(d1) * sigma / (2 * sqrt(T))
+        - r * k * exp(-r * T) * norm.cdf(d2)
+    )
+    return delta, gamma, theta
+
+
+def test_finite_difference_greeks_match_analytical():
+    rate = 0.05
+    sigma = 0.2
+    T = 1.0
+    K = 1.0
+    S_max = 3.0
+    ns = 300
+    nt = 300
+
+    pricer = OptionPricer(rate=rate, sigma=sigma)
+    s, t, values, delta, gamma, theta = pricer.compute_grid(
+        strike=K,
+        maturity=T,
+        option_type="Call",
+        s_max=S_max,
+        s_steps=ns,
+        t_steps=nt,
+        return_greeks=True,
+    )
+
+    idx = np.searchsorted(s, 1.0)
+    delta_a, gamma_a, theta_a = bs_call_greeks(1.0, K, rate, sigma, T)
+
+    assert abs(delta[-1, idx] - delta_a) < 1e-2
+    assert abs(gamma[-1, idx] - gamma_a) < 2e-2
+    assert abs(theta[-1, idx] - theta_a) < 1e-2
+


### PR DESCRIPTION
## Summary
- add `FiniteDifferenceGreeks` for Delta, Gamma and Theta using central differences
- extend `OptionPricer.compute_grid` with `return_greeks` parameter and document usage
- cover Greek calculations with unit tests and README example

## Testing
- `pre-commit run --files src/greeks.py src/option_pricer.py tests/test_greeks.py README.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a26144715483269d1929ebfbf359c4