### PR TITLE
ci: classify advisory automation failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,20 +57,29 @@ jobs:
         run: |
           if [ -f nextjs-client/package.json ]; then
             echo "present=true" >> "$GITHUB_OUTPUT"
+            if [ -f nextjs-client/package-lock.json ]; then
+              echo "lockfile=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "lockfile=false" >> "$GITHUB_OUTPUT"
+              echo "nextjs-client has package.json but no package-lock.json; npm cache and npm ci are disabled."
+            fi
           else
             echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "lockfile=false" >> "$GITHUB_OUTPUT"
             echo "nextjs-client is absent; skipping Node install/test/lint."
           fi
       - uses: actions/setup-node@v4
         if: steps.nextjs.outputs.present == 'true'
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-          cache-dependency-path: nextjs-client/package-lock.json
-      - name: Install dependencies
-        if: steps.nextjs.outputs.present == 'true'
+      - name: Install dependencies with lockfile
+        if: steps.nextjs.outputs.present == 'true' && steps.nextjs.outputs.lockfile == 'true'
         working-directory: nextjs-client
         run: npm ci
+      - name: Install dependencies without lockfile
+        if: steps.nextjs.outputs.present == 'true' && steps.nextjs.outputs.lockfile != 'true'
+        working-directory: nextjs-client
+        run: npm install --no-audit --no-fund
       - name: Run tests
         if: steps.nextjs.outputs.present == 'true'
         working-directory: nextjs-client

--- a/.github/workflows/gemini-issue-automated-triage.yml
+++ b/.github/workflows/gemini-issue-automated-triage.yml
@@ -72,6 +72,7 @@ jobs:
       - name: 'Run Gemini Issue Analysis'
         uses: 'google-github-actions/run-gemini-cli@v0'
         id: 'gemini_issue_analysis'
+        continue-on-error: true
         env:
           GITHUB_TOKEN: '' # Do not pass any auth token here since this runs on untrusted inputs
           ISSUE_TITLE: '${{ github.event.issue.title }}'
@@ -133,7 +134,7 @@ jobs:
 
       - name: 'Apply Labels to Issue'
         if: |-
-          ${{ steps.gemini_issue_analysis.outputs.summary != '' }}
+          ${{ steps.gemini_issue_analysis.outcome == 'success' && steps.gemini_issue_analysis.outputs.summary != '' }}
         env:
           REPOSITORY: '${{ github.repository }}'
           ISSUE_NUMBER: '${{ github.event.issue.number }}'
@@ -151,7 +152,7 @@ jobs:
               parsedLabels = JSON.parse(trimmedLabels);
               core.info(`Parsed labels JSON: ${JSON.stringify(parsedLabels)}`);
             } catch (err) {
-              core.setFailed(`Failed to parse labels JSON from Gemini output: ${err.message}\nRaw output: ${rawLabels}`);
+              core.warning(`Failed to parse labels JSON from Gemini output: ${err.message}. Leaving labels unchanged. Raw output: ${rawLabels}`);
               return;
             }
 
@@ -173,19 +174,13 @@ jobs:
               core.info(`No labels to set for #${issueNumber}, leaving as is${explanation}`);
             }
 
-      - name: 'Post Issue Analysis Failure Comment'
+      - name: 'Classify unavailable Gemini issue triage as advisory'
         if: |-
-          ${{ failure() && steps.gemini_issue_analysis.outcome == 'failure' }}
-        env:
-          ISSUE_NUMBER: '${{ github.event.issue.number }}'
-          RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
-        uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea'
-        with:
-          github-token: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
-          script: |-
-            github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: parseInt(process.env.ISSUE_NUMBER),
-              body: 'There is a problem with the Gemini CLI issue triaging. Please check the [action logs](${process.env.RUN_URL}) for details.'
-            })
+          ${{ steps.gemini_issue_analysis.outcome == 'failure' }}
+        run: |-
+          cat >> "${GITHUB_STEP_SUMMARY}" <<'EOF'
+          ## Gemini issue triage unavailable
+
+          The advisory Gemini issue triage failed before producing trustworthy labels. Labels were left unchanged. Quota, authentication, configuration, and tool failures are review-service events, not repository validation failures.
+          EOF
+          echo "::warning title=Gemini issue triage unavailable::Advisory triage failed before producing labels; labels left unchanged."

