### PR TITLE
Add CORS middleware configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ python -m cli plot --option-type Call --strike 1 --maturity 1 --output plot.png
 
 ## FastAPI Service
 
-Start a REST API that exposes pricing and Greek calculations:
+Start a REST API that exposes pricing and Greek calculations.
+The service allows cross-origin requests from `https://your-domain.com`.
 
 ```bash
 uvicorn api.main:app --reload

--- a/api/main.py
+++ b/api/main.py
@@ -1,10 +1,12 @@
 """FastAPI service for option pricing and Greek calculations."""
+
 from __future__ import annotations
 
 from typing import Optional
 
 import numpy as np
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from src.option_pricer import OptionPricer
@@ -19,6 +21,14 @@ from src.risk import (
 )
 
 app = FastAPI(title="Finite Difference Option Pricing")
+
+# Allow browser applications from the specified domain to access the API.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["https://your-domain.com"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 class OptionRequest(BaseModel):


### PR DESCRIPTION
## Summary
- allow configured browser origins by adding CORS middleware
- document permitted origin in README

## Testing
- `pre-commit run --files api/main.py README.md` *(fails: mypy missing type annotations in existing modules)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a505b61aa483269eeea75d067e59b2