### PR TITLE
Add CLI, FastAPI service, and Next.js client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__/
 .env
 .ipynb_checkpoints/
 .venv
+node_modules/
+.next/

--- a/README.md
+++ b/README.md
@@ -74,6 +74,40 @@ Launch an interactive application to explore option prices:
 streamlit run apps/streamlit_app.py
 ```
 
+## Command-line Interface
+
+Use [Typer](https://typer.tiangolo.com/) commands for quick pricing and plotting:
+
+```bash
+python -m cli price --option-type Call --strike 1 --maturity 1 --s0 1 --rate 0.05 --sigma 0.2
+python -m cli plot --option-type Call --strike 1 --maturity 1 --output plot.png
+```
+
+## FastAPI Service
+
+Start a REST API that exposes pricing and Greek calculations:
+
+```bash
+uvicorn api.main:app --reload
+```
+
+Endpoints:
+
+- `POST /price` → `{ "price": float }`
+- `POST /greeks` → `{ "delta": float, "gamma": float, "theta": float }`
+
+## Next.js Client
+
+A minimal client in `nextjs-client/` demonstrates how to call the API from the browser:
+
+```bash
+cd nextjs-client
+npm install
+npm run dev
+```
+
+It expects the FastAPI server to run locally on port 8000.
+
 ## License
 
 MIT

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI application exposing option pricing endpoints."""

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,79 @@
+"""FastAPI service for option pricing and Greek calculations."""
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from src.option_pricer import OptionPricer
+
+app = FastAPI(title="Finite Difference Option Pricing")
+
+
+class OptionRequest(BaseModel):
+    """Input parameters for option pricing."""
+
+    option_type: str
+    strike: float
+    maturity: float
+    s0: float
+    rate: float
+    sigma: float
+    s_max: Optional[float] = None
+    s_steps: int = 100
+    t_steps: int = 100
+
+
+class PriceResponse(BaseModel):
+    """Option price at the initial asset price."""
+
+    price: float
+
+
+class GreeksResponse(BaseModel):
+    """Greeks at the initial asset price."""
+
+    delta: float
+    gamma: float
+    theta: float
+
+
+@app.post("/price", response_model=PriceResponse)
+def price(request: OptionRequest) -> PriceResponse:
+    """Return option price for the given parameters."""
+    s_max = request.s_max or request.s0 * 3
+    pricer = OptionPricer(rate=request.rate, sigma=request.sigma)
+    s, _, values = pricer.compute_grid(
+        strike=request.strike,
+        maturity=request.maturity,
+        option_type=request.option_type,
+        s_max=s_max,
+        s_steps=request.s_steps,
+        t_steps=request.t_steps,
+    )
+    s_idx = int(np.searchsorted(s, request.s0))
+    return PriceResponse(price=float(values[-1, s_idx]))
+
+
+@app.post("/greeks", response_model=GreeksResponse)
+def greeks(request: OptionRequest) -> GreeksResponse:
+    """Return Delta, Gamma and Theta for the given parameters."""
+    s_max = request.s_max or request.s0 * 3
+    pricer = OptionPricer(rate=request.rate, sigma=request.sigma)
+    s, _, values, delta, gamma, theta = pricer.compute_grid(
+        strike=request.strike,
+        maturity=request.maturity,
+        option_type=request.option_type,
+        s_max=s_max,
+        s_steps=request.s_steps,
+        t_steps=request.t_steps,
+        return_greeks=True,
+    )
+    s_idx = int(np.searchsorted(s, request.s0))
+    return GreeksResponse(
+        delta=float(delta[-1, s_idx]),
+        gamma=float(gamma[-1, s_idx]),
+        theta=float(theta[-1, s_idx]),
+    )

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Command-line interface package using Typer."""

--- a/cli/main.py
+++ b/cli/main.py
@@ -1,0 +1,91 @@
+"""Typer-based command line interface for option pricing and plotting."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import typer
+
+from src.option_pricer import OptionPricer
+from src.plotter import MatplotlibSeabornPlotter
+
+app = typer.Typer(help="Command-line tools for option pricing.")
+
+
+@app.command()
+def price(
+    option_type: str = typer.Option("Call", help="Option type: 'Call' or 'Put'."),
+    strike: float = typer.Option(1.0, help="Strike price."),
+    maturity: float = typer.Option(1.0, help="Time to maturity in years."),
+    s0: float = typer.Option(1.0, help="Initial asset price."),
+    rate: float = typer.Option(0.05, help="Risk-free interest rate."),
+    sigma: float = typer.Option(0.2, help="Volatility of the underlying asset."),
+    s_max: float = typer.Option(3.0, help="Maximum asset price in grid."),
+    s_steps: int = typer.Option(100, help="Number of asset price steps."),
+    t_steps: int = typer.Option(100, help="Number of time steps."),
+    greeks: bool = typer.Option(False, help="Also compute Delta, Gamma and Theta."),
+) -> None:
+    """Compute option price at ``s0`` and optionally Greeks."""
+    pricer = OptionPricer(rate=rate, sigma=sigma)
+    result = pricer.compute_grid(
+        strike=strike,
+        maturity=maturity,
+        option_type=option_type,
+        s_max=s_max,
+        s_steps=s_steps,
+        t_steps=t_steps,
+        return_greeks=greeks,
+    )
+    s = result[0]
+    values = result[2]
+    s_idx = int(np.searchsorted(s, s0))
+    price_at_s0 = float(values[-1, s_idx])
+    typer.echo(f"Price: {price_at_s0}")
+    if greeks:
+        delta, gamma, theta = result[3], result[4], result[5]
+        typer.echo(f"Delta: {float(delta[-1, s_idx])}")
+        typer.echo(f"Gamma: {float(gamma[-1, s_idx])}")
+        typer.echo(f"Theta: {float(theta[-1, s_idx])}")
+
+
+@app.command()
+def plot(
+    option_type: str = typer.Option("Call", help="Option type: 'Call' or 'Put'."),
+    strike: float = typer.Option(1.0, help="Strike price."),
+    maturity: float = typer.Option(1.0, help="Time to maturity in years."),
+    rate: float = typer.Option(0.05, help="Risk-free interest rate."),
+    sigma: float = typer.Option(0.2, help="Volatility of the underlying asset."),
+    s_max: float = typer.Option(3.0, help="Maximum asset price in grid."),
+    s_steps: int = typer.Option(100, help="Number of asset price steps."),
+    t_steps: int = typer.Option(100, help="Number of time steps."),
+    kind: str = typer.Option(
+        "heatmap", help="Plot type: 'heatmap' or 'surface'."
+    ),
+    output: Optional[Path] = typer.Option(  # noqa: B008
+        None, help="Optional path to save the plot."),
+) -> None:
+    """Render option value grid as a heatmap or surface plot."""
+    pricer = OptionPricer(rate=rate, sigma=sigma)
+    s, t, values = pricer.compute_grid(
+        strike=strike,
+        maturity=maturity,
+        option_type=option_type,
+        s_max=s_max,
+        s_steps=s_steps,
+        t_steps=t_steps,
+    )
+    plotter = MatplotlibSeabornPlotter()
+    fig = (
+        plotter.surface(values, s, t)
+        if kind == "surface"
+        else plotter.heatmap(values, s, t)
+    )
+    if output:
+        fig.savefig(output)
+    else:
+        fig.show()
+
+
+if __name__ == "__main__":
+    app()

--- a/nextjs-client/package.json
+++ b/nextjs-client/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "nextjs-client",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "15.4.6",
+    "react": "19.1.1",
+    "react-dom": "19.1.1"
+  }
+}

--- a/nextjs-client/pages/index.js
+++ b/nextjs-client/pages/index.js
@@ -1,0 +1,30 @@
+import { useState } from "react";
+
+export default function Home() {
+  const [price, setPrice] = useState(null);
+
+  async function fetchPrice() {
+    const res = await fetch("http://localhost:8000/price", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        option_type: "Call",
+        strike: 1,
+        maturity: 1,
+        s0: 1,
+        rate: 0.05,
+        sigma: 0.2
+      })
+    });
+    const data = await res.json();
+    setPrice(data.price);
+  }
+
+  return (
+    <div>
+      <h1>Option Pricing Demo</h1>
+      <button onClick={fetchPrice}>Fetch Price</button>
+      {price !== null && <p>Price: {price}</p>}
+    </div>
+  );
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ numpy==2.3.2
 streamlit==1.48.1
 matplotlib==3.10.5
 seaborn==0.13.2
+fastapi==0.116.1
+typer==0.16.0
+uvicorn==0.35.0


### PR DESCRIPTION
## Summary
- add Typer-powered CLI for pricing and plotting
- expose FastAPI endpoints for option pricing and Greeks
- include Next.js demo client and document usage in README

## Testing
- `pre-commit run --files cli/main.py api/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68a263c1dd48832696e76243964cd90a