--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -155,6 +155,7 @@ jobs:
       - name: 'Run Gemini PR Review'
         uses: 'google-github-actions/run-gemini-cli@v0'
         id: 'gemini_pr_review'
+        continue-on-error: true
         env:
           GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
           GEMINI_CLI_TRUST_WORKSPACE: 'true'
@@ -456,16 +457,13 @@ jobs:
             Remember, you are running in a VM and no one reviewing your output. Your review must be posted to GitHub using the MCP tools to create a pending review, add comments to the pending review, and submit the pending review.
 
 
-      - name: 'Post PR review failure comment'
+      - name: 'Classify unavailable Gemini PR review as advisory'
         if: |-
-          ${{ failure() && steps.gemini_pr_review.outcome == 'failure' }}
-        uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea'
-        with:
-          github-token: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
-          script: |-
-            github.rest.issues.createComment({
-              owner: '${{ github.repository }}'.split('/')[0],
-              repo: '${{ github.repository }}'.split('/')[1],
-              issue_number: '${{ steps.get_pr.outputs.pr_number || steps.get_pr_comment.outputs.pr_number }}',
-              body: 'There is a problem with the Gemini CLI PR review. Please check the [action logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.'
-            })
+          ${{ steps.gemini_pr_review.outcome == 'failure' }}
+        run: |-
+          cat >> "${GITHUB_STEP_SUMMARY}" <<'EOF'
+          ## Gemini PR review unavailable
+
+          The advisory Gemini PR review failed before producing repository findings. This workflow treats Gemini outages, authentication failures, quota exhaustion, and tool failures as advisory review-service events, not as Python/Node/package validation failures. Blocking repository validation remains owned by the `CI` workflow.
+          EOF
+          echo "::warning title=Gemini PR review unavailable::Advisory review failed before producing repository findings; inspect logs for quota/auth/config/tool details."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,6 +224,8 @@ mypy .
 pytest -q
 ```
 
+The blocking pull-request/push baseline is documented in [`docs/CI_POLICY.md`](docs/CI_POLICY.md). That policy separates the fast stable Python regression suite, optional Node application profile, and advisory Gemini automation so documentation-only or narrowly-scoped numerical PRs are not forced to repay unrelated repository-wide debt.
+
 After package modernization, also require lock validation, `python -m build`, `twine check`, clean-wheel import tests and the Haircut backend conformance suite.
 
 Do not report an unconfigured or unrun gate as passing. Record the gap and owner issue.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -72,6 +72,7 @@ Cross-repository integration uses versioned wheels, contracts and parity fixture
 | CI and contributor guidance rely on repository-root state and `.gemini_project` | Non-durable architecture/task source and weak wheel confidence | GitHub/docs/tests authoritative; clean-wheel CI |
 | Next.js client shares repository without explicit product boundary | Frontend lifecycle can couple numerical release | Independent app lock/API contract and optional CI |
 | `tests/test_unified_pricing_engine.py` was excluded from blocking CI while known regressions existed | Green main could hide unified-engine time-orientation, payoff-broadcasting or incompatible-route debt | Reintroduced under #72 with explicit calendar-time semantics, multidimensional European payoff-broadcast tests and strict issue-linked xfail quarantine for #45/#62 |
+| CI and Gemini automation were ambiguous about blocking vs advisory failures | External review quota/auth/tool failures could masquerade as package or numerical failures | `docs/CI_POLICY.md` defines the blocking `CI` workflow, optional Node profile, and advisory Gemini failure classification under #69 |
 
 ## 4. Architectural principles
 

--- a/docs/CI_POLICY.md
+++ b/docs/CI_POLICY.md
@@ -1,0 +1,66 @@
+# CI policy
+
+Audit baseline: 2026-06-26
+Owning issue: [#69](https://github.com/googa27/finite_difference_options/issues/69)
+
+## Blocking signals
+
+The `CI` workflow is the blocking repository validation signal for pull requests and pushes.
+
+### Python job
+
+The Python job uses Python 3.12 and reports failures by command group:
+
+1. install dependencies from `requirements.txt` and `requirements-dev.txt`;
+2. static smoke gate:
+   - `python -m compileall -q src tests`;
+   - `ruff check . --select E9,F63,F7,F82`;
+3. architecture fitness gate:
+   - `pytest -q tests/architecture`;
+4. stable regression suite:
+   - boundary conditions;
+   - callable bond;
+   - finite-difference Greeks;
+   - Greeks;
+   - multidimensional adapter coefficients;
+   - option pricer/result/instrument tests;
+   - PDE pricer;
+   - plot API/backends;
+   - pricing-engine import smoke;
+   - unified pricing engine;
+   - unified processes.
+
+The stable suite is intentionally narrower than the whole repository. Known broader numerical, packaging, typing, performance, and application debt is tracked in GitHub issues and must not make unrelated documentation or architecture PRs permanently red.
+
+### Node job
+
+The Node job is a presence-gated application-profile smoke:
+
+- if `nextjs-client/package.json` is absent, the job records that the Next.js client is absent and skips install/test/lint;
+- if `nextjs-client/package-lock.json` is present, it uses `npm ci`;
+- if the package exists without a lockfile, it uses `npm install --no-audit --no-fund` and emits an explicit log message instead of passing a missing lock path to `actions/setup-node`.
+
+If the frontend becomes a maintained deliverable, a successor issue must add a committed lockfile, explicit `test` and `lint` scripts, and separate dependency/audit evidence. Until then, frontend checks are scoped to the optional application profile, not the numerical core package.
+
+## Advisory automated-review signals
+
+Gemini PR review, issue triage, and conversational CLI workflows are advisory automation. They may add useful feedback, but quota, authentication, configuration, external-service, or tool failures are classified as review-service events rather than repository-validation failures.
+
+The workflows therefore:
+
+- do not post generic failure comments for service failures;
+- leave labels unchanged when advisory issue triage cannot produce trustworthy JSON;
+- write a warning and step summary that the failure is advisory;
+- keep `CI` as the source of truth for blocking Python/Node/package validation.
+
+If Gemini returns concrete repository findings, those findings still require normal engineering treatment: reproduce, fix, test, and document the response in the PR.
+
+## Future hardening not closed by #69
+
+Issue #69 restores a trustworthy blocking baseline. It does not claim to finish all release hardening. Successor issues continue to own:
+
+- installable package/wheel testing outside the checkout;
+- minimum-supported versus latest-compatible numerical profiles;
+- full repository lint/type/test debt repayment;
+- action pinning, SBOM, audit, and benchmark profiles;
+- maintained frontend dependency and vulnerability policy if the frontend is promoted from optional example to deliverable.

--- a/docs/PROJECT_CONTEXT.md
+++ b/docs/PROJECT_CONTEXT.md
@@ -4,7 +4,7 @@
 - **Template Version**: 1.0
 - **Project Type**: Quantitative Finance Library
 - **AI Maintenance**: Enabled
-- **Last Updated**: 2025-08-22T14:00:00-04:00
+- **Last Updated**: 2026-06-26T18:41:56-04:00
 
 ## Project Overview
 Unified multi-dimensional PDE pricing framework for financial derivatives using finite difference methods. Supports both 1D and multi-dimensional stochastic processes with automatic solver selection and comprehensive validation.
@@ -79,8 +79,8 @@ Unified multi-dimensional PDE pricing framework for financial derivatives using 
 - **Optional**: plotly (enhanced plotting)
 
 ## Testing Strategy
-- Unit tests for all process implementations
-- Integration tests for complete pricing workflows
-- Validation against analytical Black-Scholes solutions
-- Performance benchmarks for large grids
-- Regression tests for API stability
+- Blocking GitHub `CI` is documented in `docs/CI_POLICY.md` and currently consists of Python static smoke, architecture fitness, stable regression tests, and a presence-gated optional Node application profile.
+- Unit tests for process implementations and pricing workflows remain the near-term correctness baseline.
+- Validation against analytical Black-Scholes solutions is preferred where applicable.
+- Performance benchmarks and clean-wheel/package profiles are successor hardening work, not implicit requirements of every narrow PR.
+- Regression tests cover API stability and the unified pricing engine's calendar-time orientation.

--- a/tests/architecture/test_ci_policy_contracts.py
+++ b/tests/architecture/test_ci_policy_contracts.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_blocking_ci_has_actionable_python_and_stable_suite_contract() -> None:
+    workflow = _read(".github/workflows/ci.yml")
+
+    assert "Static smoke gate" in workflow
+    assert "python -m compileall -q src tests" in workflow
+    assert "ruff check . --select E9,F63,F7,F82" in workflow
+    assert "Architecture fitness gate" in workflow
+    assert "pytest -q tests/architecture" in workflow
+    assert "Stable regression suite" in workflow
+    assert "tests/test_unified_pricing_engine.py" in workflow
+
+
+def test_node_profile_never_references_a_missing_lockfile_cache_path() -> None:
+    workflow = _read(".github/workflows/ci.yml")
+
+    assert "lockfile=true" in workflow
+    assert "Install dependencies with lockfile" in workflow
+    assert "Install dependencies without lockfile" in workflow
+    assert "cache-dependency-path: nextjs-client/package-lock.json" not in workflow
+
+
+def test_gemini_review_and_issue_triage_failures_are_advisory() -> None:
+    pr_review = _read(".github/workflows/gemini-pr-review.yml")
+    issue_triage = _read(".github/workflows/gemini-issue-automated-triage.yml")
+
+    assert "continue-on-error: true" in pr_review
+    assert "Classify unavailable Gemini PR review as advisory" in pr_review
+    assert "review-service events, not as Python/Node/package validation failures" in pr_review
+    assert "Post PR review failure comment" not in pr_review
+
+    assert "continue-on-error: true" in issue_triage
+    assert "Classify unavailable Gemini issue triage as advisory" in issue_triage
+    assert "labels left unchanged" in issue_triage
+    assert "Post Issue Analysis Failure Comment" not in issue_triage
+
+
+def test_ci_policy_is_documented_from_agent_contract_and_architecture() -> None:
+    policy = _read("docs/CI_POLICY.md")
+    agents = _read("AGENTS.md")
+    architecture = _read("docs/ARCHITECTURE.md")
+
+    assert "# CI policy" in policy
+    assert "Blocking signals" in policy
+    assert "Advisory automated-review signals" in policy
+    assert "docs/CI_POLICY.md" in agents
+    assert "docs/CI_POLICY.md" in architecture


### PR DESCRIPTION
## Summary
- Makes the blocking `CI` workflow the authoritative Python/Node validation signal and documents that policy in `docs/CI_POLICY.md`.
- Removes the Node cache dependency on a potentially absent `nextjs-client/package-lock.json`; frontend install now branches explicitly on lockfile presence.
- Makes Gemini PR review and issue triage advisory on quota/auth/config/tool failures instead of posting generic failure comments or failing repository validation.
- Adds architecture tests that pin the CI/advisory-review policy so the baseline cannot silently regress.

## Verification
- `PYTHONPATH=src .venv/bin/python -m pytest tests/architecture -q` -> 10 passed.
- `PYTHONPATH=src .venv/bin/python -m ruff check . --select E9,F63,F7,F82 --output-format=github` -> passed.
- `PYTHONPATH=src .venv/bin/python -m compileall -q src tests` -> passed.
- Stable regression suite from `.github/workflows/ci.yml` -> 100 passed, 1 xfailed, 14 warnings.
- `git diff --check` -> passed.
- YAML parse smoke for all `.github/workflows/*.yml` -> passed.

## Scope boundary
This closes the trustworthy blocking-baseline/advisory-automation portion of #69. Package wheel testing, min-vs-latest profiles, action pinning/SBOM/audit, and broader lint/type debt remain owned by successor issues #51 and #67.

Closes #69
