### PR TITLE
fix(solvers): preserve process coefficients in ADI adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
             tests/test_callable_bond.py \
             tests/test_finite_difference_greeks.py \
             tests/test_greeks.py \
+            tests/test_multidimensional_adapter_coefficients.py \
             tests/test_option_pricer.py \
             tests/test_option_pricer_result.py \
             tests/test_options.py \

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,7 +65,7 @@ Cross-repository integration uses versioned wheels, contracts and parity fixture
 | Public examples import `src.*`; code mixes relative and `src.*` imports | Checkout behavior masks broken installation and split identity | Real package namespace and import cleanup under #51/#52 |
 | Legacy and newer processes, pricers, Greeks, boundaries and solvers coexist | Divergent semantics and duplicated fixes | One canonical implementation per capability under #52 |
 | `SolverFactory` routes primarily by process dimension | Dimension does not prove coefficient, BC, obstacle or scheme support | Capability predicates and explicit problem contracts |
-| `ADISolverWrapper` constructs dummy drift and hard-coded covariance | Numerically plausible but model-incorrect output | Remove from selectable routes; explicit coefficients under #59 |
+| `ADISolverWrapper` used to construct dummy drift and hard-coded covariance | Numerically plausible but model-incorrect output | Removed from selectable multidimensional routes under #43; complete ADI splitting and explicit result diagnostics continue under #46/#59 |
 | Generic 1D adapter guesses boundary conditions from `option_type` | Product assumptions hidden in numerical core | Typed BCs supplied by problem adapter |
 | Core requirements include FastAPI, Typer, Streamlit and plotting | Numerical consumers install unrelated application stacks | Separate published extras |
 | SciPy is only in development requirements | Runtime metadata does not match numerical implementation needs | Put actual numerical runtime dependencies in core metadata |

--- a/src/solvers/base.py
+++ b/src/solvers/base.py
@@ -212,6 +212,12 @@ class ADISolverWrapper(Solver):
             raise ValidationError("process covariance contains non-finite values on the ADI state grid")
         if not np.allclose(covariance, np.swapaxes(covariance, -1, -2), rtol=1e-10, atol=1e-12):
             raise ValidationError("process covariance must be symmetric on the ADI state grid")
