### PR TITLE
feat: add callable bond PDE model

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,43 @@ option = EuropeanCall(strike=1.0)
 s = np.linspace(0, 3, 100)
 t = np.linspace(0, 1, 100)
 _, _, values, delta, gamma, theta = pricer.compute_grid(
-    strike=option.strike,
     maturity=t[-1],
-    option_type="Call",
     s_max=s[-1],
     s_steps=len(s),
     t_steps=len(t),
+    strike=option.strike,
+    option_type="Call",
     return_greeks=True,
 )
 price_at_S0 = values[-1, np.searchsorted(s, 1.0)]
 print(price_at_S0)
+```
+
+### Pricing a callable bond
+
+```python
+import numpy as np
+from src.option_pricer import OptionPricer
+from src.pde_pricer import CallableBondPDEModel
+from src.models import Market, GeometricBrownianMotion
+
+market = Market(rate=0.03)
+short_rate = GeometricBrownianMotion(rate=0.03, sigma=0.01)
+bond_model = CallableBondPDEModel(
+    face_value=100.0,
+    call_price=105.0,
+    market=market,
+    model=short_rate,
+)
+pricer = OptionPricer(pde_model=bond_model)
+s, t, values = pricer.compute_grid(
+    maturity=1.0,
+    s_max=150.0,
+    s_steps=100,
+    t_steps=100,
+)
+price_at_par = values[-1, np.searchsorted(s, 100.0)]
+print(price_at_par)
 ```
 
 ## Development

--- a/src/pde_pricer.py
+++ b/src/pde_pricer.py
@@ -1,10 +1,18 @@
-"""Finite difference pricer using :mod:`findiff`'s PDE solver."""
+"""Finite difference models for solving parabolic PDEs.
+
+This module defines an abstract :class:`PDEModel` base class together with
+concrete implementations for vanilla options and callable bonds.  The models
+encapsulate the construction of the infinitesimal generator and the boundary
+conditions required by the finite difference solver.
+"""
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 
 import numpy as np
 from numpy.typing import NDArray
+from findiff import BoundaryConditions, FinDiff
 
 from .models import GeometricBrownianMotion, Market
 from .options import EuropeanOption
@@ -13,8 +21,49 @@ from .spatial_operator import SpatialOperator
 from .time_steppers import TimeStepper, ThetaMethod
 
 
+class PDEModel(ABC):
+    """Abstract base class for PDE pricing models."""
+
+    time_stepper: TimeStepper
+
+    @abstractmethod
+    def generator(self, s: NDArray[np.float64]) -> FinDiff:
+        """Return the discretised generator on the spatial grid."""
+
+    @abstractmethod
+    def payoff(
+        self, s: NDArray[np.float64], option: EuropeanOption | None
+    ) -> NDArray[np.float64]:
+        """Return payoff at maturity for the spatial grid."""
+
+    @abstractmethod
+    def boundary_conditions(
+        self, s: NDArray[np.float64], option: EuropeanOption | None
+    ) -> BoundaryConditions:
+        """Return boundary conditions for the spatial grid."""
+
+    def price(
+        self,
+        option: EuropeanOption | None,
+        s: NDArray[np.float64],
+        t: NDArray[np.float64],
+    ) -> NDArray[np.float64]:
+        """Return grid with instrument values."""
+
+        dt = t[1] - t[0]
+        L = self.generator(s)
+
+        values = np.empty((len(t), len(s)))
+        values[0] = self.payoff(s, option)
+
+        bc = self.boundary_conditions(s, option)
+        for i in range(len(t) - 1):
+            values[i + 1] = self.time_stepper.step(values[i], L, bc, dt)
+        return values
+
+
 @dataclass
-class BlackScholesPDE:
+class BlackScholesPDE(PDEModel):
     """Price European options by solving the Black–Scholes PDE."""
 
     model: GeometricBrownianMotion
@@ -32,29 +81,91 @@ class BlackScholesPDE:
         else:  # keep ``theta`` in sync for backward compatibility
             self.theta = getattr(self.time_stepper, "theta", self.theta)
 
+    def generator(self, s: NDArray[np.float64]) -> SpatialOperator:
+        """Return the Black--Scholes infinitesimal generator."""
+
+        return SpatialOperator(self.model).build(s)
+
+    def payoff(
+        self, s: NDArray[np.float64], option: EuropeanOption | None
+    ) -> NDArray[np.float64]:
+        """Return option payoff at maturity."""
+
+        if option is None:
+            raise ValueError("Option contract must be provided for BlackScholesPDE")
+        return option.payoff(s)
+
+    def boundary_conditions(
+        self, s: NDArray[np.float64], option: EuropeanOption | None
+    ) -> BoundaryConditions:
+        """Return model-specific boundary conditions."""
+
+        if option is None:
+            raise ValueError("Option contract must be provided for BlackScholesPDE")
+        return self.boundary_builder.build(s, option)
+
+
+@dataclass
+class CallableBondPDEModel(PDEModel):
+    """PDE model for pricing simple callable bonds.
+
+    The implementation is intentionally simplified: the underlying short rate
+    follows a geometric Brownian motion and the bond may be called at a fixed
+    price at any time.
+    """
+
+    face_value: float
+    call_price: float
+    market: Market
+    model: GeometricBrownianMotion
+    time_stepper: TimeStepper = field(default_factory=lambda: ThetaMethod(0.5))
+
+    def generator(self, s: NDArray[np.float64]) -> FinDiff:
+        """Return the infinitesimal generator for the short rate."""
+
+        return SpatialOperator(self.model).build(s)
+
+    def payoff(
+        self, s: NDArray[np.float64], option: EuropeanOption | None
+    ) -> NDArray[np.float64]:
+        """Face value paid at maturity."""
+
+        return np.full_like(s, min(self.face_value, self.call_price))
+
+    def boundary_conditions(
+        self, s: NDArray[np.float64], option: EuropeanOption | None
+    ) -> BoundaryConditions:
+        """Dirichlet boundaries enforcing the call price."""
+
+        bc = BoundaryConditions(s.shape)
+        # Value is zero when the bond price approaches zero
+        bc[0] = 0, 0.0
+        # Bond cannot exceed the call price
+        bc[-1] = 0, self.call_price
+        return bc
+
     def price(
         self,
-        option: EuropeanOption,
+        option: EuropeanOption | None,
         s: NDArray[np.float64],
         t: NDArray[np.float64],
     ) -> NDArray[np.float64]:
-        """Return grid with option values.
+        """Return grid of callable bond prices.
 
-        Parameters
-        ----------
-        option:
-            Option contract to price.
-        s, t:
-            Spatial and temporal grids.
+        After each time step the value is capped at the call price to emulate
+        the early redemption feature.
         """
+
         dt = t[1] - t[0]
-        L = SpatialOperator(self.model).build(s)
+        L = self.generator(s)
 
         values = np.empty((len(t), len(s)))
-        values[0] = option.payoff(s)
+        values[0] = self.payoff(s, option)
 
-        bc = self.boundary_builder.build(s, option)
+        bc = self.boundary_conditions(s, option)
         for i in range(len(t) - 1):
             values[i + 1] = self.time_stepper.step(values[i], L, bc, dt)
+            values[i + 1] = np.minimum(values[i + 1], self.call_price)
+        values = np.minimum(values, self.call_price)
         return values
 


### PR DESCRIPTION
## Summary
- add abstract PDEModel base class
- support callable bond pricing and generic PDE models
- allow OptionPricer to accept custom PDE models and document usage

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a263c7f56883268356127d67fb6ac3