### PR TITLE
docs: expand public API docstrings

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,4 +1,8 @@
-"""FastAPI service for option pricing and Greek calculations."""
+"""FastAPI service for option pricing and reporting examples.
+
+Endpoints are intentionally minimal and are designed as reference API shapes for
+front-end integrations and smoke testing.
+"""
 
 from __future__ import annotations
 
@@ -31,7 +35,14 @@ app.add_middleware(
 
 
 class OptionRequest(BaseModel):
-    """Input parameters for option pricing."""
+    """Request payload for option pricing endpoints.
+
+    Units follow model conventions:
+
+    - rates in annual decimal units,
+    - maturities in years,
+    - ``s_steps`` and ``t_steps`` are integer grid resolutions.
+    """
 
     option_type: str = "Call"
     strike: float
@@ -44,7 +55,10 @@ class OptionRequest(BaseModel):
 
 
 class PriceResponse(BaseModel):
-    """Option price at the initial asset price."""
+    """Response containing dense price grid for a requested option.
+
+    The full surface is returned to simplify downstream plotting and debugging.
+    """
 
     s: list[float]
     t: list[float]
@@ -52,7 +66,7 @@ class PriceResponse(BaseModel):
 
 
 class GreeksResponse(BaseModel):
-    """Greeks at the initial asset price."""
+    """Scalar Greeks sampled at spot for backward-compatible API consumers."""
 
     delta: float
     gamma: float
@@ -60,7 +74,10 @@ class GreeksResponse(BaseModel):
 
 
 class FullPDEResponse(BaseModel):
-    """Full 2D grids for PDE solution and Greeks for visualization."""
+    """Full PDE grid and Greeks for visualisation.
+
+    All arrays are in nested list form to keep FastAPI/JSON serialization simple.
+    """
     
     s: list[float]
     t: list[float]
@@ -72,7 +89,10 @@ class FullPDEResponse(BaseModel):
 
 @app.post("/price", response_model=PriceResponse)
 def price(request: OptionRequest) -> PriceResponse:
-    """Return option price for the given parameters."""
+    """Return full PDE-generated value grid for the requested option.
+
+    The endpoint uses default grid settings when ``s_max`` is omitted.
+    """
     s_max = request.s_max or request.strike * 3
     model = GeometricBrownianMotion(mu=request.rate, sigma=request.sigma)
     option_cls = EuropeanCall if request.option_type == "Call" else EuropeanPut
@@ -92,7 +112,7 @@ def price(request: OptionRequest) -> PriceResponse:
 
 @app.post("/greeks", response_model=GreeksResponse)
 def greeks(request: OptionRequest) -> GreeksResponse:
-    """Return Delta, Gamma and Theta for the given parameters."""
+    """Return scalar Greeks at spot for the requested option contract."""
     s_max = request.s_max or request.strike * 3
     model = GeometricBrownianMotion(mu=request.rate, sigma=request.sigma)
     option_cls = EuropeanCall if request.option_type == "Call" else EuropeanPut
@@ -114,10 +134,9 @@ def greeks(request: OptionRequest) -> GreeksResponse:
 
 @app.post("/pde_solution", response_model=FullPDEResponse)
 def pde_solution(request: OptionRequest) -> FullPDEResponse:
-    """Return full 2D grids for PDE solution and Greeks for visualization.
-    
-    Returns the complete solution grids that enable frontend plotting
-    of option prices and Greeks over time and asset price dimensions.
+    """Return complete solution and Greeks grids.
+
+    This is the most visualization-friendly API endpoint for frontend charts.
     """
     s_max = request.s_max or request.strike * 3
     model = GeometricBrownianMotion(mu=request.rate, sigma=request.sigma)
@@ -141,7 +160,7 @@ def pde_solution(request: OptionRequest) -> FullPDEResponse:
 
 
 class TradeModel(BaseModel):
-    """Trade description used in regulatory reports."""
+    """Trade description used by the lightweight reporting endpoints."""
 
     trade_id: str
     product_type: str
@@ -151,7 +170,7 @@ class TradeModel(BaseModel):
 
 
 class RiskFactorModel(BaseModel):
-    """Risk factor affecting trades."""
+    """Single risk factor used to drive report exposures."""
 
     name: str
     value: float
@@ -159,7 +178,7 @@ class RiskFactorModel(BaseModel):
 
 
 class ExposureModel(BaseModel):
-    """Exposure of a trade to a risk factor."""
+    """Association of a trade and risk factor with an exposure amount."""
 
     trade: TradeModel
     risk_factor: RiskFactorModel
@@ -167,19 +186,19 @@ class ExposureModel(BaseModel):
 
 
 class CRIFResponse(BaseModel):
-    """CSV output representing the CRIF report."""
+    """String payload for CRIF report output."""
 
     crif: str
 
 
 class PlaceholderResponse(BaseModel):
-    """Generic placeholder response."""
+    """Generic response wrapper for non-production reporting stubs."""
 
     status: str
 
 
 def _convert_exposures(models: list[ExposureModel]) -> list[Exposure]:
-    """Convert API models to dataclass exposures."""
+    """Convert API request payloads into internal report domain objects."""
 
     return [
         Exposure(
@@ -193,7 +212,11 @@ def _convert_exposures(models: list[ExposureModel]) -> list[Exposure]:
 
 @app.post("/reports/crif", response_model=CRIFResponse)
 def crif_report(exposures: list[ExposureModel]) -> CRIFResponse:
-    """Generate a CRIF report for the provided exposures."""
+    """Generate a CRIF report for the provided exposures.
+
+    Inputs are converted from API models to internal domain objects before
+    invoking the configured report strategy.
+    """
 
     strategy = ReportFactory.get_strategy("crif")
     crif = strategy.generate_report(_convert_exposures(exposures))
@@ -202,7 +225,7 @@ def crif_report(exposures: list[ExposureModel]) -> CRIFResponse:
 
 @app.post("/reports/cuso", response_model=PlaceholderResponse)
 def cuso_report(exposures: list[ExposureModel]) -> PlaceholderResponse:
-    """Placeholder CUSO report endpoint."""
+    """Return placeholder CUSO report from the active strategy adapter."""
 
     strategy = ReportFactory.get_strategy("cuso")
     data = strategy.generate_report(_convert_exposures(exposures))
@@ -211,7 +234,7 @@ def cuso_report(exposures: list[ExposureModel]) -> PlaceholderResponse:
 
 @app.post("/reports/basel", response_model=PlaceholderResponse)
 def basel_report(exposures: list[ExposureModel]) -> PlaceholderResponse:
-    """Placeholder Basel report endpoint."""
+    """Return placeholder Basel report from the active strategy adapter."""
 
     strategy = ReportFactory.get_strategy("basel")
     data = strategy.generate_report(_convert_exposures(exposures))

--- a/cli/main.py
+++ b/cli/main.py
@@ -1,4 +1,9 @@
-"""Typer-based command line interface for option pricing and plotting."""
+"""Typer-based command line interface for option pricing and plotting.
+
+The CLI is intentionally small and primarily serves smoke-test and manual
+exploration workflows. It wires together process construction, pricer execution,
+optionally computes Greeks, and can render heatmap/surface plots.
+"""
 from __future__ import annotations
 
 from pathlib import Path
@@ -29,7 +34,15 @@ def price(
     t_steps: int = typer.Option(100, help="Number of time steps."),
     greeks: bool = typer.Option(False, help="Also compute Delta, Gamma and Theta."),
 ) -> None:
-    """Compute option price at ``s0`` and optionally Greeks."""
+    """Compute Black--Scholes option price (and optional Greeks) on an asset grid.
+
+    The command prints the interpolated spot price at ``s0``.
+
+    Notes
+    -----
+    Greeks, when requested, are extracted from the model grid result using the
+    same index as the price output.
+    """
     model = GeometricBrownianMotion(mu=rate, sigma=sigma)
     option_cls = EuropeanCall if option_type == "Call" else EuropeanPut
     instrument = option_cls(strike=strike, maturity=maturity, model=model)
@@ -67,7 +80,11 @@ def plot(
     output: Optional[Path] = typer.Option(  # noqa: B008
         None, help="Optional path to save the plot."),
 ) -> None:
-    """Render option value grid as a heatmap or surface plot."""
+    """Render option value grid as heatmap or 3D surface.
+
+    Output target: if ``--output`` is given, saves image to the path and returns
+    without interactive display.
+    """
     model = GeometricBrownianMotion(mu=rate, sigma=sigma)
     option_cls = EuropeanCall if option_type == "Call" else EuropeanPut
     instrument = option_cls(strike=strike, maturity=maturity, model=model)

--- a/src/boundary_conditions/builder.py
+++ b/src/boundary_conditions/builder.py
@@ -1,8 +1,11 @@
 """Utilities for constructing boundary conditions.
 
 This module provides helpers to build boundary conditions for the
-Black--Scholes PDE solver.  The implementation lives in its own module to
-respect the single responsibility principle.
+Black--Scholes PDE solver.  The implementation is separated from core
+solver code to keep BC policy explicit and testable.
+
+These builders currently cover univariate spatial boundaries only and are not a
+full taxonomy of generic multidimensional boundary strategies.
 """
 from __future__ import annotations
 
@@ -19,13 +22,15 @@ if TYPE_CHECKING:
 
 @dataclass
 class BlackScholesBoundaryBuilder:
-    """Factory for boundary conditions in the Black--Scholes model.
+    """Build boundary conditions for standard univariate Black--Scholes grids.
 
-    The builder creates first- or second-order boundary conditions depending
-    on the option type:
+    The convention used is:
 
-    * Left boundary: gamma equals zero.
-    * Right boundary: delta tends to +1 for calls and 0 for puts.
+    * Left boundary (``s=0``): second derivative (gamma) set to zero.
+    * Right boundary: first derivative (delta) equals 1 for calls, 0 for puts.
+
+    Unknown option contract types are defaulted to second-derivative zero at the
+    right boundary (Neumann-like fallback).
     """
 
     def build(
@@ -41,6 +46,11 @@ class BlackScholesBoundaryBuilder:
             Spatial grid for the underlying asset price.
         option:
             Option contract whose payoff determines the boundary behaviour.
+
+        Returns
+        -------
+        BoundaryConditions
+            Findiff boundary-condition container configured for the chosen option.
         """
         ds = s[1] - s[0]
         bc = BoundaryConditions(s.shape)

--- a/src/greeks/base.py
+++ b/src/greeks/base.py
@@ -1,7 +1,8 @@
 """Greeks calculator interface for PDE pricing.
 
-This module defines the abstract interface for Greeks calculators
-in the unified pricing framework.
+The module exposes a small strategy surface that maps a computed price surface
+into first-order and second-order sensitivities (Delta/Gamma/Theta/Vega, where
+supported).
 """
 from __future__ import annotations
 
@@ -16,7 +17,7 @@ from src.exceptions import ValidationError
 
 
 class GreeksCalculator(ABC):
-    """Abstract base class for computing option Greeks."""
+    """Abstract base class for computing option Greeks from price grids."""
 
     def calculate(
         self,
@@ -62,7 +63,11 @@ class GreeksCalculator(ABC):
 
 
 class FDCalculator1D(GreeksCalculator):
-    """Finite difference Greeks calculator for 1D processes."""
+    """Finite-difference Greeks calculator for one-dimensional processes.
+
+    Returns spatial Greeks with shape ``(n_s,)`` for Delta/Gamma and
+    ``(n_t, n_s)`` for Theta.
+    """
 
     def __init__(self) -> None:
         """Initialize calculator."""
@@ -123,7 +128,11 @@ class FDCalculator1D(GreeksCalculator):
 
 
 class FDCalculator2D(GreeksCalculator):
-    """Finite difference Greeks calculator for 2D processes."""
+    """Finite-difference Greeks calculator for two-dimensional processes.
+
+    The implementation returns Delta/Gamma/Vega as first-time-step spatial
+    slices (``(n_x, n_y)``) and Theta on the full time grid.
+    """
 
     def __init__(self) -> None:
         """Initialize calculator."""

--- a/src/greeks/finite_difference.py
+++ b/src/greeks/finite_difference.py
@@ -9,12 +9,15 @@ from .base import GreeksCalculator
 
 
 class FiniteDifferenceGreeks(GreeksCalculator):
-    """Compute option Greeks using finite difference approximations.
+    """Compute option Greeks using finite-difference approximations.
 
-    The price grid is assumed to have shape ``(len(t), len(s))`` where the first
-    axis represents time to maturity and the second axis the underlying asset
-    price.  Central differences are used in the interior of the grid and
-    one–sided second order approximations are applied at the boundaries.
+    The price grid is assumed to have shape ``(n_t, n_s[, n_v])`` where axis 0 is
+    time and the remaining axes are spatial dimensions.
+
+    Notes
+    -----
+    These methods are intentionally generic; they do not assume a specific
+    diffusion model and therefore operate purely on the provided numeric grids.
     """
 
     def _validate_price_grid(self, grid: NDArray[np.float64]) -> None:

--- a/src/pricing/engines/unified.py
+++ b/src/pricing/engines/unified.py
@@ -1,12 +1,22 @@
 """Unified pricing engine for multi-dimensional option pricing.
 
-This module provides a unified framework for pricing options using various
-stochastic processes through a dimension-agnostic interface.
+The unified engine handles one- to three-dimensional processes via a single
+interface and normalises time/space input before dispatching to the selected
+solver.
+
+Current production guidance
+--------------------------
+
+- Univariate problems route to the finite-difference adapter.
+- Multi-dimensional problems route to ADI implementations where available.
+- Solver output is in calendar-time order where index 0 is valuation time.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional, Dict, Any
+from typing import Optional, Dict
+
 import numpy as np
 from numpy.typing import NDArray
 
@@ -19,94 +29,142 @@ from ...solvers.base import Solver, SolverFactory
 @dataclass
 class UnifiedPricingEngine:
     """Unified pricing engine for multi-dimensional processes.
-    
-    This engine automatically selects appropriate solvers based on
-    the process dimension and provides a consistent interface for
-    pricing various financial instruments.
-    
+
+    The engine performs lightweight input normalisation and delegates numerical
+    work to a concrete solver from :mod:`src.solvers.base`.
+
+    Notes
+    -----
+    The returned price arrays are in calendar-time order:
+
+    - index 0: valuation time (time 0)
+    - index -1: maturity/terminal time
+
+    Use ``create_unified_pricing_engine`` to obtain a default engine configured
+    with the auto-selected solver.
+
     Parameters
     ----------
     process : StochasticProcess
         Stochastic process for the underlying asset(s).
-    solver : Optional
-        PDE solver (auto-selected if None).
+    solver : Optional[Solver]
+        PDE solver to use (defaults to auto-selection by process dimension).
     """
-    
+
     process: StochasticProcess
     solver: Optional[Solver] = None
-    
+
     def __post_init__(self) -> None:
-        """Initialize pricing engine."""
+        """Initialise engine and auto-select the solver if missing."""
         if self.solver is None:
             self.solver = SolverFactory.create_solver(self.process)
-    
+
     def price_option(
         self,
         instrument: UnifiedInstrument,
         *grids: NDArray[np.float64],
         time_grid: Optional[NDArray[np.float64]] = None,
     ) -> NDArray[np.float64]:
-        """Price option using unified framework.
-        
+        """Price an option via the configured solver.
+
+        Examples
+        --------
+        Price a Black--Scholes call with a default grid:
+
+        >>> from src.processes.affine import create_black_scholes_process
+        >>> from src.pricing.engines.unified import (
+        ...     create_unified_pricing_engine,
+        ...     create_log_grid,
+        ... )
+        >>> from src.pricing.instruments.options import create_unified_european_call
+        >>> process = create_black_scholes_process(mu=0.03, sigma=0.2)
+        >>> engine = create_unified_pricing_engine(process)
+        >>> option = create_unified_european_call(strike=100.0, maturity=1.0)
+        >>> grid = create_log_grid(20.0, 200.0, 51)
+        >>> times = np.linspace(0, 1.0, 8)
+        >>> value_slice = engine.price_option(option, grid, time_grid=times)[-1]
+
         Parameters
         ----------
         instrument : UnifiedInstrument
-            Financial instrument to price.
+            Option contract to price.
         *grids : NDArray[np.float64]
-            Spatial grids for each dimension.
+            One spatial grid per process dimension.
         time_grid : NDArray[np.float64], optional
-            Time grid for evolution.
-            
+            Monotone calendar-time grid on ``[0, maturity]``.
+
         Returns
         -------
         NDArray[np.float64]
-            Option prices on the spatial grid.
+            Prices on all time slices (calendar-time order).
         """
         if len(grids) == 0:
             raise ValidationError("At least one spatial grid required")
 
         time_grid = self._normalise_time_grid(time_grid, instrument.maturity)
-        
-        # Validate grid dimensions match process dimension
+
         if len(grids) != self.process.dimension.value:
             raise ValidationError(
                 f"Expected {self.process.dimension.value} grids, got {len(grids)}"
             )
-        
-        # Get initial condition (payoff at maturity)
-        # For multi-dimensional case, we need to create a meshgrid
+
         if len(grids) == 1:
             initial_condition = instrument.payoff(grids[0])
         else:
-            mesh_grids = np.meshgrid(*grids, indexing='ij')
-            # Flatten the meshgrid to pass to payoff function
+            mesh_grids = np.meshgrid(*grids, indexing="ij")
             flattened_grids = [grid.flatten() for grid in mesh_grids]
-            # Reshape back to grid shape
             grid_shape = mesh_grids[0].shape
             initial_condition = instrument.payoff(*flattened_grids).reshape(grid_shape)
-        
-        # Solve PDE using the abstract solver interface
+
         solution = self.solver.solve(
             initial_condition,
             instrument,
             *grids,
-            time_grid=time_grid
+            time_grid=time_grid,
         )
-        
+
         return solution
+
+    def compute_greeks(
+        self,
+        prices: NDArray[np.float64],
+        *grids: NDArray[np.float64],
+        time_grid: Optional[NDArray[np.float64]] = None,
+    ) -> Dict[str, NDArray[np.float64]]:
+        """Compute option Greeks from a precomputed price surface.
+
+        Parameters
+        ----------
+        prices : NDArray[np.float64]
+            Option prices on the corresponding spatial/time grid.
+        *grids : NDArray[np.float64]
+            Spatial grids used for pricing.
+        time_grid : NDArray[np.float64], optional
+            Calendar-time grid. If omitted, defaults to the default solver grid.
+
+        Returns
+        -------
+        Dict[str, NDArray[np.float64]]
+            Mapping with common Greeks ``delta``, ``gamma``, ``theta`` etc.
+        """
+        from ...greeks.base import GreeksCalculatorFactory
+
+        calculator = GreeksCalculatorFactory.create_calculator(self.process)
+        return calculator.calculate(prices, *grids, time_grid=time_grid)
 
     @staticmethod
     def _normalise_time_grid(
         time_grid: Optional[NDArray[np.float64]],
         maturity: float,
     ) -> NDArray[np.float64]:
-        """Return a governed increasing calendar-time grid over ``[0, maturity]``.
+        """Normalise an optional user-supplied time grid.
 
-        Public unified-engine solutions are in calendar-time order: index 0 is
-        valuation time and index -1 is maturity/terminal payoff. Solver
-        adapters may internally use forward time-to-maturity, but the engine
-        passes an explicit validated grid so default handling is not hidden in
-        adapter-specific branches.
+        The helper enforces
+
+        - one-dimensional input,
+        - finite values,
+        - strict monotonicity,
+        - boundaries ``0`` and ``maturity``.
         """
         if time_grid is None or len(time_grid) == 0:
             return np.linspace(0.0, maturity, 50)
@@ -125,66 +183,44 @@ class UnifiedPricingEngine:
         ):
             raise ValidationError("time_grid must span [0, maturity]")
         return normalised
-    
-    def compute_greeks(
-        self,
-        prices: NDArray[np.float64],
-        *grids: NDArray[np.float64],
-        time_grid: Optional[NDArray[np.float64]] = None,
-    ) -> Dict[str, NDArray[np.float64]]:
-        """Compute option Greeks using finite differences.
-        
-        Parameters
-        ----------
-        prices : NDArray[np.float64]
-            Option prices on the grid.
-        *grids : NDArray[np.float64]
-            Spatial grids.
-        time_grid : NDArray[np.float64], optional
-            Time grid.
-            
-        Returns
-        -------
-        Dict[str, NDArray[np.float64]]
-            Dictionary of Greeks.
-        """
-        from ...greeks.base import GreeksCalculatorFactory
-        
-        # Create appropriate Greeks calculator
-        calculator = GreeksCalculatorFactory.create_calculator(self.process)
-        
-        # Calculate Greeks
-        greeks = calculator.calculate(prices, *grids, time_grid=time_grid)
-        
-        return greeks
 
 
 # Convenience functions
+
 def create_unified_pricing_engine(process: StochasticProcess) -> UnifiedPricingEngine:
-    """Create unified pricing engine with auto-selected solver."""
+    """Create a unified pricing engine with auto-selected solver."""
+
     return UnifiedPricingEngine(process=process)
 
 
-# Grid utility functions
-def create_log_grid(s_min: float, s_max: float, n_points: int, center: Optional[float] = None) -> NDArray[np.float64]:
-    """Create logarithmically spaced grid.
-    
+def create_log_grid(
+    s_min: float, s_max: float, n_points: int, center: Optional[float] = None
+) -> NDArray[np.float64]:
+    """Create a logarithmically spaced positive grid.
+
     Parameters
     ----------
     s_min : float
-        Minimum value of the grid.
+        Lower grid bound, must be positive.
     s_max : float
-        Maximum value of the grid.
+        Upper grid bound, greater than ``s_min``.
     n_points : int
-        Number of points in the grid.
+        Number of grid points.
     center : float, optional
-        Center point for the grid. If provided, the grid will be centered around this point.
-        
+        Optional central point inserted at the midpoint index.
+
     Returns
     -------
     NDArray[np.float64]
-        Logarithmically spaced grid.
+        Monotone log-spaced grid.
     """
+    if s_min <= 0:
+        raise ValidationError("s_min must be positive")
+    if s_max <= s_min:
+        raise ValidationError("s_max must be greater than s_min")
+    if n_points < 2:
+        raise ValidationError("n_points must be at least 2")
+
     if center is None:
         log_min = np.log(s_min)
         log_max = np.log(s_max)
@@ -194,10 +230,6 @@ def create_log_grid(s_min: float, s_max: float, n_points: int, center: Optional[
         if not s_min < center < s_max:
             raise ValidationError("center must lie strictly between s_min and s_max")
 
-        # Put the requested center at the middle node without ever extending
-        # past the supplied bounds.  A post-hoc endpoint clamp can make the
-        # last interval negative for asymmetric bounds such as [50, 150] around
-        # center=100, corrupting finite-difference stencils downstream.
         center_idx = n_points // 2
         left = np.exp(np.linspace(np.log(s_min), np.log(center), center_idx + 1))
         right = np.exp(np.linspace(np.log(center), np.log(s_max), n_points - center_idx))
@@ -209,5 +241,24 @@ def create_log_grid(s_min: float, s_max: float, n_points: int, center: Optional[
 
 
 def create_linear_grid(x_min: float, x_max: float, n_points: int) -> NDArray[np.float64]:
-    """Create linearly spaced grid."""
+    """Create a linearly spaced grid.
+
+    Parameters
+    ----------
+    x_min : float
+        Lower bound.
+    x_max : float
+        Upper bound.
+    n_points : int
+        Number of points.
+
+    Returns
+    -------
+    NDArray[np.float64]
+        Uniformly spaced values between ``x_min`` and ``x_max``.
+    """
+    if n_points < 2:
+        raise ValidationError("n_points must be at least 2")
+    if x_max <= x_min:
+        raise ValidationError("x_max must be greater than x_min")
     return np.linspace(x_min, x_max, n_points)

--- a/src/pricing/instruments/options.py
+++ b/src/pricing/instruments/options.py
@@ -1,14 +1,16 @@
-"""Option instruments implementation.
+"""Option instruments for the unified pricing framework.
 
-This module contains implementations of various option types
-for the unified pricing framework.
+The module exposes dataclass-style option objects compatible with the unified
+engine and small helpers for constructing common products.
 """
+
 from __future__ import annotations
+
+from typing import Any
 
 import numpy as np
 from numpy.typing import NDArray
-from pydantic import BaseModel, Field, field_validator, ConfigDict
-from typing import Any
+from pydantic import BaseModel, ConfigDict, field_validator
 
 from .base import UnifiedInstrument
 from .payoff_calculators import PayoffCalculatorFactory
@@ -18,123 +20,175 @@ from src.exceptions import ValidationError
 
 
 class UnifiedEuropeanOption(UnifiedInstrument, BaseModel):
-    """European option for unified pricing framework."""
-    
+    """Plain-vanilla European option.
+
+    Parameters
+    ----------
+    strike : float
+        Strike level, must be strictly positive.
+    maturity : float
+        Time to maturity in year fraction.
+    option_type : str
+        Either ``"call"`` or ``"put"``.
+
+    See Also
+    --------
+    create_unified_european_call : convenience constructor for call options.
+    create_unified_european_put : convenience constructor for put options.
+    """
+
     strike: float
     maturity: float
-    option_type: str = 'call'  # Default to 'call'
-    
-    model_config = ConfigDict(frozen=True, extra='forbid')
-    
-    @field_validator('strike')
+    option_type: str = "call"  # Default to 'call'
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    @field_validator("strike")
     @classmethod
-    def validate_strike(cls, v):
-        """Validate strike price."""
+    def validate_strike(cls, v: float) -> float:
+        """Validate strike price and require strictly positive values."""
         validate_positive(v, "strike")
         return v
-    
-    @field_validator('maturity')
+
+    @field_validator("maturity")
     @classmethod
-    def validate_maturity(cls, v):
-        """Validate maturity."""
+    def validate_maturity(cls, v: float) -> float:
+        """Validate maturity is strictly positive."""
         validate_positive(v, "maturity")
         return v
-    
-    @field_validator('option_type')
+
+    @field_validator("option_type")
     @classmethod
-    def validate_option_type(cls, v):
-        """Validate option type."""
-        if v not in ['call', 'put']:
+    def validate_option_type(cls, v: str) -> str:
+        """Validate option type and normalise invalid values."""
+        if v not in ["call", "put"]:
             raise ValidationError(f"option_type must be 'call' or 'put', got {v}")
         return v
-    
+
     def payoff(self, *grids: NDArray[np.float64]) -> NDArray[np.float64]:
-        """Compute European option payoff."""
+        """Compute European payoff for one or more spot grids.
+
+        The call/put payoff is evaluated at the terminal grid via
+        :class:`PayoffCalculatorFactory`.
+        """
         calculator = PayoffCalculatorFactory.create_calculator(self)
         return calculator.calculate_payoff(self, *grids)
 
 
 class UnifiedBasketOption(UnifiedInstrument, BaseModel):
-    """Basket option for unified pricing framework."""
-    
+    """Basket option payoff on a weighted combination of underlying states.
+
+    Parameters
+    ----------
+    strikes : array-like
+        Per-asset strike values.
+    weights : array-like
+        Portfolio weights (must sum to one).
+    maturity : float
+        Time to maturity.
+    option_type : str
+        Either ``"call"`` or ``"put"``.
+    """
+
     strikes: Any  # Using Any to avoid Pydantic issues with NDArray
     weights: Any  # Using Any to avoid Pydantic issues with NDArray
     maturity: float
-    option_type: str = 'call'  # Default to 'call'
-    
-    model_config = ConfigDict(frozen=True, extra='forbid', arbitrary_types_allowed=True)
-    
-    @field_validator('maturity')
+    option_type: str = "call"  # Default to 'call'
+
+    model_config = ConfigDict(frozen=True, extra="forbid", arbitrary_types_allowed=True)
+
+    @field_validator("maturity")
     @classmethod
-    def validate_maturity(cls, v):
-        """Validate maturity."""
+    def validate_maturity(cls, v: float) -> float:
+        """Validate maturity is strictly positive."""
         validate_positive(v, "maturity")
         return v
-    
-    @field_validator('strikes')
+
+    @field_validator("strikes")
     @classmethod
-    def validate_strikes(cls, v):
-        """Validate strikes."""
+    def validate_strikes(cls, v: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Validate all strikes are strictly positive."""
         v = np.asarray(v, dtype=np.float64)
         if not np.all(v > 0):
             raise ValidationError("All strikes must be positive")
         return v
-    
-    @field_validator('weights')
+
+    @field_validator("weights")
     @classmethod
-    def validate_weights(cls, v):
-        """Validate weights."""
-        v = np.asarray(v, dtype=np.float64)
-        return v
-    
-    @field_validator('option_type')
+    def validate_weights(cls, v: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Convert weights to ndarray (additional checks done in ``__init__``)."""
+        return np.asarray(v, dtype=np.float64)
+
+    @field_validator("option_type")
     @classmethod
-    def validate_option_type(cls, v):
+    def validate_option_type(cls, v: str) -> str:
         """Validate option type."""
-        if v not in ['call', 'put']:
+        if v not in ["call", "put"]:
             raise ValidationError(f"option_type must be 'call' or 'put', got {v}")
         return v
-    
+
     def __init__(self, **data):
-        """Initialize and validate basket option parameters."""
+        """Initialise and perform cross-field checks.
+
+        Raises
+        ------
+        ValidationError
+            If strike/weight dimensions mismatch or weights do not sum to one.
+        """
         super().__init__(**data)
-        
-        # Additional validation that requires multiple fields
+
         if len(self.strikes) != len(self.weights):
             raise ValidationError("strikes and weights must have same length")
-        
+
         validate_weights_sum_to_one(self.weights)
-    
+
     def payoff(self, *grids: NDArray[np.float64]) -> NDArray[np.float64]:
-        """Compute basket option payoff."""
+        """Compute basket payoff from the supplied state grid(s)."""
         calculator = PayoffCalculatorFactory.create_calculator(self)
         return calculator.calculate_payoff(self, *grids)
 
 
 # Convenience functions
-def create_unified_european_call(strike: float, maturity: float) -> UnifiedEuropeanOption:
-    """Create European call option."""
-    return UnifiedEuropeanOption(strike=strike, maturity=maturity, option_type='call')
+
+def create_unified_european_call(
+    strike: float,
+    maturity: float,
+) -> UnifiedEuropeanOption:
+    """Create a plain-vanilla European call."""
+    return UnifiedEuropeanOption(strike=strike, maturity=maturity, option_type="call")
 
 
-def create_unified_european_put(strike: float, maturity: float) -> UnifiedEuropeanOption:
-    """Create European put option."""
-    return UnifiedEuropeanOption(strike=strike, maturity=maturity, option_type='put')
+def create_unified_european_put(
+    strike: float,
+    maturity: float,
+) -> UnifiedEuropeanOption:
+    """Create a plain-vanilla European put."""
+    return UnifiedEuropeanOption(strike=strike, maturity=maturity, option_type="put")
 
 
 def create_unified_basket_call(
-    strikes: NDArray[np.float64], 
-    weights: NDArray[np.float64], 
-    maturity: float
+    strikes: NDArray[np.float64],
+    weights: NDArray[np.float64],
+    maturity: float,
 ) -> UnifiedBasketOption:
-    """Create basket call option."""
-    return UnifiedBasketOption(strikes=strikes, weights=weights, maturity=maturity, option_type='call')
+    """Create a basket call with explicit per-asset strikes/weights."""
+    return UnifiedBasketOption(
+        strikes=strikes,
+        weights=weights,
+        maturity=maturity,
+        option_type="call",
+    )
 
 
 def create_unified_basket_put(
-    strikes: NDArray[np.float64], 
-    weights: NDArray[np.float64], 
-    maturity: float
+    strikes: NDArray[np.float64],
+    weights: NDArray[np.float64],
+    maturity: float,
 ) -> UnifiedBasketOption:
-    """Create basket put option."""
-    return UnifiedBasketOption(strikes=strikes, weights=weights, maturity=maturity, option_type='put')
+    """Create a basket put with explicit per-asset strikes/weights."""
+    return UnifiedBasketOption(
+        strikes=strikes,
+        weights=weights,
+        maturity=maturity,
+        option_type="put",
+    )

--- a/src/processes/affine.py
+++ b/src/processes/affine.py
@@ -1,7 +1,14 @@
-"""Affine stochastic processes implementation.
+"""Affine stochastic process models.
 
-This module contains implementations of common affine stochastic processes
-used in quantitative finance, utilizing the new validation utilities.
+The classes and helpers in this module define common affine SDE models used by
+pricing solvers.  All models expose dimensioned drift and covariance terms that
+are compatible with the finite-difference operator builders.
+
+Each model follows the ``StochasticProcess`` contract:
+
+- ``drift`` and ``covariance`` use the shared calendar-time convention
+- state is ``(d,)`` for a single point or ``(n, d)`` for a batch
+- validated parameters are stored immutably (Pydantic ``frozen`` models)
 """
 from __future__ import annotations
 
@@ -22,16 +29,24 @@ from ..utils.state_handling import validate_positive_state_components
 
 
 class GeometricBrownianMotion(AffineProcess, BaseModel):
-    """Geometric Brownian Motion process.
-    
-    dS = μS dt + σS dW
-    
-    Parameters
-    ----------
-    mu : float
-        Drift parameter.
-    sigma : float
-        Volatility parameter.
+    r"""Geometric Brownian Motion:
+
+    .. math::
+
+       dS_t = \mu S_t dt + \sigma S_t dW_t
+
+    Notes
+    -----
+    This is the Black--Scholes process used for vanilla equity dynamics.
+
+    Examples
+    --------
+    >>> from src.processes.affine import GeometricBrownianMotion
+    >>> gbm = GeometricBrownianMotion(mu=0.03, sigma=0.2)
+    >>> gbm.dimension.value
+    1
+    >>> gbm.drift(0.0, [100.0]).shape
+    (1,)
     """
     
     mu: float
@@ -71,18 +86,15 @@ class GeometricBrownianMotion(AffineProcess, BaseModel):
 
 
 class OrnsteinUhlenbeck(AffineProcess, BaseModel):
-    """Ornstein-Uhlenbeck process.
-    
-    dr = κ(θ - r) dt + σ dW
-    
-    Parameters
-    ----------
-    kappa : float
-        Mean reversion speed.
-    theta : float
-        Long-term mean.
-    sigma : float
-        Volatility parameter.
+    r"""Ornstein--Uhlenbeck (Vasicek) process.
+
+    .. math::
+
+       dr_t = \kappa(\theta - r_t)dt + \sigma dW_t
+
+    Notes
+    -----
+    The state is interpreted as short rate in calendar time.
     """
     
     kappa: float
@@ -129,18 +141,14 @@ class OrnsteinUhlenbeck(AffineProcess, BaseModel):
 
 
 class CoxIngersollRoss(AffineProcess, BaseModel):
-    """Cox-Ingersoll-Ross process.
-    
-    dr = κ(θ - r) dt + σ√r dW
-    
-    Parameters
-    ----------
-    kappa : float
-        Mean reversion speed.
-    theta : float
-        Long-term mean.
-    sigma : float
-        Volatility parameter.
+    r"""Cox--Ingersoll--Ross (CIR) short-rate model.
+
+    .. math::
+
+       dr_t = \kappa(\theta-r_t)dt + \sigma\sqrt{r_t} dW_t
+
+    The Feller condition is validated at construction time to avoid negative
+    variance under idealized analytical assumptions.
     """
     
     kappa: float
@@ -203,27 +211,21 @@ class CoxIngersollRoss(AffineProcess, BaseModel):
 
 
 class HestonModel(AffineProcess, BaseModel):
-    """Heston stochastic volatility model.
-    
-    dS = rS dt + √V S dW₁
-    dV = κ(θ - V) dt + σ√V dW₂
-    
-    with correlation ρ between W₁ and W₂.
-    
-    Parameters
-    ----------
-    risk_free_rate : float
-        Risk-free interest rate.
-    kappa : float
-        Mean reversion speed of variance.
-    theta : float
-        Long-term variance.
-    sigma : float
-        Volatility of volatility.
-    rho : float
-        Correlation between asset and variance.
-    dividend_yield : float, optional
-        Dividend yield.
+    r"""Two-factor Heston stochastic-volatility model.
+
+    Equations
+    ---------
+
+    .. math::
+
+       dS_t = (r - q)S_t dt + \sqrt{v_t} S_t dW_t^{(1)}
+       dv_t = \kappa(\theta-v_t)dt + \sigma\sqrt{v_t} dW_t^{(2)}
+       dW_t^{(1)} dW_t^{(2)} = \rho dt
+
+    Notes
+    -----
+    The state vector is ``(S, v)`` and both coordinates are validated for
+    non-negativity where applicable.
     """
     
     risk_free_rate: float
@@ -300,17 +302,38 @@ class HestonModel(AffineProcess, BaseModel):
 
 # Convenience functions for creating common processes
 def create_black_scholes_process(mu: float, sigma: float) -> GeometricBrownianMotion:
-    """Create Black-Scholes (GBM) process."""
+    """Create a one-factor Black--Scholes process.
+
+    Parameters
+    ----------
+    mu : float
+        Drift under pricing measure.
+    sigma : float
+        Spot volatility.
+
+    Returns
+    -------
+    GeometricBrownianMotion
+        Configured process instance.
+    """
     return GeometricBrownianMotion(mu=mu, sigma=sigma)
 
 
 def create_vasicek_process(kappa: float, theta: float, sigma: float) -> OrnsteinUhlenbeck:
-    """Create Vasicek (OU) process."""
+    """Create a Vasicek short-rate process.
+
+    This is the canonical one-factor affine short-rate configuration used for
+    simple fixed-income sanity checks.
+    """
     return OrnsteinUhlenbeck(kappa=kappa, theta=theta, sigma=sigma)
 
 
 def create_cir_process(kappa: float, theta: float, sigma: float) -> CoxIngersollRoss:
-    """Create CIR process."""
+    """Create a CIR short-rate process.
+
+    Parameters are validated against the Feller condition; the caller receives an
+    exception early if positivity constraints are not satisfied.
+    """
     return CoxIngersollRoss(kappa=kappa, theta=theta, sigma=sigma)
 
 
@@ -322,7 +345,11 @@ def create_standard_heston(
     rho: float = -0.7,
     dividend_yield: float = 0.0
 ) -> HestonModel:
-    """Create standard Heston model with typical parameters."""
+    """Create a standard Heston model with conservative defaults.
+
+    The defaults are a common starting point for regression tests and documentation
+    examples, not a calibrated production set.
+    """
     return HestonModel(
         risk_free_rate=r,
         kappa=kappa,

--- a/src/processes/base.py
+++ b/src/processes/base.py
@@ -1,7 +1,13 @@
-"""Base classes for stochastic processes.
+r"""Base classes for stochastic processes.
 
-This module contains the abstract interfaces and base implementations
-for all stochastic processes in the unified framework.
+This module defines the abstract interfaces and reusable base implementations
+for all stochastic processes used by the pricing engines.
+
+Public process objects must expose a drift :math:`\mu(t, x)` and
+covariance :math:`\Sigma(t, x)` in calendar-time convention
+where time increases forward from valuation (``t = 0``) to maturity.
+State coordinates are represented as NumPy arrays and validated against
+``ProcessDimension`` before numerical operator construction.
 """
 from __future__ import annotations
 
@@ -17,7 +23,18 @@ from ..utils.state_handling import ensure_state_array, validate_state_dimensions
 
 
 class ProcessDimension(BaseModel):
-    """Represents the dimension of a stochastic process."""
+    """Container and validator for process dimensionality.
+
+    The dimension is a small strongly typed value object so that process and
+    solver code can reliably branch on state space shape.  A value of ``1``
+    indicates a univariate process while values greater than one indicate
+    multi-dimensional dynamics.
+
+    Parameters
+    ----------
+    value : int
+        Number of state dimensions.
+    """
     
     value: int
     
@@ -26,19 +43,37 @@ class ProcessDimension(BaseModel):
     @field_validator('value')
     @classmethod
     def validate_value(cls, v):
-        """Validate that dimension is positive."""
+        """Validate that process dimension is strictly positive.
+
+        Raises
+        ------
+        ValidationError
+            If ``value < 1``.
+        """
         if v < 1:
             raise ValidationError(f"Process dimension must be positive, got {v}")
         return v
     
     @property
     def is_univariate(self) -> bool:
-        """Check if process is 1-dimensional."""
+        """Whether the process has a single state coordinate.
+
+        Returns
+        -------
+        bool
+            ``True`` when ``value == 1``.
+        """
         return self.value == 1
     
     @property
     def is_multivariate(self) -> bool:
-        """Check if process is multi-dimensional."""
+        """Whether the process has multiple state coordinates.
+
+        Returns
+        -------
+        bool
+            ``True`` when ``value > 1``.
+        """
         return self.value > 1
     
     def __eq__(self, other) -> bool:
@@ -57,83 +92,122 @@ class ProcessType(Enum):
 
 
 class StochasticProcess(ABC):
-    """Abstract base class for all stochastic processes."""
+    """Abstract base class for all stochastic processes.
+
+    Implementations must provide drift and covariance in consistent array shapes.
+    The canonical convention is that ``state`` is either:
+
+    - a 1D state vector ``(d,)`` for a single point
+    - a 2D array ``(n, d)`` for a batch of ``n`` points
+
+    where ``d`` is ``self.dimension.value``.
+
+    Both methods are defined for the *calendar-time* convention used by the rest
+    of the framework.
+    """
     
     @property
     @abstractmethod
     def dimension(self) -> ProcessDimension:
-        """Get process dimension."""
+        """Get process dimension.
+
+        Returns
+        -------
+        ProcessDimension
+            Strongly-typed number of state dimensions.
+        """
         ...
     
     @property
     @abstractmethod
     def process_type(self) -> ProcessType:
-        """Get process type for optimization."""
+        """Get process type for optimization.
+
+        Returns
+        -------
+        ProcessType
+            Either :class:`ProcessType.AFFINE` or
+            :class:`ProcessType.NON_AFFINE`.
+        """
         ...
     
     @abstractmethod
     def drift(self, time: float, state: NDArray[np.float64]) -> NDArray[np.float64]:
-        """Compute drift vector μ(x,t).
-        
+        r"""Compute drift vector :math:`\mu(t, x)`.
+
         Parameters
         ----------
         time : float
-            Current time.
+            Calendar time.
         state : NDArray[np.float64]
-            Current state vector(s).
-            
+            State vector(s) with shape ``(d,)`` or ``(n, d)``.
+
         Returns
         -------
         NDArray[np.float64]
-            Drift vector(s).
+            Drift evaluated at each input point. The shape follows the input shape
+            by replacing state dimension with ``d``.
         """
         ...
     
     @abstractmethod
     def covariance(self, time: float, state: NDArray[np.float64]) -> NDArray[np.float64]:
-        """Compute covariance matrix Σ(x,t).
-        
+        r"""Compute diffusion covariance matrix :math:`\Sigma(t, x)`.
+
         Parameters
         ----------
         time : float
-            Current time.
+            Calendar time.
         state : NDArray[np.float64]
-            Current state vector(s).
-            
+            State vector(s) with shape ``(d,)`` or ``(n, d)``.
+
         Returns
         -------
         NDArray[np.float64]
-            Covariance matrix/matrices.
+            Covariance matrix/matrices with shape ``(d, d)`` or
+            ``(n, d, d)``.
         """
         ...
     
     def validate_state(self, state: NDArray[np.float64]) -> None:
-        """Validate state vector dimensions and values."""
+        """Validate state vector dimensions and state-space assumptions.
+
+        Parameters
+        ----------
+        state : NDArray[np.float64]
+            Candidate state array.
+
+        Raises
+        ------
+        ValidationError
+            If dimensionality does not match ``self.dimension``.
+        """
         state = ensure_state_array(state)
         validate_state_dimensions(state, self.dimension.value, self.__class__.__name__)
     
     def diffusion(self, time: float, state: NDArray[np.float64]) -> NDArray[np.float64]:
-        """Compute diffusion matrix σ(x,t) from covariance.
-        
-        This is a convenience method that computes the matrix square root
-        of the covariance matrix.
-        
+        r"""Compute diffusion matrix :math:`\sigma(t, x)` from covariance.
+
+        This convenience method applies the matrix square root to the covariance
+        returned by :meth:`covariance`.  For a batched state array, the square
+        root is returned per batch point.
+
         Parameters
         ----------
         time : float
-            Current time.
+            Calendar time.
         state : NDArray[np.float64]
-            Current state vector(s).
-            
+            State vector(s).
+
         Returns
         -------
         NDArray[np.float64]
-            Diffusion matrix/matrices.
+            Diffusion matrix/matrices with matching batch shape to covariance.
         """
         from ..utils.covariance_utils import matrix_sqrt
-        
+
         cov = self.covariance(time, state)
-        
+
         if cov.ndim == 2:
             # Single covariance matrix
             return matrix_sqrt(cov)
@@ -142,10 +216,10 @@ class StochasticProcess(ABC):
             batch_size = cov.shape[0]
             dim = cov.shape[1]
             result = np.zeros((batch_size, dim, dim))
-            
+
             for i in range(batch_size):
                 result[i] = matrix_sqrt(cov[i])
-            
+
             return result
 
 
@@ -158,6 +232,7 @@ class AffineProcess(StochasticProcess):
     
     This structure enables computational optimizations and analytical solutions.
     """
+
     
     @property
     def process_type(self) -> ProcessType:
@@ -238,7 +313,12 @@ class AffineProcess(StochasticProcess):
 
 
 class NonAffineProcess(StochasticProcess):
-    """Base class for non-affine stochastic processes."""
+    """Abstract base class for non-affine stochastic processes.
+
+    Non-affine processes do not admit a global affine decomposition of drift and
+    covariance. They must implement :meth:`drift` and :meth:`covariance` directly
+    and are typically used for models where state-dependence is non-linear.
+    """
     
     @property
     def process_type(self) -> ProcessType:

--- a/src/processes/nonaffine.py
+++ b/src/processes/nonaffine.py
@@ -1,7 +1,11 @@
-"""Non-affine stochastic processes implementation.
+"""Non-affine stochastic process models.
 
-This module contains implementations of non-affine stochastic processes
-that don't fit the linear drift/affine covariance structure.
+This module provides two-factor and one-factor process implementations with
+state-dependent coefficients that are not representable as globally affine forms.
+
+These models are primarily used when closed-form affine drift/covariance
+factorisations are unavailable but finite-difference numerics can still be
+constructed.
 """
 from __future__ import annotations
 
@@ -17,18 +21,16 @@ from ..utils.state_handling import validate_positive_state_components
 
 
 class ConstantElasticityVariance(NonAffineProcess, BaseModel):
-    """Constant Elasticity of Variance (CEV) process.
-    
-    dS = μS dt + σS^β dW
-    
-    Parameters
-    ----------
-    mu : float
-        Drift parameter.
-    sigma : float
-        Volatility parameter.
-    beta : float
-        Elasticity parameter (0 ≤ β ≤ 1).
+    r"""Constant Elasticity of Variance (CEV) process.
+
+    .. math::
+
+       dS_t = \mu S_t dt + \sigma S_t^{\beta} dW_t
+
+    Notes
+    -----
+    ``beta=1`` recovers geometric Brownian motion; ``beta<1`` increases leverage
+    in the diffusion term as spot decreases.
     """
     
     mu: float
@@ -56,7 +58,7 @@ class ConstantElasticityVariance(NonAffineProcess, BaseModel):
         return ProcessDimension(value=1)
     
     def drift(self, time: float, state: NDArray[np.float64]) -> NDArray[np.float64]:
-        """CEV drift μ(S) = μS."""
+        r"""Compute CEV drift :math:`\mu S_t` for each input state point."""
         self.validate_state(state)
         
         if state.ndim == 1:
@@ -65,7 +67,13 @@ class ConstantElasticityVariance(NonAffineProcess, BaseModel):
             return self.mu * state[:, 0:1]
     
     def covariance(self, time: float, state: NDArray[np.float64]) -> NDArray[np.float64]:
-        """CEV covariance Σ(S) = σ²S^(2β)."""
+        r"""Compute CEV covariance :math:`\sigma^2 S_t^{2\beta}`.
+
+        Returns
+        -------
+        NDArray[np.float64]
+            Matrix of shape ``(1,1)`` or ``(n, 1, 1)``.
+        """
         self.validate_state(state)
         
         if state.ndim == 1:
@@ -80,21 +88,20 @@ class ConstantElasticityVariance(NonAffineProcess, BaseModel):
 
 
 class SABRModel(NonAffineProcess, BaseModel):
-    """SABR (Stochastic Alpha Beta Rho) model.
-    
-    dF = σF^β dW₁
-    dσ = ασ dW₂
-    
-    with correlation ρ between W₁ and W₂.
-    
-    Parameters
-    ----------
-    alpha : float
-        Volatility of volatility.
-    beta : float
-        CEV exponent (0 ≤ β ≤ 1).
-    rho : float
-        Correlation between forward and volatility.
+    r"""SABR (Stochastic Alpha Beta Rho) model.
+
+    In two-factor form with state ``(F, sigma)``:
+
+    .. math::
+
+       dF_t = \sigma_t F_t^{\beta} dW_t^{(1)}
+       d\sigma_t = \alpha \sigma_t dW_t^{(2)}
+       dW_t^{(1)} dW_t^{(2)} = \rho dt
+
+    Notes
+    -----
+    The implementation assumes risk-neutral forward drift for the chosen
+    convention and validates ``alpha``, ``beta`` and ``rho`` at construction.
     """
     
     alpha: float
@@ -113,7 +120,11 @@ class SABRModel(NonAffineProcess, BaseModel):
         return ProcessDimension(value=2)
     
     def drift(self, time: float, state: NDArray[np.float64]) -> NDArray[np.float64]:
-        """SABR drift (zero drift for martingale processes)."""
+        """Return SABR model drift vector.
+
+        In this simplified implementation, risk-neutral forward drift is assumed
+        to be zero for the two state coordinates.
+        """
         self.validate_state(state)
         
         if state.ndim == 1:
@@ -123,7 +134,7 @@ class SABRModel(NonAffineProcess, BaseModel):
             return np.zeros((batch_size, 2))
     
     def covariance(self, time: float, state: NDArray[np.float64]) -> NDArray[np.float64]:
-        """SABR covariance matrix."""
+        """Compute SABR diffusion matrix for each state point."""
         self.validate_state(state)
         
         if state.ndim == 1:
@@ -159,10 +170,10 @@ class SABRModel(NonAffineProcess, BaseModel):
 
 # Convenience functions
 def create_cev_process(mu: float, sigma: float, beta: float) -> ConstantElasticityVariance:
-    """Create CEV process."""
+    """Create a single-factor CEV process instance."""
     return ConstantElasticityVariance(mu=mu, sigma=sigma, beta=beta)
 
 
 def create_sabr_model(alpha: float, beta: float, rho: float) -> SABRModel:
-    """Create SABR model."""
+    """Create a two-factor SABR model instance."""
     return SABRModel(alpha=alpha, beta=beta, rho=rho)

--- a/src/solvers/base.py
+++ b/src/solvers/base.py
@@ -1,7 +1,8 @@
 """Solver interface for PDE pricing.
 
-This module defines the abstract interface for PDE solvers
-in the unified pricing framework.
+This module defines the unified solver abstraction and concrete adapters used by
+pricing engines. Adapters translate the generic ":class:`Solver`" contract into
+underlying numerical implementations for finite differences and ADI.
 """
 from __future__ import annotations
 
@@ -25,7 +26,11 @@ from .finite_difference import (
 
 
 class Solver(ABC):
-    """Abstract base class for PDE solvers."""
+    """Abstract base class for PDE solvers.
+
+    Implementations should accept a terminal/initial payoff and return a full time
+    profile in the canonical orientation used by the rest of the stack.
+    """
     
     @abstractmethod
     def solve(
@@ -57,7 +62,12 @@ class Solver(ABC):
 
 
 class FiniteDifferenceSolverAdapter(Solver):
-    """Adapter exposing the finite difference solver through the unified API."""
+    """Adapter exposing the finite-difference solver through the unified API.
+
+    This adapter is intentionally conservative: only univariate (1D) spatial
+    problems are supported in this path. A :class:`ValidationError` is raised for
+    other dimensions rather than silently degrading behavior.
+    """
 
     def __init__(
         self,
@@ -66,6 +76,18 @@ class FiniteDifferenceSolverAdapter(Solver):
         time_stepper: TimeStepper | None = None,
         theta: float = 0.5,
     ) -> None:
+        """Create the 1D finite-difference adapter.
+
+        Parameters
+        ----------
+        process : StochasticProcess
+            Underlying model. It is used to build the spatial generator.
+        time_stepper : TimeStepper, optional
+            Optional custom time stepper. If omitted, defaults to
+            ``ThetaMethod(theta)``.
+        theta : float
+            Theta parameter used when ``time_stepper`` is not supplied.
+        """
         if time_stepper is None:
             time_stepper = ThetaMethod(theta)
 
@@ -80,6 +102,12 @@ class FiniteDifferenceSolverAdapter(Solver):
         *grids: NDArray[np.float64],
         time_grid: Optional[NDArray[np.float64]] = None,
     ) -> NDArray[np.float64]:
+        """Solve a 1D PDE and return solution ordered by valuation to maturity.
+
+        The wrapped :class:`FiniteDifferenceSolver` emits values in forward time,
+        so this adapter reverses the axis to keep ``prices[0]`` at valuation time
+        and ``prices[-1]`` at maturity, consistent with unified API docs.
+        """
         if len(grids) != 1:
             raise ValidationError("1D finite difference solver expects a single spatial grid")
 
@@ -131,16 +159,22 @@ class FiniteDifferenceSolverAdapter(Solver):
 
 
 class ADISolverWrapper(Solver):
-    """Wrapper for ADI solver to conform to Solver interface.
+    """Wrapper for ADI solvers to conform to the unified :class:`Solver` interface.
 
-    The wrapper owns coefficient evaluation for the selected stochastic process.
-    It deliberately does not invent placeholder drift or covariance arrays: if a
-    process cannot provide coefficients with the expected shape, the route fails
-    before calling the ADI solver.
+    Supported dimensions are 2D/3D. The wrapper validates shape consistency and
+    covariance definiteness before dispatching to the underlying ADI implementation.
     """
 
     def __init__(self, adi_solver, *, process: StochasticProcess) -> None:
-        """Initialize wrapper with ADI solver and selected process."""
+        """Initialize wrapper with ADI solver and selected process.
+
+        Parameters
+        ----------
+        adi_solver
+            Concrete ADI implementation.
+        process
+            Multi-dimensional stochastic process providing drift and covariance.
+        """
         self._adi_solver = adi_solver
         self._process = process
 
@@ -227,7 +261,13 @@ class ADISolverWrapper(Solver):
 
 
 class SolverFactory:
-    """Factory for creating appropriate solvers."""
+    """Factory for creating appropriate solvers.
+
+    Current production recommendation:
+    - 1D processes use the finite-difference adapter.
+    - 2D/3D processes route to ADI.
+    - Any unsupported dimension intentionally fails with a typed validation error.
+    """
     
     @staticmethod
     def create_solver(
@@ -235,15 +275,17 @@ class SolverFactory:
         theta: float = 0.5,
         time_stepper: TimeStepper | None = None,
     ) -> Solver:
-        """Create appropriate solver for process.
-        
+        """Create an appropriate solver for the supplied process.
+
         Parameters
         ----------
         process : StochasticProcess
             Stochastic process for the underlying asset(s).
         theta : float, optional
             Implicitness parameter for finite difference methods.
-            
+        time_stepper : TimeStepper | None
+            Optional time stepper override for the 1D finite-difference adapter.
+
         Returns
         -------
         Solver

--- a/src/solvers/finite_difference.py
+++ b/src/solvers/finite_difference.py
@@ -1,5 +1,9 @@
-"""Finite difference solvers and time-stepping schemes."""
+"""Finite difference solvers and time-stepping schemes.
+
+Core PDE stepping primitives used by :mod:`src.solvers.base`.
+"""
 from __future__ import annotations
+
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -10,7 +14,7 @@ from numpy.typing import NDArray
 
 
 class TimeStepper(ABC):
-    """Abstract base class for time stepping schemes."""
+    """Abstract base class for one-step time integration schemes."""
 
     @abstractmethod
     def step(
@@ -25,7 +29,11 @@ class TimeStepper(ABC):
 
 @dataclass
 class ThetaMethod(TimeStepper):
-    """Generic :math:`\theta`-method time integrator."""
+    """Generic :math:`\theta`-method time integrator.
+
+    ``theta=0`` gives explicit Euler, ``theta=0.5`` Crank--Nicolson,
+    ``theta=1`` implicit Euler.
+    """
 
     theta: float
 
@@ -58,7 +66,11 @@ class CrankNicolson(ThetaMethod):
 
 
 class PDESolver(ABC):
-    """Abstract base class for PDE solving engines."""
+    """Abstract base class for finite-difference PDE engines.
+
+    Concrete solvers should map a generator and boundary-condition object into an
+    array of temporal solutions.
+    """
 
     @abstractmethod
     def solve(
@@ -69,12 +81,28 @@ class PDESolver(ABC):
         initial_conditions: NDArray[np.float64],
         time_grid: NDArray[np.float64],
     ) -> NDArray[np.float64]:
-        """Solve the PDE with given conditions."""
+        """Solve PDE coefficients starting from ``initial_conditions``.
+
+        Parameters
+        ----------
+        generator
+            Spatial differential operator from ``findiff``.
+        boundary_conditions
+            Boundary condition container.
+        initial_conditions
+            Values at the first time slice.
+        time_grid
+            Monotone time grid in calendar time.
+        """
 
 
 @dataclass
 class FiniteDifferenceSolver(PDESolver):
-    """Finite difference PDE solver using a supplied time-stepper."""
+    """Finite difference PDE solver using a supplied time-stepper.
+
+    The implementation assumes a single spatial axis and fixed time-step size in
+    ``time_grid``.
+    """
 
     time_stepper: TimeStepper
 
@@ -102,7 +130,10 @@ class FiniteDifferenceSolver(PDESolver):
 
 
 def create_default_solver() -> PDESolver:
-    """Return a Crank--Nicolson finite difference solver."""
+    """Return a default Crank--Nicolson finite difference solver.
+
+    Equivalent to ``FiniteDifferenceSolver(theta=0.5)``.
+    """
 
     return FiniteDifferenceSolver(time_stepper=ThetaMethod(theta=0.5))
 

--- a/tests/test_docstring_smoke.py
+++ b/tests/test_docstring_smoke.py
@@ -1,0 +1,60 @@
+"""Smoke tests derived from public docstring examples.
+
+These tests execute small pricing/greeks snippets that are presented in module
+documentation and keep the documented examples runnable.
+"""
+
+import numpy as np
+
+from src.processes.affine import create_black_scholes_process, create_standard_heston
+from src.pricing import create_log_grid, create_unified_european_call, create_unified_pricing_engine
+from src.greeks.base import GreeksCalculatorFactory
+
+
+def test_docstring_example_black_scholes_price_smoke() -> None:
+    """Smoke test for 1D Black--Scholes pricing example.
+
+    This mirrors the usage pattern shown in ``pricing/engines/unified.py``.
+    """
+    process = create_black_scholes_process(mu=0.03, sigma=0.2)
+    engine = create_unified_pricing_engine(process)
+    option = create_unified_european_call(strike=100.0, maturity=1.0)
+    grid = create_log_grid(20.0, 200.0, 51)
+    times = np.linspace(0.0, 1.0, 8)
+
+    prices = engine.price_option(option, grid, time_grid=times)
+    assert prices.shape == (len(times), len(grid))
+    assert np.all(np.isfinite(prices))
+    assert np.all(prices >= 0.0)
+
+
+def test_docstring_example_heston_price_smoke() -> None:
+    """Smoke test for 2D Heston pricing example."""
+    process = create_standard_heston(r=0.03, kappa=1.8, theta=0.05, sigma=0.35, rho=-0.35)
+    engine = create_unified_pricing_engine(process)
+    option = create_unified_european_call(strike=100.0, maturity=0.25)
+    s_grid = create_log_grid(40.0, 220.0, 17, center=100.0)
+    v_grid = np.linspace(0.01, 0.30, 8)
+
+    prices = engine.price_option(option, s_grid, v_grid)
+    assert prices.shape == (50, len(s_grid), len(v_grid))
+    assert np.all(np.isfinite(prices))
+    assert np.all(prices >= 0.0)
+
+
+def test_docstring_example_greeks_smoke() -> None:
+    """Smoke test for Greeks calculation example."""
+    process = create_black_scholes_process(mu=0.03, sigma=0.2)
+    engine = create_unified_pricing_engine(process)
+    option = create_unified_european_call(strike=100.0, maturity=0.5)
+    s_grid = np.linspace(40.0, 200.0, 31)
+    times = np.linspace(0.0, 0.5, 12)
+
+    prices = engine.price_option(option, s_grid, time_grid=times)
+    calculator = GreeksCalculatorFactory.create_calculator(process)
+    greeks = calculator.calculate(prices, s_grid, time_grid=times)
+
+    assert set(greeks).issuperset({"delta", "gamma", "theta"})
+    assert greeks["delta"].shape == (len(s_grid),)
+    assert greeks["gamma"].shape == (len(s_grid),)
+    assert greeks["theta"].shape == prices.shape

--- a/tests/test_docstring_smoke.py
+++ b/tests/test_docstring_smoke.py
@@ -36,8 +36,10 @@ def test_docstring_example_heston_price_smoke() -> None:
     s_grid = create_log_grid(40.0, 220.0, 17, center=100.0)
     v_grid = np.linspace(0.01, 0.30, 8)
 
-    prices = engine.price_option(option, s_grid, v_grid)
-    assert prices.shape == (50, len(s_grid), len(v_grid))
+    time_grid = np.linspace(0.0, option.maturity, 10)
+
+    prices = engine.price_option(option, s_grid, v_grid, time_grid=time_grid)
+    assert prices.shape == (len(time_grid), len(s_grid), len(v_grid))
     assert np.all(np.isfinite(prices))
     assert np.all(prices >= 0.0)
 


### PR DESCRIPTION
## Summary
- Closes #3 by expanding public-facing docstrings across CLI/API, processes, solvers, pricing engines, instruments, Greeks, and boundary-condition builders.
- Adds executable smoke coverage for documented examples so docstrings stay aligned with importable public behavior.
- Keeps the CI blocking gate unchanged: static smoke, architecture tests, and the documented stable regression suite.

## Verification
- `./.venv/bin/ruff check . --select E9,F63,F7,F82`
- `PYTHONPATH=$PWD ./.venv/bin/pytest -q tests/architecture tests/test_docstring_smoke.py`
  - 13 passed.
- `PYTHONPATH=$PWD ./.venv/bin/pytest -q tests/test_boundary_conditions.py tests/test_callable_bond.py tests/test_finite_difference_greeks.py tests/test_greeks.py tests/test_multidimensional_adapter_coefficients.py tests/test_option_pricer.py tests/test_option_pricer_result.py tests/test_options.py tests/test_pde_pricer.py tests/test_plot_api.py tests/test_plot_backends.py tests/test_pricing_engine_imports.py tests/test_unified_pricing_engine.py tests/test_unified_processes.py`
  - 100 passed, 1 xfailed.
- `git diff --check`

## Follow-up discovered
- Full `PYTHONPATH=$PWD ./.venv/bin/pytest -q` currently exposes pre-existing issue #77: `tests/test_validation.py::test_option_validation_in_constructor` expects `InstrumentError` but receives lower-level `ValidationError`. That failure is outside this docstring PR and is not in the current CI stable regression subset.
