### PR TITLE
refactor: relocate finite difference pricing engine

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -17,8 +17,22 @@ from .processes.affine import (
     create_cir_process,
     create_standard_heston,
 )
-from .processes.nonaffine import ConstantElasticityVariance, SABRModel, create_cev_process, create_sabr_model
-from .pricing.engines.unified import UnifiedPricingEngine, create_unified_pricing_engine, create_log_grid
+from .processes.nonaffine import (
+    ConstantElasticityVariance,
+    SABRModel,
+    create_cev_process,
+    create_sabr_model,
+)
+from .pricing.engines import (
+    GridParameters,
+    PricingEngine,
+    PricingResult,
+    UnifiedPricingEngine,
+    create_default_pricing_engine,
+    create_linear_grid,
+    create_log_grid,
+    create_unified_pricing_engine,
+)
 from .solvers.adi import ADISolver, create_adi_solver
 from .validation import validate_positive, validate_non_negative, validate_probability
 
@@ -55,7 +69,7 @@ __all__ = [
     "EuropeanCall",
     "EuropeanPut",
     "EuropeanOption",
-    
+
     # Processes
     "StochasticProcess",
     "AffineProcess",
@@ -72,12 +86,17 @@ __all__ = [
     "create_standard_heston",
     "create_cev_process",
     "create_sabr_model",
-    
+
     # Pricing
+    "GridParameters",
+    "PricingEngine",
+    "PricingResult",
     "UnifiedPricingEngine",
-    "create_unified_pricing_engine",
+    "create_default_pricing_engine",
+    "create_linear_grid",
     "create_log_grid",
-    
+    "create_unified_pricing_engine",
+
     # Backward compatibility
     "UnifiedInstrument",
     "UnifiedEuropeanOption",
@@ -85,22 +104,22 @@ __all__ = [
     "create_unified_european_call",
     "create_unified_european_put",
     "create_unified_basket_call",
-    
+
     # Solvers
     "ADISolver",
     "create_adi_solver",
-    
+
     # Validation
     "validate_positive",
     "validate_non_negative",
     "validate_probability",
     "validate_weights_sum_to_one",
-    
+
     # Utilities
     "matrix_sqrt",
     "ensure_state_array",
     "validate_state_dimensions",
-    
+
     # Exceptions
     "FiniteDifferenceError",
     "ValidationError",

--- a/src/pricing/__init__.py
+++ b/src/pricing/__init__.py
@@ -2,7 +2,16 @@
 
 This package contains the unified pricing framework for financial instruments.
 """
-from .engines.unified import UnifiedPricingEngine, create_unified_pricing_engine, create_log_grid, create_linear_grid
+from .engines import (
+    GridParameters,
+    PricingEngine,
+    PricingResult,
+    UnifiedPricingEngine,
+    create_default_pricing_engine,
+    create_linear_grid,
+    create_log_grid,
+    create_unified_pricing_engine,
+)
 
 # Backward compatibility imports
 from .instruments.base import UnifiedInstrument
@@ -15,11 +24,15 @@ from .instruments.options import (
 )
 
 __all__ = [
+    "GridParameters",
+    "PricingEngine",
+    "PricingResult",
     "UnifiedPricingEngine",
-    "create_unified_pricing_engine",
-    "create_log_grid",
+    "create_default_pricing_engine",
     "create_linear_grid",
-    
+    "create_log_grid",
+    "create_unified_pricing_engine",
+
     # Backward compatibility
     "UnifiedInstrument",
     "UnifiedEuropeanOption",

--- a/src/pricing/engines/__init__.py
+++ b/src/pricing/engines/__init__.py
@@ -1,1 +1,25 @@
 """Pricing engines package."""
+
+from .finite_difference import (
+    GridParameters,
+    PricingEngine,
+    PricingResult,
+    create_default_pricing_engine,
+)
+from .unified import (
+    UnifiedPricingEngine,
+    create_linear_grid,
+    create_log_grid,
+    create_unified_pricing_engine,
+)
+
+__all__ = [
+    "GridParameters",
+    "PricingEngine",
+    "PricingResult",
+    "UnifiedPricingEngine",
+    "create_default_pricing_engine",
+    "create_linear_grid",
+    "create_log_grid",
+    "create_unified_pricing_engine",
+]

--- a/tests/test_pricing_engine_imports.py
+++ b/tests/test_pricing_engine_imports.py
@@ -1,0 +1,40 @@
+"""Tests covering the finite difference pricing engine import surface."""
+import pathlib
+import sys
+
+# Ensure project root on path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from src.pricing import (
+    GridParameters,
+    PricingEngine,
+    PricingResult,
+    create_default_pricing_engine,
+)
+from src.pricing.engines import (
+    GridParameters as GridParametersFromPackage,
+    PricingEngine as PricingEngineFromPackage,
+    PricingResult as PricingResultFromPackage,
+    create_default_pricing_engine as create_default_pricing_engine_from_package,
+    finite_difference,
+)
+
+
+def test_symbols_reexported_from_pricing_package() -> None:
+    """The pricing package should expose the finite difference engine API."""
+    assert PricingEngine is finite_difference.PricingEngine
+    assert PricingEngine is PricingEngineFromPackage
+    assert GridParameters is finite_difference.GridParameters
+    assert GridParameters is GridParametersFromPackage
+    assert PricingResult is finite_difference.PricingResult
+    assert PricingResult is PricingResultFromPackage
+    assert (
+        create_default_pricing_engine
+        is create_default_pricing_engine_from_package
+    )
+
+
+def test_create_default_pricing_engine_returns_engine() -> None:
+    """Factory helper should yield a configured pricing engine instance."""
+    engine = create_default_pricing_engine()
+    assert isinstance(engine, PricingEngine)


### PR DESCRIPTION
## Summary
- move the finite difference pricing engine into `src/pricing/engines/finite_difference.py` and drop the legacy module
- update `src/pricing` and top-level package exports to expose the relocated engine API
- add a regression test that exercises the new import surface to guard against future regressions

## Testing
- pytest tests/test_pricing_engine_imports.py

------
https://chatgpt.com/codex/tasks/task_e_68ca1fb266e88326bc875114e2b1462b