### PR TITLE
refactor: reorganize spatial operator under instruments

### DIFF
--- a/src/instruments/__init__.py
+++ b/src/instruments/__init__.py
@@ -4,10 +4,12 @@ This package contains implementations of various financial instruments
 for the unified pricing framework.
 """
 from .base import Instrument, EuropeanOption, EuropeanCall, EuropeanPut
+from .operators import SpatialOperator
 
 __all__ = [
     "Instrument",
     "EuropeanOption",
     "EuropeanCall",
     "EuropeanPut",
+    "SpatialOperator",
 ]

--- a/src/instruments/base.py
+++ b/src/instruments/base.py
@@ -14,7 +14,7 @@ from findiff import FinDiff, BoundaryConditions
 
 from src.exceptions import ValidationError
 from ..processes.base import StochasticProcess
-from ..spatial_operator import SpatialOperator
+from .operators import SpatialOperator
 
 
 class Instrument(BaseModel):

--- a/src/instruments/operators.py
+++ b/src/instruments/operators.py
@@ -1,15 +1,15 @@
-"""Construction of spatial differential operators."""
+"""Construction of spatial differential operators for instruments."""
 from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+import findiff as fd
 import numpy as np
 from numpy.typing import NDArray
-import findiff as fd
 
 if TYPE_CHECKING:  # pragma: no cover - runtime import only for typing
-    from .processes import GeometricBrownianMotion
+    from src.processes import GeometricBrownianMotion
 
 
 @dataclass

--- a/src/pricing/engines/finite_difference.py
+++ b/src/pricing/engines/finite_difference.py
@@ -27,7 +27,7 @@ from src.solvers.finite_difference import (
     create_default_solver,
 )
 from src.processes.affine import GeometricBrownianMotion
-from src.spatial_operator import SpatialOperator
+from src.instruments.operators import SpatialOperator
 from src.validation import validate_grid_parameters, validate_spot_price
 
 

--- a/src/solvers/base.py
+++ b/src/solvers/base.py
@@ -12,9 +12,9 @@ import numpy as np
 from findiff import BoundaryConditions, FinDiff
 from numpy.typing import NDArray
 
+from ..instruments.operators import SpatialOperator
 from ..pricing.instruments.base import UnifiedInstrument
 from ..processes.base import StochasticProcess
-from ..spatial_operator import SpatialOperator
 from src.exceptions import ValidationError
 
 from .finite_difference import (


### PR DESCRIPTION
## Summary
- move `SpatialOperator` into a dedicated `src/instruments/operators.py` submodule and export it from the instruments package
- update instrument, solver, and finite-difference pricing modules to import the operator from its new location and remove the legacy module

## Testing
- pytest tests/test_callable_bond.py

------
https://chatgpt.com/codex/tasks/task_e_68ca34450c2483269ed5f9b8957163af