+        min_eigenvalue = float(np.min(np.linalg.eigvalsh(covariance)))
+        if min_eigenvalue < -1e-10:
+            raise ValidationError(
+                "process covariance must be positive semi-definite on the ADI state grid; "
+                f"minimum eigenvalue is {min_eigenvalue:.2e}"
+            )
 
         return (
             drift.reshape(*grid_shape, dimension),

--- a/src/solvers/base.py
+++ b/src/solvers/base.py
@@ -130,12 +130,19 @@ class FiniteDifferenceSolverAdapter(Solver):
 
 
 class ADISolverWrapper(Solver):
-    """Wrapper for ADI solver to conform to Solver interface."""
-    
-    def __init__(self, adi_solver):
-        """Initialize wrapper with ADI solver."""
+    """Wrapper for ADI solver to conform to Solver interface.
+
+    The wrapper owns coefficient evaluation for the selected stochastic process.
+    It deliberately does not invent placeholder drift or covariance arrays: if a
+    process cannot provide coefficients with the expected shape, the route fails
+    before calling the ADI solver.
+    """
+
+    def __init__(self, adi_solver, *, process: StochasticProcess) -> None:
+        """Initialize wrapper with ADI solver and selected process."""
         self._adi_solver = adi_solver
-    
+        self._process = process
+
     def solve(
         self,
         initial_condition: NDArray[np.float64],
@@ -143,49 +150,73 @@ class ADISolverWrapper(Solver):
         *grids: NDArray[np.float64],
         time_grid: Optional[NDArray[np.float64]] = None,
     ) -> NDArray[np.float64]:
-        """Solve multi-dimensional PDE using ADI method."""
-        if time_grid is None:
+        """Solve a multi-dimensional PDE using process-derived coefficients."""
+        if time_grid is None or len(time_grid) == 0:
             n_time_steps = 100
             time_grid = np.linspace(0, instrument.maturity, n_time_steps + 1)
-        
-        # For this example, we'll use the existing ADI solver methods
-        if len(grids) == 2:
-            # Create dummy drift and covariance for 2D
-            grid_shape = np.meshgrid(*grids, indexing='ij')[0].shape
-            drift = np.zeros(grid_shape + (2,))
-            covariance = np.zeros(grid_shape + (2, 2))
-            # Set some basic values to make it work
-            covariance[..., 0, 0] = 0.04  # sigma^2 for first dimension
-            covariance[..., 1, 1] = 0.01  # sigma^2 for second dimension
-            
-            solution = self._adi_solver.solve_2d(
+
+        dimension = self._process.dimension.value
+        if dimension not in {2, 3}:
+            raise ValidationError(f"ADI wrapper supports only 2D and 3D processes, got {dimension}D")
+        if len(grids) != dimension:
+            raise ValidationError(f"Expected {dimension} grids for ADI solve, got {len(grids)}")
+
+        drift, covariance = self._build_process_coefficients(float(time_grid[-1]), grids)
+
+        if dimension == 2:
+            return self._adi_solver.solve_2d(
                 initial_condition=initial_condition,
                 drift=drift,
                 covariance=covariance,
                 time_grid=time_grid,
                 spatial_grids=grids,
             )
-            return solution
-        elif len(grids) == 3:
-            # Create dummy drift and covariance for 3D
-            grid_shape = np.meshgrid(*grids, indexing='ij')[0].shape
-            drift = np.zeros(grid_shape + (3,))
-            covariance = np.zeros(grid_shape + (3, 3))
-            # Set some basic values to make it work
-            covariance[..., 0, 0] = 0.04  # sigma^2 for first dimension
-            covariance[..., 1, 1] = 0.01  # sigma^2 for second dimension
-            covariance[..., 2, 2] = 0.005  # sigma^2 for third dimension
-            
-            solution = self._adi_solver.solve_3d(
-                initial_condition=initial_condition,
-                drift=drift,
-                covariance=covariance,
-                time_grid=time_grid,
-                spatial_grids=grids,
+
+        return self._adi_solver.solve_3d(
+            initial_condition=initial_condition,
+            drift=drift,
+            covariance=covariance,
+            time_grid=time_grid,
+            spatial_grids=grids,
+        )
+
+    def _build_process_coefficients(
+        self,
+        time: float,
+        grids: tuple[NDArray[np.float64], ...],
+    ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+        """Evaluate drift and covariance on the full tensor product grid."""
+        dimension = self._process.dimension.value
+        grid_shape = tuple(len(grid) for grid in grids)
+        mesh = np.meshgrid(*grids, indexing="ij")
+        states = np.stack([axis.reshape(-1) for axis in mesh], axis=-1)
+
+        drift = np.asarray(self._process.drift(time, states), dtype=float)
+        covariance = np.asarray(self._process.covariance(time, states), dtype=float)
+
+        expected_drift_shape = (states.shape[0], dimension)
+        expected_covariance_shape = (states.shape[0], dimension, dimension)
+        if drift.shape != expected_drift_shape:
+            raise ValidationError(
+                "process drift must have shape "
+                f"{expected_drift_shape} on the ADI state grid, got {drift.shape}"
             )
-            return solution
-        else:
-            raise ValidationError(f"Unsupported dimension: {len(grids)}")
+        if covariance.shape != expected_covariance_shape:
+            raise ValidationError(
+                "process covariance must have shape "
+                f"{expected_covariance_shape} on the ADI state grid, got {covariance.shape}"
+            )
+        if not np.all(np.isfinite(drift)):
+            raise ValidationError("process drift contains non-finite values on the ADI state grid")
+        if not np.all(np.isfinite(covariance)):
+            raise ValidationError("process covariance contains non-finite values on the ADI state grid")
+        if not np.allclose(covariance, np.swapaxes(covariance, -1, -2), rtol=1e-10, atol=1e-12):
+            raise ValidationError("process covariance must be symmetric on the ADI state grid")
+
+        return (
+            drift.reshape(*grid_shape, dimension),
+            covariance.reshape(*grid_shape, dimension, dimension),
+        )
 
 
 class SolverFactory:
@@ -221,4 +252,4 @@ class SolverFactory:
             )
         else:
             adi_solver = ADISolver(theta=theta)
-            return ADISolverWrapper(adi_solver)
+            return ADISolverWrapper(adi_solver, process=process)

--- a/tests/test_multidimensional_adapter_coefficients.py
+++ b/tests/test_multidimensional_adapter_coefficients.py
@@ -1,0 +1,150 @@
+"""Regression tests for multidimensional unified-engine coefficient plumbing."""
+from __future__ import annotations
+
+import inspect
+
+import numpy as np
+from numpy.testing import assert_allclose
+import pytest
+
+from src.exceptions import ValidationError
+from src.pricing import UnifiedEuropeanOption
+from src.processes import ProcessDimension, create_standard_heston
+from src.solvers.base import ADISolverWrapper
+
+
+class RecordingADISolver:
+    """ADI test double that records the coefficients it receives."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def solve_2d(
+        self,
+        initial_condition,
+        drift,
+        covariance,
+        time_grid,
+        spatial_grids,
+        boundary_conditions=None,
+    ):
+        self.calls.append(
+            {
+                "initial_condition": np.array(initial_condition, copy=True),
+                "drift": np.array(drift, copy=True),
+                "covariance": np.array(covariance, copy=True),
+                "time_grid": np.array(time_grid, copy=True),
+                "spatial_grids": tuple(np.array(grid, copy=True) for grid in spatial_grids),
+                "boundary_conditions": boundary_conditions,
+            }
+        )
+        solution = np.zeros((len(time_grid), *initial_condition.shape), dtype=float)
+        solution[-1] = initial_condition
+        return solution
+
+    def solve_3d(self, *args, **kwargs):  # pragma: no cover - should not be called here
+        raise AssertionError("3D solver should not be reached by these tests")
+
+
+class FourDimensionalProcess:
+    @property
+    def dimension(self) -> ProcessDimension:
+        return ProcessDimension(value=4)
+
+    def drift(self, time: float, state: np.ndarray) -> np.ndarray:  # pragma: no cover - fail-fast path
+        raise AssertionError("drift should not be evaluated for unsupported dimensions")
+
+    def covariance(self, time: float, state: np.ndarray) -> np.ndarray:  # pragma: no cover - fail-fast path
+        raise AssertionError("covariance should not be evaluated for unsupported dimensions")
+
+
+def _expected_process_coefficients(process, time_grid, grids):
+    mesh = np.meshgrid(*grids, indexing="ij")
+    grid_shape = mesh[0].shape
+    states = np.stack([axis.reshape(-1) for axis in mesh], axis=-1)
+    drift = process.drift(float(time_grid[-1]), states).reshape(*grid_shape, process.dimension.value)
+    covariance = process.covariance(float(time_grid[-1]), states).reshape(
+        *grid_shape,
+        process.dimension.value,
+        process.dimension.value,
+    )
+    return drift, covariance
+
+
+def test_multidimensional_adapter_passes_heston_process_coefficients_to_adi() -> None:
+    process = create_standard_heston(r=0.03, kappa=4.0, theta=0.08, sigma=0.55, rho=-0.35)
+    recording_solver = RecordingADISolver()
+    wrapper = ADISolverWrapper(recording_solver, process=process)
+
+    spot_grid = np.array([80.0, 100.0, 120.0])
+    variance_grid = np.array([0.02, 0.06, 0.12])
+    grids = (spot_grid, variance_grid)
+    time_grid = np.array([0.0, 0.25])
+    initial_condition = np.maximum(spot_grid[:, None] - 100.0, 0.0)
+    instrument = UnifiedEuropeanOption(strike=100.0, maturity=0.25, option_type="call")
+
+    wrapper.solve(initial_condition, instrument, *grids, time_grid=time_grid)
+
+    assert len(recording_solver.calls) == 1
+    call = recording_solver.calls[0]
+    expected_drift, expected_covariance = _expected_process_coefficients(process, time_grid, grids)
+    assert_allclose(call["drift"], expected_drift)
+    assert_allclose(call["covariance"], expected_covariance)
+
+    covariance = call["covariance"]
+    assert np.any(covariance[..., 0, 1] != 0.0), "Heston mixed covariance must reach ADI assembly"
+    assert_allclose(covariance[..., 0, 1], covariance[..., 1, 0])
+
+
+def test_multidimensional_adapter_coefficients_change_with_selected_process() -> None:
+    spot_grid = np.array([90.0, 110.0])
+    variance_grid = np.array([0.03, 0.09])
+    time_grid = np.array([0.0, 0.5])
+
+    low_vol_process = create_standard_heston(r=0.03, kappa=4.0, theta=0.08, sigma=0.2, rho=-0.1)
+    high_vol_process = create_standard_heston(r=0.03, kappa=8.0, theta=0.06, sigma=0.8, rho=-0.7)
+
+    _, low_covariance = ADISolverWrapper(RecordingADISolver(), process=low_vol_process)._build_process_coefficients(
+        float(time_grid[-1]),
+        (spot_grid, variance_grid),
+    )
+    _, high_covariance = ADISolverWrapper(RecordingADISolver(), process=high_vol_process)._build_process_coefficients(
+        float(time_grid[-1]),
+        (spot_grid, variance_grid),
+    )
+
+    assert not np.allclose(low_covariance, high_covariance)
+    expected_shape = low_covariance[..., 1, 1].shape
+    expected_low_var = np.broadcast_to(low_vol_process.sigma**2 * variance_grid[None, :], expected_shape)
+    expected_high_var = np.broadcast_to(high_vol_process.sigma**2 * variance_grid[None, :], expected_shape)
+    assert_allclose(low_covariance[..., 1, 1], expected_low_var)
+    assert_allclose(high_covariance[..., 1, 1], expected_high_var)
+
+
+def test_multidimensional_adapter_rejects_unsupported_dimensions_before_allocation() -> None:
+    wrapper = ADISolverWrapper(RecordingADISolver(), process=FourDimensionalProcess())
+    instrument = UnifiedEuropeanOption(strike=100.0, maturity=0.25, option_type="call")
+
+    with pytest.raises(ValidationError, match="supports only 2D and 3D"):
+        wrapper.solve(
+            np.zeros((2, 2, 2, 2)),
+            instrument,
+            np.array([0.0, 1.0]),
+            np.array([0.0, 1.0]),
+            np.array([0.0, 1.0]),
+            np.array([0.0, 1.0]),
+            time_grid=np.array([0.0, 0.25]),
+        )
+
+
+def test_multidimensional_adapter_contains_no_zero_drift_constant_variance_fallback() -> None:
+    source = inspect.getsource(ADISolverWrapper.solve)
+    forbidden_fragments = [
+        "Create dummy drift",
+        "np.zeros(grid_shape + (2,))",
+        "np.zeros(grid_shape + (3,))",
+        "covariance[..., 0, 0] = 0.04",
+        "covariance[..., 1, 1] = 0.01",
+        "covariance[..., 2, 2] = 0.005",
+    ]
+    assert not any(fragment in source for fragment in forbidden_fragments)

--- a/tests/test_multidimensional_adapter_coefficients.py
+++ b/tests/test_multidimensional_adapter_coefficients.py
@@ -2,6 +2,10 @@
 from __future__ import annotations
 
 import inspect
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 import numpy as np
 from numpy.testing import assert_allclose
@@ -9,7 +13,7 @@ import pytest
 
 from src.exceptions import ValidationError
 from src.pricing import UnifiedEuropeanOption
-from src.processes import ProcessDimension, create_standard_heston
+from src.processes import ProcessDimension, ProcessType, StochasticProcess, create_standard_heston
 from src.solvers.base import ADISolverWrapper
 
 
@@ -46,16 +50,37 @@ class RecordingADISolver:
         raise AssertionError("3D solver should not be reached by these tests")
 
 
-class FourDimensionalProcess:
+class FourDimensionalProcess(StochasticProcess):
     @property
     def dimension(self) -> ProcessDimension:
         return ProcessDimension(value=4)
+
+    @property
+    def process_type(self) -> ProcessType:
+        return ProcessType.NON_AFFINE
 
     def drift(self, time: float, state: np.ndarray) -> np.ndarray:  # pragma: no cover - fail-fast path
         raise AssertionError("drift should not be evaluated for unsupported dimensions")
 
     def covariance(self, time: float, state: np.ndarray) -> np.ndarray:  # pragma: no cover - fail-fast path
         raise AssertionError("covariance should not be evaluated for unsupported dimensions")
+
+
+class IndefiniteTwoDimensionalProcess(StochasticProcess):
+    @property
+    def dimension(self) -> ProcessDimension:
+        return ProcessDimension(value=2)
+
+    @property
+    def process_type(self) -> ProcessType:
+        return ProcessType.NON_AFFINE
+
+    def drift(self, time: float, state: np.ndarray) -> np.ndarray:
+        return np.zeros((len(state), 2), dtype=float)
+
+    def covariance(self, time: float, state: np.ndarray) -> np.ndarray:
+        covariance = np.array([[1.0, 2.0], [2.0, 1.0]])
+        return np.broadcast_to(covariance, (len(state), 2, 2)).copy()
 
 
 def _expected_process_coefficients(process, time_grid, grids):
@@ -135,6 +160,22 @@ def test_multidimensional_adapter_rejects_unsupported_dimensions_before_allocati
             np.array([0.0, 1.0]),
             time_grid=np.array([0.0, 0.25]),
         )
+
+
+def test_multidimensional_adapter_rejects_indefinite_covariance_before_adi_call() -> None:
+    recording_solver = RecordingADISolver()
+    wrapper = ADISolverWrapper(recording_solver, process=IndefiniteTwoDimensionalProcess())
+    instrument = UnifiedEuropeanOption(strike=100.0, maturity=0.25, option_type="call")
+
+    with pytest.raises(ValidationError, match="positive semi-definite"):
+        wrapper.solve(
+            np.zeros((2, 2)),
+            instrument,
+            np.array([0.0, 1.0]),
+            np.array([0.0, 1.0]),
+            time_grid=np.array([0.0, 0.25]),
+        )
+    assert recording_solver.calls == []
 
 
 def test_multidimensional_adapter_contains_no_zero_drift_constant_variance_fallback() -> None:


### PR DESCRIPTION
## Summary
- Removes the multidimensional `ADISolverWrapper` dummy zero-drift / hard-coded covariance fallback.
- Passes the selected stochastic process into the wrapper and evaluates `drift(t, state)` plus `covariance(t, state)` on the full tensor-product state grid.
- Fails closed before ADI allocation for unsupported dimensions, malformed coefficient shapes, non-finite values, or asymmetric covariance.
- Adds regression tests proving Heston drift/covariance, including mixed covariance, reaches ADI assembly and that changing process parameters changes assembled coefficients.
- Adds the new regression file to the blocking stable CI suite.

## Closes
Closes #43

## Related issue raised while proceeding
- #72 — uncovered that `tests/test_unified_pricing_engine.py` is outside blocking CI and has known failures around 1D time orientation and 2D payoff-shape expectations. This PR does not promote that full file; it adds only the stable #43 regression coverage.

## Evidence
RED before implementation:
- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_multidimensional_adapter_coefficients.py -q`
- Result after valid Heston parameters but before code change: 4 failed
  - `ADISolverWrapper.__init__() got an unexpected keyword argument 'process'`
  - source still contained dummy drift / constant variance fallback fragments

GREEN after implementation:
- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_multidimensional_adapter_coefficients.py -q` -> 4 passed in 0.86s
- `PYTHONPATH=src .venv/bin/python -m pytest tests/architecture -q` -> 6 passed in 0.09s
- `PYTHONPATH=src .venv/bin/python -m ruff check . --select E9,F63,F7,F82 --output-format=github` -> exit 0
- `PYTHONPATH=src .venv/bin/python -m compileall -q src tests` -> exit 0
- Stable CI-equivalent suite with the new regression file -> 66 passed, 14 third-party matplotlib/pyparsing warnings in 33.08s
- `git diff --check` -> exit 0

## Acceptance criteria mapping for #43
- A state-dependent process produces state-dependent operator coefficients: covered by Heston tensor-grid coefficient tests.
- Heston requests use Heston drift/covariance, including the mixed term: wrapper now passes full Heston covariance to ADI; test asserts off-diagonal covariance reaches assembly.
- Changing process parameters changes assembled operator/coefficient inputs: covered by low/high vol Heston regression.
- Unsupported process/solver combinations fail before allocation: unsupported dimension test raises before coefficient evaluation/ADI call.
- No public route contains zero-drift/constant-variance fallback behavior: dummy fallback removed; source regression checks the wrapper.
- Regression demonstrates the old adapter failure mode: RED test failed before the process-aware wrapper existed.

## Remaining explicitly-owned successors
- #46 owns complete ADI splitting, mixed-derivative discretization, and reaction terms.
- #48 owns time-consistent discount/boundary/exercise conditions.
- #59 owns the shared solver-backend adapter/result-diagnostics contract.
- #72 owns promotion/governance of the broader excluded unified-engine regression file.
