### PR TITLE
docs: explain theta method and callable bonds

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ It expects the FastAPI server to run locally on port 8000.
 
 Details on assumptions and limitations are available in [docs/regulatory.md](docs/regulatory.md).
 An explanation of the Black--Scholes PDE and its finite difference discretization is provided in [docs/explanation/black_scholes_fdm.md](docs/explanation/black_scholes_fdm.md).
+The derivation of θ-stepping and the modelling of callable bonds are discussed in [docs/explanation/pde_models.md](docs/explanation/pde_models.md).
 
 ## License
 

--- a/docs/adr/001-support-theta-stepping-callable-bonds.md
+++ b/docs/adr/001-support-theta-stepping-callable-bonds.md
@@ -1,0 +1,15 @@
+# 001: Support θ-Stepping and Callable Bonds
+
+## Status
+Accepted
+
+## Context
+The initial solver handled only fixed schemes for European options. To broaden the framework we needed a unified time-stepper and support for instruments with early redemption features.
+
+## Decision
+Adopt a configurable θ-method for time-stepping and introduce a callable bond PDE model. The model caps grid values at the call price and uses boundary conditions that enforce the same limit.
+
+## Consequences
+- Users can choose between explicit, implicit and Crank–Nicolson stepping.
+- Callable bonds can be priced alongside vanilla options.
+- Additional documentation explains the method and modelling approach.

--- a/docs/explanation/pde_models.md
+++ b/docs/explanation/pde_models.md
@@ -1,0 +1,77 @@
+# θ-Method and Callable Bond PDE Models
+
+This note derives the general θ-method for time-stepping parabolic PDEs and explains how callable bonds are handled in the finite difference framework.
+
+## θ-method derivation
+
+Consider a linear parabolic PDE of the form
+
+$$
+\frac{\partial V}{\partial t} = \mathcal{L}V,
+$$
+
+where $\mathcal{L}$ is the spatial differential operator. On a grid with time step $\Delta t$, the θ-method approximates the time derivative by a weighted average of the operator evaluated at the current and next time levels:
+
+$$
+\frac{V^{n+1}-V^{n}}{\Delta t} = (1-\theta)\,\mathcal{L}V^{n} + \theta\,\mathcal{L}V^{n+1}.
+$$
+
+Rearranging gives a linear system for the unknown $V^{n+1}$,
+
+$$
+\bigl(I - \theta\,\Delta t\,\mathcal{L}\bigr) V^{n+1} = \bigl(I + (1-\theta)\,\Delta t\,\mathcal{L}\bigr) V^{n}.
+$$
+
+Different choices of $\theta$ recover common schemes:
+
+### Explicit Euler ($\theta=0$)
+
+$$
+V^{n+1} = \bigl(I + \Delta t\,\mathcal{L}\bigr) V^{n}.
+$$
+
+This scheme is first-order accurate in time and conditionally stable; $\Delta t$ must satisfy a Courant condition.
+
+### Implicit Euler ($\theta=1$)
+
+$$
+\bigl(I - \Delta t\,\mathcal{L}\bigr) V^{n+1} = V^{n}.
+$$
+
+It remains first-order accurate but is unconditionally stable because the operator is evaluated fully at the new time level.
+
+### Crank–Nicolson ($\theta=1/2$)
+
+$$
+\bigl(I - \tfrac{1}{2}\Delta t\,\mathcal{L}\bigr) V^{n+1} = \bigl(I + \tfrac{1}{2}\Delta t\,\mathcal{L}\bigr) V^{n}.
+$$
+
+Averaging the explicit and implicit forms yields second-order accuracy in both time and space while retaining unconditional stability.
+
+## Callable bond modelling
+
+A callable bond allows the issuer to redeem the bond early at a fixed call price $C$. The PDE for the bond value is solved as usual, but the early redemption feature is enforced numerically.
+
+### Grid capping
+
+After each time step the grid values are capped at the call price:
+
+$$
+V^{n+1}_i \leftarrow \min\bigl(V^{n+1}_i, C\bigr),
+$$
+
+which emulates the optimal calling strategy and prevents the numerical solution from exceeding $C$.
+
+### Boundary conditions
+
+Dirichlet boundaries keep the solution within admissible bounds:
+
+- **Lower boundary:** as the short rate approaches zero, the bond value tends to zero.
+- **Upper boundary:** the bond price cannot exceed the call price $C$.
+
+Together, boundary conditions and grid capping ensure the finite difference solution respects the callable feature at all times.
+
+## Further reading
+
+- John C. Hull. *Options, Futures, and Other Derivatives*. Pearson, 2022.
+- Paul Wilmott, Sam Howison, and Jeff Dewynne. *The Mathematics of Financial Derivatives*. Cambridge University Press, 1995.

--- a/docs/regulatory.md
+++ b/docs/regulatory.md
@@ -16,4 +16,4 @@ This module offers minimal structures for representing trades, risk factors and 
 
 ## Further reading
 
-For the mathematical background on the PDE solver, see [docs/explanation/black_scholes_fdm.md](explanation/black_scholes_fdm.md).
+For the mathematical background on the PDE solver, see [docs/explanation/black_scholes_fdm.md](explanation/black_scholes_fdm.md) and [docs/explanation/pde_models.md](explanation/pde_models.md).


### PR DESCRIPTION
## Summary
- document derivation of the θ-method and callable bond modeling
- link PDE model explanation from README and regulatory docs
- log decision to support θ-stepping and callable bonds in ADR 001

## Testing
- `pre-commit run --files README.md docs/regulatory.md docs/explanation/pde_models.md docs/adr/001-support-theta-stepping-callable-bonds.md`


------
https://chatgpt.com/codex/tasks/task_e_68a50b0b87588326a86d4f3b9e72f1a8