### PR TITLE
Add callable bond pricing test and fix boundary conditions

### DIFF
--- a/src/pde_pricer.py
+++ b/src/pde_pricer.py
@@ -5,6 +5,7 @@ concrete implementations for vanilla options and callable bonds.  The models
 encapsulate the construction of the infinitesimal generator and the boundary
 conditions required by the finite difference solver.
 """
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
@@ -72,7 +73,7 @@ class BlackScholesPDE(PDEModel):
     boundary_builder: BlackScholesBoundaryBuilder = field(
         default_factory=BlackScholesBoundaryBuilder
     )
-    time_stepper: TimeStepper | None = None
+    time_stepper: TimeStepper | None = None  # type: ignore[assignment]
 
     def __post_init__(self) -> None:
         """Initialise default time stepper if not supplied."""
@@ -139,9 +140,9 @@ class CallableBondPDEModel(PDEModel):
 
         bc = BoundaryConditions(s.shape)
         # Value is zero when the bond price approaches zero
-        bc[0] = 0, 0.0
+        bc[0] = 0.0
         # Bond cannot exceed the call price
-        bc[-1] = 0, self.call_price
+        bc[-1] = self.call_price
         return bc
 
     def price(
@@ -168,4 +169,3 @@ class CallableBondPDEModel(PDEModel):
             values[i + 1] = np.minimum(values[i + 1], self.call_price)
         values = np.minimum(values, self.call_price)
         return values
-

--- a/src/time_steppers.py
+++ b/src/time_steppers.py
@@ -1,4 +1,5 @@
 """Time stepping schemes for finite difference PDE solvers."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -7,7 +8,7 @@ from abc import ABC, abstractmethod
 import numpy as np
 from numpy.typing import NDArray
 import findiff as fd
-from findiff import PDE
+from findiff import PDE, BoundaryConditions
 
 
 class TimeStepper(ABC):
@@ -18,7 +19,7 @@ class TimeStepper(ABC):
         self,
         u: NDArray[np.float64],
         operator: fd.FinDiff,
-        bc,
+        bc: BoundaryConditions,
         dt: float,
     ) -> NDArray[np.float64]:
         """Advance the solution ``u`` by one time step of size ``dt``."""
@@ -34,7 +35,7 @@ class ThetaMethod(TimeStepper):
         self,
         u: NDArray[np.float64],
         operator: fd.FinDiff,
-        bc,
+        bc: BoundaryConditions,
         dt: float,
     ) -> NDArray[np.float64]:
         A = fd.Identity() - self.theta * dt * operator

--- a/tests/test_callable_bond.py
+++ b/tests/test_callable_bond.py
@@ -1,0 +1,34 @@
+"""Tests for callable bond pricing grid."""
+
+import pathlib
+import sys
+
+# Ensure project root on path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import numpy as np
+
+from src.option_pricer import OptionPricer
+from src.pde_pricer import CallableBondPDEModel
+from src.models import Market, GeometricBrownianMotion
+
+
+def test_callable_bond_grid_respects_call_price_and_face_value() -> None:
+    market = Market(rate=0.03)
+    short_rate = GeometricBrownianMotion(rate=0.03, sigma=0.01)
+    bond_model = CallableBondPDEModel(
+        face_value=100.0,
+        call_price=105.0,
+        market=market,
+        model=short_rate,
+    )
+    pricer = OptionPricer(pde_model=bond_model)
+    res = pricer.compute_grid(
+        maturity=1.0,
+        s_max=150.0,
+        s_steps=50,
+        t_steps=50,
+    )
+
+    assert np.all(res.values <= bond_model.call_price)
+    assert np.allclose(res.values[0], bond_model.face_value)


### PR DESCRIPTION
## Summary
- add test verifying callable bond grid respects call price and face value
- fix callable bond boundary conditions and improve typing for MyPy

## Testing
- `pre-commit run --files src/pde_pricer.py src/time_steppers.py src/option_pricer.py tests/test_callable_bond.py`
- `pytest tests/test_callable_bond.py`


------
https://chatgpt.com/codex/tasks/task_e_68a50b1194808326b28d36d2a341f764