### PR TITLE
Add risk data models and regulatory reporting endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ the Black--Scholes partial differential equation (PDE) with
 - Unit tests covering calls and puts.
 - Finite difference Greeks (Delta, Gamma, Theta).
 - Continuous integration with linting (`ruff`), type checking (`mypy`) and tests (`pytest`).
+- Basic regulatory reporting utilities (CRIF, CUSO, Basel, FRTB placeholders).
 
 ## Installation
 
@@ -122,6 +123,10 @@ Endpoints:
 
 - `POST /price` → `{ "price": float }`
 - `POST /greeks` → `{ "delta": float, "gamma": float, "theta": float }`
+- `POST /reports/crif` → `{ "crif": str }`
+- `POST /reports/cuso` → `{ "status": str }`
+- `POST /reports/basel` → `{ "status": str }`
+- `POST /reports/frtb` → `{ "status": str }`
 
 ## Next.js Client
 
@@ -134,6 +139,10 @@ npm run dev
 ```
 
 It expects the FastAPI server to run locally on port 8000.
+
+## Regulatory Documentation
+
+Details on assumptions and limitations are available in [docs/regulatory.md](docs/regulatory.md).
 
 ## License
 

--- a/api/main.py
+++ b/api/main.py
@@ -8,6 +8,15 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 
 from src.option_pricer import OptionPricer
+from src.risk import (
+    Exposure,
+    RiskFactor,
+    Trade,
+    calculate_basel,
+    calculate_cuso,
+    calculate_frtb,
+    exposures_to_crif,
+)
 
 app = FastAPI(title="Finite Difference Option Pricing")
 
@@ -77,3 +86,86 @@ def greeks(request: OptionRequest) -> GreeksResponse:
         gamma=float(gamma[-1, s_idx]),
         theta=float(theta[-1, s_idx]),
     )
+
+
+class TradeModel(BaseModel):
+    """Trade description used in regulatory reports."""
+
+    trade_id: str
+    product_type: str
+    notional: float
+    currency: str
+    description: Optional[str] = None
+
+
+class RiskFactorModel(BaseModel):
+    """Risk factor affecting trades."""
+
+    name: str
+    value: float
+    description: Optional[str] = None
+
+
+class ExposureModel(BaseModel):
+    """Exposure of a trade to a risk factor."""
+
+    trade: TradeModel
+    risk_factor: RiskFactorModel
+    amount: float
+
+
+class CRIFResponse(BaseModel):
+    """CSV output representing the CRIF report."""
+
+    crif: str
+
+
+class PlaceholderResponse(BaseModel):
+    """Generic placeholder response."""
+
+    status: str
+
+
+def _convert_exposures(models: list[ExposureModel]) -> list[Exposure]:
+    """Convert API models to dataclass exposures."""
+
+    return [
+        Exposure(
+            trade=Trade(**m.trade.dict()),
+            risk_factor=RiskFactor(**m.risk_factor.dict()),
+            amount=m.amount,
+        )
+        for m in models
+    ]
+
+
+@app.post("/reports/crif", response_model=CRIFResponse)
+def crif_report(exposures: list[ExposureModel]) -> CRIFResponse:
+    """Generate a CRIF report for the provided exposures."""
+
+    crif = exposures_to_crif(_convert_exposures(exposures))
+    return CRIFResponse(crif=crif)
+
+
+@app.post("/reports/cuso", response_model=PlaceholderResponse)
+def cuso_report(exposures: list[ExposureModel]) -> PlaceholderResponse:
+    """Placeholder CUSO report endpoint."""
+
+    data = calculate_cuso(_convert_exposures(exposures))
+    return PlaceholderResponse(**data)
+
+
+@app.post("/reports/basel", response_model=PlaceholderResponse)
+def basel_report(exposures: list[ExposureModel]) -> PlaceholderResponse:
+    """Placeholder Basel report endpoint."""
+
+    data = calculate_basel(_convert_exposures(exposures))
+    return PlaceholderResponse(**data)
+
+
+@app.post("/reports/frtb", response_model=PlaceholderResponse)
+def frtb_report(exposures: list[ExposureModel]) -> PlaceholderResponse:
+    """Placeholder FRTB report endpoint."""
+
+    data = calculate_frtb(_convert_exposures(exposures))
+    return PlaceholderResponse(**data)

--- a/docs/regulatory.md
+++ b/docs/regulatory.md
@@ -1,0 +1,15 @@
+# Regulatory Reporting
+
+This module offers minimal structures for representing trades, risk factors and exposures.
+
+## Assumptions
+
+- Only a handful of fields are captured for each trade and risk factor.
+- CRIF output includes trade identifier, risk factor name and exposure amount.
+- CUSO, Basel and FRTB calculations are placeholders that return a "not implemented" status.
+
+## Limitations
+
+- The simplified data model does not cover product-specific attributes.
+- No validation against official regulatory schemas is performed.
+- Risk calculations are not implemented and must be provided by a risk engine.

--- a/src/risk/__init__.py
+++ b/src/risk/__init__.py
@@ -1,0 +1,19 @@
+"""Risk data models and converters for regulatory reporting."""
+
+from .models import Exposure, RiskFactor, Trade
+from .converters import (
+    exposures_to_crif,
+    calculate_cuso,
+    calculate_basel,
+    calculate_frtb,
+)
+
+__all__ = [
+    "Trade",
+    "RiskFactor",
+    "Exposure",
+    "exposures_to_crif",
+    "calculate_cuso",
+    "calculate_basel",
+    "calculate_frtb",
+]

--- a/src/risk/converters.py
+++ b/src/risk/converters.py
@@ -1,0 +1,41 @@
+"""Conversion utilities for regulatory reporting formats."""
+from __future__ import annotations
+
+import csv
+import io
+from typing import Iterable
+
+from .models import Exposure
+
+
+def exposures_to_crif(exposures: Iterable[Exposure]) -> str:
+    """Return a CSV string in the Common Risk Interchange Format (CRIF).
+
+    The implementation is intentionally minimal and includes only the
+    trade identifier, risk factor name and exposure amount.
+    """
+
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(["TradeId", "RiskFactor", "Amount"])
+    for exp in exposures:
+        writer.writerow([exp.trade.trade_id, exp.risk_factor.name, exp.amount])
+    return output.getvalue()
+
+
+def calculate_cuso(_: Iterable[Exposure]) -> dict[str, str]:
+    """Placeholder for a Current US Supervision Office (CUSO) calc."""
+
+    return {"status": "CUSO calculation not implemented"}
+
+
+def calculate_basel(_: Iterable[Exposure]) -> dict[str, str]:
+    """Placeholder for Basel capital requirements calculation."""
+
+    return {"status": "Basel calculation not implemented"}
+
+
+def calculate_frtb(_: Iterable[Exposure]) -> dict[str, str]:
+    """Placeholder for Fundamental Review of the Trading Book (FRTB) calc."""
+
+    return {"status": "FRTB calculation not implemented"}

--- a/src/risk/models.py
+++ b/src/risk/models.py
@@ -1,0 +1,34 @@
+"""Data models for regulatory risk reporting."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class Trade:
+    """Basic representation of a financial trade."""
+
+    trade_id: str
+    product_type: str
+    notional: float
+    currency: str
+    description: Optional[str] = None
+
+
+@dataclass
+class RiskFactor:
+    """Market risk factor affecting a trade."""
+
+    name: str
+    value: float
+    description: Optional[str] = None
+
+
+@dataclass
+class Exposure:
+    """Exposure of a trade to a risk factor."""
+
+    trade: Trade
+    risk_factor: RiskFactor
+    amount: float


### PR DESCRIPTION
## Summary
- add Trade, RiskFactor, and Exposure dataclasses with CRIF converter and placeholders for CUSO/Basel/FRTB
- expose new FastAPI endpoints for generating regulatory reports
- document regulatory assumptions and limitations

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a269f817d48326aae60d52ceba624d