### PR TITLE
Fix put boundary condition

### DIFF
--- a/src/boundary_conditions.py
+++ b/src/boundary_conditions.py
@@ -23,7 +23,7 @@ class BlackScholesBoundaryBuilder:
     on the option type:
 
     * Left boundary: gamma equals zero.
-    * Right boundary: delta tends to +1 for calls and -1 for puts.
+    * Right boundary: delta tends to +1 for calls and 0 for puts.
     """
 
     def build(
@@ -48,7 +48,7 @@ class BlackScholesBoundaryBuilder:
         # Gamma equals zero on the left boundary for stability
         bc[0] = d2, 0.0
 
-        # Right boundary: delta approaches 1 for calls and -1 for puts.
+        # Right boundary: delta approaches 1 for calls and 0 for puts.
         if isinstance(option, EuropeanCall):
             bc[-1] = d1, 1.0
         elif isinstance(option, EuropeanPut):

--- a/tests/test_boundary_conditions.py
+++ b/tests/test_boundary_conditions.py
@@ -46,4 +46,4 @@ def test_put_boundary_conditions():
     assert np.allclose(lhs[0], expected_left)
     assert np.allclose(lhs[-1], expected_right)
     assert np.allclose(bc.rhs.toarray().ravel()[0], 0.0)
-    assert np.allclose(bc.rhs.toarray().ravel()[-1], -1.0)
+    assert np.allclose(bc.rhs.toarray().ravel()[-1], 0.0)


### PR DESCRIPTION
## Summary
- Correct Black-Scholes boundary builder documentation to state put delta tends to zero
- Align put boundary test with zero right-boundary value

## Testing
- `pre-commit run --files src/boundary_conditions.py tests/test_boundary_conditions.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4f83db6f08326834141f2984e61c8