### PR TITLE
feat: add FD backend capability manifest

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -322,6 +322,10 @@ Adapter lifecycle:
 
 The adapter imports no Haircut domain/application, PDP or delivery modules and advertises only tested capabilities.
 
+Issue #79 adds the transitional `src/contracts/backend_capabilities.py` module as the first executable FD adapter contract. It owns the data-only `FDCapabilityManifest`, `FDRouteRequest`, and `UnsupportedRouteDiagnostic` records used to screen QuantProblemSpec-style payloads before grid, operator, or ADI allocation. The default manifest intentionally advertises only validated FD/ADI capabilities: 1D/2D/3D uniform or log-uniform parabolic routes, drift/diffusion/reaction/source/mixed-derivative terms, Dirichlet/Neumann/Robin/second-derivative boundaries, European exercise, value/Delta/Gamma outputs, and theta/Crank-Nicolson/explicit/ADI controls.
+
+Unsupported dimensions, jump/PIDE or HJB/control terms, free-boundary/American exercise, unsupported Greeks, unsupported stability controls, and missing measure/numeraire/units/date conventions produce explicit unsupported-route diagnostics. They must not fall through to placeholder coefficients, guessed boundaries, or plausible-looking downgraded outputs.
+
 ## 17. Canonical implementation consolidation
 
 For every duplicated capability, choose one canonical path based on correctness evidence, API clarity and maintainability. The other path becomes:
@@ -396,7 +400,7 @@ Default tests are deterministic and offline. Frontend and service tests are sepa
 
 ## 22. Architecture fitness gates and CI release topology
 
-The baseline gate for #60 is `pytest -q tests/architecture`. It is intentionally ratcheted: it records the current transitional `src/*` surface, enforces the rule **No new root package under `src/`** unless `docs/ARCHITECTURE.md` and the gate baseline are updated, and prevents numerical-core modules from importing API, CLI, UI or plotting stacks.
+The baseline gate for #60 is `pytest -q tests/architecture`. It is intentionally ratcheted: it records the current transitional `src/*` surface, including the issue #79 `contracts` root for domain-neutral capability metadata, enforces the rule **No new root package under `src/`** unless `docs/ARCHITECTURE.md` and the gate baseline are updated, and prevents numerical-core modules from importing API, CLI, UI or plotting stacks.
 
 After package foundation #51 lands, the architecture gate must add the hard `src.*` import ban, package install/import smoke tests, and `deptry` or equivalent dependency-drift checks against PEP 621 metadata. Those follow-on checks are not optional; they are sequenced because the repository does not yet publish runtime metadata.
 

--- a/src/contracts/__init__.py
+++ b/src/contracts/__init__.py
@@ -1,0 +1,25 @@
+"""Domain-neutral finite-difference contracts and capability manifests."""
+
+from .backend_capabilities import (
+    CapabilityStatus,
+    DEFAULT_FD_CAPABILITY_MANIFEST,
+    FDCapabilityManifest,
+    FDRouteRequest,
+    UnsupportedReason,
+    UnsupportedRouteDiagnostic,
+    UnsupportedRouteError,
+    diagnose_unsupported_route,
+    ensure_route_supported,
+)
+
+__all__ = [
+    "CapabilityStatus",
+    "DEFAULT_FD_CAPABILITY_MANIFEST",
+    "FDCapabilityManifest",
+    "FDRouteRequest",
+    "UnsupportedReason",
+    "UnsupportedRouteDiagnostic",
+    "UnsupportedRouteError",
+    "diagnose_unsupported_route",
+    "ensure_route_supported",
+]

