### PR TITLE
fix: preserve instrument validation exceptions

### DIFF
--- a/src/instruments/base.py
+++ b/src/instruments/base.py
@@ -5,14 +5,12 @@ for all financial instruments in the unified framework.
 """
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
-from typing import Optional
 import numpy as np
 from numpy.typing import NDArray
-from pydantic import BaseModel, Field, field_validator, ConfigDict
+from pydantic import BaseModel, field_validator, ConfigDict
 from findiff import FinDiff, BoundaryConditions
 
-from src.exceptions import ValidationError
+from src.exceptions import InstrumentError
 from ..processes.base import StochasticProcess
 from .operators import SpatialOperator
 
@@ -29,7 +27,7 @@ class Instrument(BaseModel):
     def validate_maturity(cls, v):
         """Validate maturity."""
         if v <= 0:
-            raise ValidationError(f"Maturity must be positive, got {v}")
+            raise InstrumentError(f"Invalid instrument parameter: maturity must be positive, got {v}")
         return v
     
     def payoff(self, state: NDArray[np.float64]) -> NDArray[np.float64]:
@@ -99,7 +97,7 @@ class EuropeanOption(Instrument):
     def validate_strike(cls, v):
         """Validate strike price."""
         if v <= 0:
-            raise ValidationError(f"Strike price must be positive, got {v}")
+            raise InstrumentError(f"Invalid option parameter: strike price must be positive, got {v}")
         return v
     
     def generator(self, s: NDArray[np.float64]) -> FinDiff:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -6,10 +6,9 @@ import sys
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 import pytest
-import numpy as np
 from src.exceptions import ValidationError, GridError, InstrumentError, ModelError
 from src.validation import (
-    validate_positive, validate_non_negative, validate_probability,
+    validate_positive,
     validate_grid_parameters, validate_option_parameters, validate_model_parameters
 )
 from src.processes.affine import GeometricBrownianMotion
@@ -80,7 +79,7 @@ def test_option_validation_in_constructor():
     with pytest.raises(InstrumentError):
         EuropeanCall(strike=100.0, maturity=-1.0, model=model)
     
-    # Invalid model parameters should raise
-    bad_model = GeometricBrownianMotion(mu=0.05, sigma=-0.2)
-    with pytest.raises(ModelError):
-        EuropeanCall(strike=100.0, maturity=1.0, model=bad_model)
+    # Invalid process parameters fail at the model boundary before the
+    # instrument constructor is reached.
+    with pytest.raises(ValidationError, match="sigma must be a positive number"):
+        GeometricBrownianMotion(mu=0.05, sigma=-0.2)


### PR DESCRIPTION
## Summary
- Closes #77 by restoring instrument-domain exception semantics for option constructor validation.
- `Instrument.validate_maturity` and `EuropeanOption.validate_strike` now raise `InstrumentError`, matching the public validation taxonomy expected by callers and tests.
- Updates the stale model-boundary assertion: invalid GBM parameters fail at process construction with `ValidationError`, before an option constructor can receive the model.
- Removes unused imports touched by the instrument/test changes.

## Verification
- `./.venv/bin/ruff check src/instruments/base.py tests/test_validation.py --select E9,F63,F7,F82,F401`
- `PYTHONPATH=$PWD ./.venv/bin/pytest -q tests/test_validation.py::test_option_validation_in_constructor tests/test_validation.py`
  - 6 passed.
- `PYTHONPATH=$PWD ./.venv/bin/pytest -q`
  - 118 passed, 1 xfailed.
- `git diff --check`