--- a/src/contracts/backend_capabilities.py
+++ b/src/contracts/backend_capabilities.py
@@ -1,0 +1,334 @@
+"""Finite-difference backend capability manifest and route diagnostics.
+
+This module is intentionally domain-neutral. It describes what the FD backend
+can support before any numerical grid/operator allocation happens and maps the
+shared QuantProblemSpec vocabulary into FD adapter inputs without importing
+Haircut Engine or other repository internals.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class CapabilityStatus(str, Enum):
+    """Maturity of one advertised backend capability."""
+
+    PRODUCTION = "production"
+    VALIDATED = "validated"
+    EXPERIMENTAL = "experimental"
+    UNSUPPORTED = "unsupported"
+
+
+class UnsupportedReason(str, Enum):
+    """Stable diagnostic codes for unsupported solver-route requests."""
+
+    UNSUPPORTED_DIMENSION = "unsupported_dimension"
+    UNSUPPORTED_GRID = "unsupported_grid"
+    UNSUPPORTED_TERM = "unsupported_pde_term"
+    UNSUPPORTED_BOUNDARY = "unsupported_boundary_condition"
+    UNSUPPORTED_EXERCISE = "unsupported_exercise_style"
+    UNSUPPORTED_OUTPUT = "unsupported_output"
+    UNSUPPORTED_STABILITY_CONTROL = "unsupported_stability_control"
+    MISSING_CONVENTION = "missing_convention"
+
+
+@dataclass(frozen=True)
+class UnsupportedRouteDiagnostic:
+    """Actionable reason why an FD route request is unsupported."""
+
+    reason: UnsupportedReason
+    field: str
+    value: str
+    supported: tuple[str, ...]
+    message: str
+
+
+@dataclass(frozen=True)
+class FDCapabilityManifest:
+    """Declarative finite-difference backend support matrix.
+
+    The manifest is intentionally data-only so routers, agents, and docs can
+    inspect it before importing any concrete numerical implementation.
+    """
+
+    backend_id: str
+    contract_version: str
+    status: CapabilityStatus
+    supported_dimensions: tuple[int, ...]
+    grid_types: tuple[str, ...]
+    pde_terms: tuple[str, ...]
+    boundary_conditions: tuple[str, ...]
+    exercise_styles: tuple[str, ...]
+    outputs: tuple[str, ...]
+    stability_controls: tuple[str, ...]
+    required_conventions: tuple[str, ...]
+    diagnostics: tuple[str, ...]
+    notes: tuple[str, ...] = ()
+
+    def supports(self, request: FDRouteRequest) -> bool:
+        """Return ``True`` only when no fail-closed diagnostics are produced."""
+
+        return not diagnose_unsupported_route(request, self)
+
+
+@dataclass(frozen=True)
+class FDRouteRequest:
+    """FD adapter request distilled from a QuantProblemSpec-like payload.
+
+    This is not the numerical problem itself. It is the capability-screening
+    envelope that preserves conventions agents must not drop: measure,
+    numeraire, units, valuation/maturity dates, boundary classes, requested
+    outputs and stability policy.
+    """
+
+    dimension: int
+    grid_type: str
+    pde_terms: tuple[str, ...]
+    boundary_conditions: tuple[str, ...]
+    exercise_style: str
+    requested_outputs: tuple[str, ...]
+    stability_controls: tuple[str, ...]
+    measure: str | None
+    numeraire: str | None
+    units: Mapping[str, str] = field(default_factory=dict)
+    valuation_date: str | None = None
+    maturity_date: str | None = None
+    source_schema_version: str | None = None
+
+    @classmethod
+    def from_quant_problem_spec(cls, payload: Mapping[str, Any]) -> FDRouteRequest:
+        """Map a shared QuantProblemSpec-like mapping to an FD route request.
+
+        Accepted keys deliberately mirror the v0 cross-repo problem vocabulary
+        while remaining permissive about nesting so public-synthetic fixtures can
+        evolve without forcing a hard dependency on Haircut Engine.
+        """
+
+        math = _mapping(payload.get("mathematical_problem"))
+        solver = _mapping(payload.get("solver_plan"))
+        context = _mapping(payload.get("valuation_context"))
+        conventions = _mapping(payload.get("conventions"))
+
+        dimension = int(_first_present(math, ("dimension", "dimensions", "state_dimension"), default=1))
+        grid_type = str(_first_present(solver, ("grid_type", "grid", "grid_family"), default="uniform"))
+        exercise_style = str(_first_present(math, ("exercise_style", "exercise"), default="european"))
+
+        return cls(
+            dimension=dimension,
+            grid_type=grid_type,
+            pde_terms=_tuple_of_strings(_first_present(math, ("pde_terms", "terms"), default=("drift", "diffusion", "reaction"))),
+            boundary_conditions=_tuple_of_strings(
+                _first_present(math, ("boundary_conditions", "boundary_types", "boundaries"), default=("dirichlet",))
+            ),
+            exercise_style=exercise_style,
+            requested_outputs=_tuple_of_strings(
+                _first_present(solver, ("requested_outputs", "outputs"), default=("value",))
+            ),
+            stability_controls=_tuple_of_strings(
+                _first_present(solver, ("stability_controls", "stability"), default=("theta",))
+            ),
+            measure=_optional_string(_first_present(context, ("measure",), default=conventions.get("measure"))),
+            numeraire=_optional_string(_first_present(context, ("numeraire",), default=conventions.get("numeraire"))),
+            units=_mapping(_first_present(context, ("units",), default=conventions.get("units", {}))),
+            valuation_date=_optional_string(_first_present(context, ("valuation_date", "as_of_date"), default=None)),
+            maturity_date=_optional_string(_first_present(context, ("maturity_date",), default=None)),
+            source_schema_version=_optional_string(payload.get("schema_version")),
+        )
+
+
+DEFAULT_FD_CAPABILITY_MANIFEST = FDCapabilityManifest(
+    backend_id="finite_difference_options.fd_backend.v0",
+    contract_version="0.1.0",
+    status=CapabilityStatus.VALIDATED,
+    supported_dimensions=(1, 2, 3),
+    grid_types=("uniform", "log_uniform"),
+    pde_terms=("drift", "diffusion", "reaction", "source", "mixed_derivative"),
+    boundary_conditions=("dirichlet", "neumann", "robin", "second_derivative"),
+    exercise_styles=("european",),
+    outputs=("value", "delta", "gamma"),
+    stability_controls=("theta", "crank_nicolson", "explicit_euler", "adi_psor"),
+    required_conventions=("measure", "numeraire", "units", "valuation_date", "maturity_date"),
+    diagnostics=(
+        "unsupported dimension",
+        "unsupported PDE term",
+        "unsupported boundary condition",
+        "unsupported exercise style",
+        "missing measure/numeraire/units/date convention",
+    ),
+    notes=(
+        "American/LCP exercise is intentionally unsupported until complementarity diagnostics land.",
+        "Jump/PIDE and HJB/control terms must fail closed instead of using placeholder coefficients.",
+    ),
+)
+
+
+def diagnose_unsupported_route(
+    request: FDRouteRequest,
+    manifest: FDCapabilityManifest = DEFAULT_FD_CAPABILITY_MANIFEST,
+) -> tuple[UnsupportedRouteDiagnostic, ...]:
+    """Return fail-closed diagnostics for unsupported request fields."""
+
+    diagnostics: list[UnsupportedRouteDiagnostic] = []
+
+    if request.dimension not in manifest.supported_dimensions:
+        diagnostics.append(
+            _diagnostic(
+                UnsupportedReason.UNSUPPORTED_DIMENSION,
+                "dimension",
+                str(request.dimension),
+                tuple(str(item) for item in manifest.supported_dimensions),
+                f"FD backend supports dimensions {manifest.supported_dimensions}, got {request.dimension}D.",
+            )
+        )
+
+    _extend_set_diagnostics(diagnostics, UnsupportedReason.UNSUPPORTED_GRID, "grid_type", (request.grid_type,), manifest.grid_types)
+    _extend_set_diagnostics(diagnostics, UnsupportedReason.UNSUPPORTED_TERM, "pde_terms", request.pde_terms, manifest.pde_terms)
+    _extend_set_diagnostics(
+        diagnostics,
+        UnsupportedReason.UNSUPPORTED_BOUNDARY,
+        "boundary_conditions",
+        request.boundary_conditions,
+        manifest.boundary_conditions,
+    )
+    _extend_set_diagnostics(
+        diagnostics,
+        UnsupportedReason.UNSUPPORTED_EXERCISE,
+        "exercise_style",
+        (request.exercise_style,),
+        manifest.exercise_styles,
+    )
+    _extend_set_diagnostics(
+        diagnostics,
+        UnsupportedReason.UNSUPPORTED_OUTPUT,
+        "requested_outputs",
+        request.requested_outputs,
+        manifest.outputs,
+    )
+    _extend_set_diagnostics(
+        diagnostics,
+        UnsupportedReason.UNSUPPORTED_STABILITY_CONTROL,
+        "stability_controls",
+        request.stability_controls,
+        manifest.stability_controls,
+    )
+
+    conventions = {
+        "measure": request.measure,
+        "numeraire": request.numeraire,
+        "units": request.units,
+        "valuation_date": request.valuation_date,
+        "maturity_date": request.maturity_date,
+    }
+    for field_name in manifest.required_conventions:
+        if not conventions.get(field_name):
+            diagnostics.append(
+                _diagnostic(
+                    UnsupportedReason.MISSING_CONVENTION,
+                    field_name,
+                    "<missing>",
+                    ("required",),
+                    f"QuantProblemSpec mapping must preserve {field_name}; it was missing or empty.",
+                )
+            )
+
+    return tuple(diagnostics)
+
+
+def ensure_route_supported(
+    request: FDRouteRequest,
+    manifest: FDCapabilityManifest = DEFAULT_FD_CAPABILITY_MANIFEST,
+) -> None:
+    """Raise :class:`UnsupportedRouteError` if the manifest rejects the request."""
+
+    diagnostics = diagnose_unsupported_route(request, manifest)
+    if diagnostics:
+        raise UnsupportedRouteError(diagnostics)
+
+
+class UnsupportedRouteError(ValueError):
+    """Raised when a route request is unsupported before numerical work."""
+
+    def __init__(self, diagnostics: Iterable[UnsupportedRouteDiagnostic]) -> None:
+        self.diagnostics = tuple(diagnostics)
+        reasons = "; ".join(d.message for d in self.diagnostics)
+        super().__init__(reasons)
+
+
+def _diagnostic(
+    reason: UnsupportedReason,
+    field_name: str,
+    value: str,
+    supported: tuple[str, ...],
+    message: str,
+) -> UnsupportedRouteDiagnostic:
+    return UnsupportedRouteDiagnostic(
+        reason=reason,
+        field=field_name,
+        value=value,
+        supported=supported,
+        message=message,
+    )
+
+
+def _extend_set_diagnostics(
+    diagnostics: list[UnsupportedRouteDiagnostic],
+    reason: UnsupportedReason,
+    field_name: str,
+    requested: tuple[str, ...],
+    supported: tuple[str, ...],
+) -> None:
+    supported_set = set(supported)
+    for value in requested:
+        if value not in supported_set:
+            diagnostics.append(
+                _diagnostic(
+                    reason,
+                    field_name,
+                    value,
+                    supported,
+                    f"Unsupported {field_name} value {value!r}; supported values are {supported}.",
+                )
+            )
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _first_present(mapping: Mapping[str, Any], keys: tuple[str, ...], *, default: Any) -> Any:
+    for key in keys:
+        if key in mapping:
+            return mapping[key]
+    return default
+
+
+def _tuple_of_strings(value: Any) -> tuple[str, ...]:
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, Iterable) and not isinstance(value, Mapping):
+        return tuple(str(item) for item in value)
+    return (str(value),)
+
+
+def _optional_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text or None
+
+
+__all__ = [
+    "CapabilityStatus",
+    "DEFAULT_FD_CAPABILITY_MANIFEST",
+    "FDCapabilityManifest",
+    "FDRouteRequest",
+    "UnsupportedReason",
+    "UnsupportedRouteDiagnostic",
+    "UnsupportedRouteError",
+    "diagnose_unsupported_route",
+    "ensure_route_supported",
+]

--- a/tests/architecture/test_architecture_contracts.py
+++ b/tests/architecture/test_architecture_contracts.py
@@ -26,6 +26,7 @@ CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 # reflected in docs/ARCHITECTURE.md before code lands.
 TRANSITIONAL_SRC_PACKAGES = {
     "boundary_conditions",
+    "contracts",
     "exceptions",
     "greeks",
     "instruments",
@@ -41,6 +42,7 @@ TRANSITIONAL_SRC_PACKAGES = {
 
 NUMERICAL_CORE_PACKAGES = {
     "boundary_conditions",
+    "contracts",
     "exceptions",
     "greeks",
     "instruments",

--- a/tests/test_fd_backend_capabilities.py
+++ b/tests/test_fd_backend_capabilities.py
@@ -1,0 +1,134 @@
+"""FD capability-manifest and unsupported-route diagnostics tests."""
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from src.contracts import (  # noqa: E402
+    DEFAULT_FD_CAPABILITY_MANIFEST,
+    FDRouteRequest,
+    UnsupportedReason,
+    UnsupportedRouteError,
+    diagnose_unsupported_route,
+    ensure_route_supported,
+)
+
+
+def _supported_payload() -> dict[str, object]:
+    return {
+        "schema_version": "quant-problem-spec/v0",
+        "valuation_context": {
+            "measure": "risk_neutral",
+            "numeraire": "money_market_account",
+            "units": {"underlying": "USD", "time": "ACT/365F"},
+            "valuation_date": "2026-01-02",
+            "maturity_date": "2027-01-02",
+        },
+        "mathematical_problem": {
+            "dimension": 1,
+            "pde_terms": ["drift", "diffusion", "reaction"],
+            "boundary_conditions": ["dirichlet", "neumann"],
+            "exercise_style": "european",
+        },
+        "solver_plan": {
+            "grid_type": "log_uniform",
+            "requested_outputs": ["value", "delta", "gamma"],
+            "stability_controls": ["theta"],
+        },
+    }
+
+
+def test_default_manifest_declares_fd_support_without_claiming_american_or_jumps() -> None:
+    manifest = DEFAULT_FD_CAPABILITY_MANIFEST
+
+    assert manifest.backend_id == "finite_difference_options.fd_backend.v0"
+    assert manifest.contract_version == "0.1.0"
+    assert manifest.supported_dimensions == (1, 2, 3)
+    assert "american" not in manifest.exercise_styles
+    assert "jump_integral" not in manifest.pde_terms
+    assert {"measure", "numeraire", "units", "valuation_date", "maturity_date"} <= set(
+        manifest.required_conventions
+    )
+
+
+def test_quant_problem_spec_mapping_preserves_conventions_and_outputs() -> None:
+    request = FDRouteRequest.from_quant_problem_spec(_supported_payload())
+
+    assert request.dimension == 1
+    assert request.grid_type == "log_uniform"
+    assert request.pde_terms == ("drift", "diffusion", "reaction")
+    assert request.boundary_conditions == ("dirichlet", "neumann")
+    assert request.requested_outputs == ("value", "delta", "gamma")
+    assert request.measure == "risk_neutral"
+    assert request.numeraire == "money_market_account"
+    assert request.units == {"underlying": "USD", "time": "ACT/365F"}
+    assert request.valuation_date == "2026-01-02"
+    assert request.maturity_date == "2027-01-02"
+    assert diagnose_unsupported_route(request) == ()
+
+
+def test_unsupported_terms_dimensions_boundaries_and_exercise_fail_closed() -> None:
+    payload = _supported_payload()
+    payload["mathematical_problem"] = {
+        "dimension": 4,
+        "pde_terms": ["drift", "jump_integral", "hjb_control"],
+        "boundary_conditions": ["free_boundary"],
+        "exercise_style": "american",
+    }
+    request = FDRouteRequest.from_quant_problem_spec(payload)
+
+    diagnostics = diagnose_unsupported_route(request)
+    reasons = {diagnostic.reason for diagnostic in diagnostics}
+
+    assert UnsupportedReason.UNSUPPORTED_DIMENSION in reasons
+    assert UnsupportedReason.UNSUPPORTED_TERM in reasons
+    assert UnsupportedReason.UNSUPPORTED_BOUNDARY in reasons
+    assert UnsupportedReason.UNSUPPORTED_EXERCISE in reasons
+    assert {diagnostic.field for diagnostic in diagnostics} >= {
+        "dimension",
+        "pde_terms",
+        "boundary_conditions",
+        "exercise_style",
+    }
+    with pytest.raises(UnsupportedRouteError, match="FD backend supports dimensions") as exc_info:
+        ensure_route_supported(request)
+    assert exc_info.value.diagnostics == diagnostics
+
+
+def test_missing_measure_numeraire_units_and_dates_are_actionable_diagnostics() -> None:
+    payload = _supported_payload()
+    payload["valuation_context"] = {}
+    request = FDRouteRequest.from_quant_problem_spec(payload)
+
+    diagnostics = diagnose_unsupported_route(request)
+    missing = {diagnostic.field for diagnostic in diagnostics if diagnostic.reason == UnsupportedReason.MISSING_CONVENTION}
+
+    assert missing == {"measure", "numeraire", "units", "valuation_date", "maturity_date"}
+    assert all("missing or empty" in diagnostic.message for diagnostic in diagnostics)
+
+
+def test_unsupported_outputs_and_stability_controls_do_not_silently_downgrade() -> None:
+    payload = _supported_payload()
+    payload["solver_plan"] = {
+        "grid_type": "adaptive_sparse_grid",
+        "requested_outputs": ["value", "vega", "exercise_boundary"],
+        "stability_controls": ["rannacher", "policy_iteration_lcp"],
+    }
+    request = FDRouteRequest.from_quant_problem_spec(payload)
+
+    diagnostics = diagnose_unsupported_route(request)
+    by_field = {diagnostic.field: diagnostic for diagnostic in diagnostics}
+
+    assert by_field["grid_type"].reason == UnsupportedReason.UNSUPPORTED_GRID
+    assert {diagnostic.value for diagnostic in diagnostics if diagnostic.field == "requested_outputs"} == {
+        "vega",
+        "exercise_boundary",
+    }
+    assert {diagnostic.value for diagnostic in diagnostics if diagnostic.field == "stability_controls"} == {
+        "rannacher",
+        "policy_iteration_lcp",
+    }


### PR DESCRIPTION
Closes googa27/finite_difference_options#79.

## Summary
- Adds the FD backend capability manifest and fail-closed unsupported-route diagnostics.
- Adds QuantProblemSpec-like mapping into `FDRouteRequest`, preserving measure, numeraire, units, valuation/maturity dates, boundaries, outputs, and stability controls.
- Documents the transitional `src/contracts` root and ratchets the architecture gate to include it.

## Verification
```text
python3 -m compileall -q src tests
./.venv/bin/ruff check . --select E9,F63,F7,F82
PYTHONPATH=$PWD ./.venv/bin/pytest -q tests/architecture
PYTHONPATH=$PWD ./.venv/bin/pytest -q tests/test_fd_backend_capabilities.py tests/test_multidimensional_adapter_coefficients.py
PYTHONPATH=$PWD ./.venv/bin/pytest -q
```

Observed:
- Targeted architecture/capability gate: `20 passed`.
- Full suite: `123 passed, 1 xfailed`.
- CI stable suite separately re-run: `100 passed, 1 xfailed`.
- `git diff --check`: clean.

## Risk / rollback
- Data-only contract module; no numerical solver behavior changes.
- Rollback removes `src/contracts`, its tests, and the architecture-doc ratchet entry.
