### PR TITLE
test: add FD Black-Scholes parity fixture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
           pytest -q \
             tests/test_boundary_conditions.py \
             tests/test_callable_bond.py \
+            tests/test_fd_backend_capabilities.py \
+            tests/test_fd_black_scholes_parity_fixture.py \
             tests/test_finite_difference_greeks.py \
             tests/test_greeks.py \
             tests/test_multidimensional_adapter_coefficients.py \

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -326,6 +326,8 @@ Issue #79 adds the transitional `src/contracts/backend_capabilities.py` module a
 
 Unsupported dimensions, jump/PIDE or HJB/control terms, free-boundary/American exercise, unsupported Greeks, unsupported stability controls, and missing measure/numeraire/units/date conventions produce explicit unsupported-route diagnostics. They must not fall through to placeholder coefficients, guessed boundaries, or plausible-looking downgraded outputs.
 
+Issue #80 adds the public-synthetic Black-Scholes call parity fixture in `src/validation/black_scholes_parity.py`. The fixture defines its analytical oracle, convergence table, tolerance, boundary assumptions, resource controls, and `SolverEvidence` payload with route/backend/code/config/seed/convention fields. It uses only synthetic parameters and is part of the blocking CI stable suite so adapter/router evidence cannot drift silently.
+
 ## 17. Canonical implementation consolidation
 
 For every duplicated capability, choose one canonical path based on correctness evidence, API clarity and maintainability. The other path becomes:

--- a/docs/CI_POLICY.md
+++ b/docs/CI_POLICY.md
@@ -20,6 +20,8 @@ The Python job uses Python 3.12 and reports failures by command group:
 4. stable regression suite:
    - boundary conditions;
    - callable bond;
+   - FD backend capability manifest;
+   - public-synthetic Black-Scholes parity/evidence fixture;
    - finite-difference Greeks;
    - Greeks;
    - multidimensional adapter coefficients;

--- a/src/contracts/__init__.py
+++ b/src/contracts/__init__.py
@@ -11,6 +11,7 @@ from .backend_capabilities import (
     diagnose_unsupported_route,
     ensure_route_supported,
 )
+from .solver_evidence import SolverEvidence
 
 __all__ = [
     "CapabilityStatus",
@@ -20,6 +21,7 @@ __all__ = [
     "UnsupportedReason",
     "UnsupportedRouteDiagnostic",
     "UnsupportedRouteError",
+    "SolverEvidence",
     "diagnose_unsupported_route",
     "ensure_route_supported",
 ]

--- a/src/contracts/solver_evidence.py
+++ b/src/contracts/solver_evidence.py
@@ -1,0 +1,39 @@
+"""Solver evidence records shared by FD routing and validation fixtures."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SolverEvidence:
+    """Reproducibility envelope emitted by public-synthetic solver fixtures.
+
+    The fields mirror the router evidence expected by the cross-repo quant
+    platform: route identity, backend identity, code/config identity, fixture
+    identity, deterministic seed where applicable, conventions, boundary
+    assumptions, and bounded resource controls.
+    """
+
+    route_id: str
+    backend_id: str
+    code_version: str
+    config_hash: str
+    fixture_id: str
+    seed: int | None
+    valuation_date: str
+    maturity_date: str
+    measure: str
+    numeraire: str
+    units: dict[str, str]
+    boundary_assumptions: tuple[str, ...]
+    resource_controls: dict[str, int | float | str]
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable evidence payload."""
+
+        return asdict(self)
+
+
+__all__ = ["SolverEvidence"]

--- a/src/validation/black_scholes_parity.py
+++ b/src/validation/black_scholes_parity.py
@@ -1,0 +1,202 @@
+"""Public-synthetic Black--Scholes parity fixtures for FD routing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+from math import exp, log, sqrt
+import json
+from typing import Any
+
+import numpy as np
+from scipy.stats import norm
+
+from src.contracts import DEFAULT_FD_CAPABILITY_MANIFEST, SolverEvidence
+from src.instruments.base import EuropeanCall
+from src.pricing.engines import BlackScholesPDE
+from src.processes.affine import GeometricBrownianMotion
+
+
+@dataclass(frozen=True)
+class BlackScholesParityCase:
+    """Public-synthetic Black--Scholes call-option fixture definition."""
+
+    fixture_id: str = "public-synthetic.black-scholes-call.v0"
+    route_id: str = "fd.black_scholes_1d.crank_nicolson"
+    backend_id: str = DEFAULT_FD_CAPABILITY_MANIFEST.backend_id
+    code_version: str = "local-checkout"
+    spot: float = 1.0
+    strike: float = 1.0
+    rate: float = 0.05
+    sigma: float = 0.2
+    maturity: float = 1.0
+    s_max: float = 3.0
+    tolerance: float = 5.0e-4
+    valuation_date: str = "2026-01-02"
+    maturity_date: str = "2027-01-02"
+    measure: str = "risk_neutral"
+    numeraire: str = "money_market_account"
+    units: dict[str, str] | None = None
+    seed: int | None = None
+
+    def normalized_units(self) -> dict[str, str]:
+        """Return explicit synthetic units for evidence serialization."""
+
+        return self.units or {"underlying": "synthetic_currency", "time": "ACT/365F"}
+
+
+@dataclass(frozen=True)
+class ConvergenceObservation:
+    """One row in the parity fixture convergence table."""
+
+    s_steps: int
+    t_steps: int
+    price: float
+    oracle_price: float
+    abs_error: float
+
+
+@dataclass(frozen=True)
+class BlackScholesParityReport:
+    """Black--Scholes fixture result with solver evidence."""
+
+    case: BlackScholesParityCase
+    evidence: SolverEvidence
+    oracle_price: float
+    observations: tuple[ConvergenceObservation, ...]
+
+    @property
+    def max_abs_error(self) -> float:
+        """Maximum absolute pricing error across convergence rows."""
+
+        return max(observation.abs_error for observation in self.observations)
+
+    @property
+    def final_abs_error(self) -> float:
+        """Absolute pricing error on the finest configured grid."""
+
+        return self.observations[-1].abs_error
+
+    @property
+    def converged(self) -> bool:
+        """Whether the finest grid satisfies the fixture tolerance."""
+
+        return self.final_abs_error <= self.case.tolerance
+
+    def convergence_table(self) -> tuple[dict[str, float | int], ...]:
+        """Return a JSON-friendly convergence table."""
+
+        return tuple(
+            {
+                "s_steps": row.s_steps,
+                "t_steps": row.t_steps,
+                "price": row.price,
+                "oracle_price": row.oracle_price,
+                "abs_error": row.abs_error,
+            }
+            for row in self.observations
+        )
+
+
+def black_scholes_call_oracle(spot: float, strike: float, rate: float, sigma: float, maturity: float) -> float:
+    """Analytical Black--Scholes call price used as the public oracle."""
+
+    d1 = (log(spot / strike) + (rate + 0.5 * sigma**2) * maturity) / (sigma * sqrt(maturity))
+    d2 = d1 - sigma * sqrt(maturity)
+    return float(spot * norm.cdf(d1) - strike * exp(-rate * maturity) * norm.cdf(d2))
+
+
+def run_public_black_scholes_parity_fixture(
+    *,
+    case: BlackScholesParityCase | None = None,
+    grid_levels: tuple[tuple[int, int], ...] = ((40, 40), (80, 120), (120, 200)),
+) -> BlackScholesParityReport:
+    """Run the public-synthetic Black--Scholes fixture and emit evidence.
+
+    The fixture uses only synthetic parameters and deterministic finite-difference
+    grids. It records boundary assumptions and resource controls so a router can
+    compare evidence without relying on private market data or hidden defaults.
+    """
+
+    case = case or BlackScholesParityCase()
+    oracle = black_scholes_call_oracle(case.spot, case.strike, case.rate, case.sigma, case.maturity)
+
+    model = GeometricBrownianMotion(mu=case.rate, sigma=case.sigma)
+    instrument = EuropeanCall(strike=case.strike, maturity=case.maturity, model=model)
+    pricer = BlackScholesPDE(instrument=instrument)
+
+    observations: list[ConvergenceObservation] = []
+    for s_steps, t_steps in grid_levels:
+        s_grid = np.linspace(0.0, case.s_max, s_steps)
+        t_grid = np.linspace(0.0, case.maturity, t_steps)
+        values = pricer.price(option=instrument, s=s_grid, t=t_grid)
+        price = float(np.interp(case.spot, s_grid, values[-1]))
+        observations.append(
+            ConvergenceObservation(
+                s_steps=s_steps,
+                t_steps=t_steps,
+                price=price,
+                oracle_price=oracle,
+                abs_error=abs(price - oracle),
+            )
+        )
+
+    evidence = SolverEvidence(
+        route_id=case.route_id,
+        backend_id=case.backend_id,
+        code_version=case.code_version,
+        config_hash=_config_hash(case, grid_levels),
+        fixture_id=case.fixture_id,
+        seed=case.seed,
+        valuation_date=case.valuation_date,
+        maturity_date=case.maturity_date,
+        measure=case.measure,
+        numeraire=case.numeraire,
+        units=case.normalized_units(),
+        boundary_assumptions=(
+            "left boundary: zero call value at S=0",
+            "right boundary: first derivative approaches one for call far field",
+            "uniform physical-price grid on [0, s_max]",
+        ),
+        resource_controls={
+            "max_s_steps": max(level[0] for level in grid_levels),
+            "max_t_steps": max(level[1] for level in grid_levels),
+            "grid_levels": len(grid_levels),
+            "deterministic": "true",
+        },
+    )
+
+    return BlackScholesParityReport(
+        case=case,
+        evidence=evidence,
+        oracle_price=oracle,
+        observations=tuple(observations),
+    )
+
+
+def _config_hash(case: BlackScholesParityCase, grid_levels: tuple[tuple[int, int], ...]) -> str:
+    payload: dict[str, Any] = {
+        "fixture_id": case.fixture_id,
+        "spot": case.spot,
+        "strike": case.strike,
+        "rate": case.rate,
+        "sigma": case.sigma,
+        "maturity": case.maturity,
+        "s_max": case.s_max,
+        "tolerance": case.tolerance,
+        "grid_levels": grid_levels,
+        "measure": case.measure,
+        "numeraire": case.numeraire,
+        "units": case.normalized_units(),
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return sha256(encoded).hexdigest()
+
+
+__all__ = [
+    "BlackScholesParityCase",
+    "BlackScholesParityReport",
+    "ConvergenceObservation",
+    "black_scholes_call_oracle",
+    "run_public_black_scholes_parity_fixture",
+]

--- a/tests/test_fd_black_scholes_parity_fixture.py
+++ b/tests/test_fd_black_scholes_parity_fixture.py
@@ -1,0 +1,61 @@
+"""Public-synthetic Black--Scholes parity fixture tests."""
+from __future__ import annotations
+
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from src.contracts import SolverEvidence  # noqa: E402
+from src.validation.black_scholes_parity import (  # noqa: E402
+    BlackScholesParityCase,
+    black_scholes_call_oracle,
+    run_public_black_scholes_parity_fixture,
+)
+
+
+def test_black_scholes_oracle_matches_known_public_synthetic_case() -> None:
+    oracle = black_scholes_call_oracle(spot=1.0, strike=1.0, rate=0.05, sigma=0.2, maturity=1.0)
+
+    assert abs(oracle - 0.1045058357) < 1e-10
+
+
+def test_public_black_scholes_fixture_converges_with_evidence() -> None:
+    report = run_public_black_scholes_parity_fixture()
+
+    assert report.converged
+    assert report.final_abs_error <= report.case.tolerance
+    assert report.final_abs_error < report.observations[0].abs_error
+    assert len(report.convergence_table()) == 3
+
+    evidence = report.evidence
+    assert isinstance(evidence, SolverEvidence)
+    assert evidence.fixture_id == "public-synthetic.black-scholes-call.v0"
+    assert evidence.route_id == "fd.black_scholes_1d.crank_nicolson"
+    assert evidence.backend_id == "finite_difference_options.fd_backend.v0"
+    assert len(evidence.config_hash) == 64
+    assert evidence.code_version == "local-checkout"
+    assert evidence.seed is None
+    assert evidence.measure == "risk_neutral"
+    assert evidence.numeraire == "money_market_account"
+    assert evidence.units == {"underlying": "synthetic_currency", "time": "ACT/365F"}
+    assert evidence.valuation_date == "2026-01-02"
+    assert evidence.maturity_date == "2027-01-02"
+    assert evidence.resource_controls == {
+        "max_s_steps": 120,
+        "max_t_steps": 200,
+        "grid_levels": 3,
+        "deterministic": "true",
+    }
+    assert any("right boundary" in item for item in evidence.boundary_assumptions)
+
+
+def test_fixture_is_public_synthetic_and_deterministic() -> None:
+    case = BlackScholesParityCase(code_version="test-head")
+    first = run_public_black_scholes_parity_fixture(case=case)
+    second = run_public_black_scholes_parity_fixture(case=case)
+
+    assert first.evidence.as_dict() == second.evidence.as_dict()
+    assert first.convergence_table() == second.convergence_table()
+    assert "synthetic" in first.evidence.units["underlying"]
+    assert first.evidence.seed is None


### PR DESCRIPTION
Closes googa27/finite_difference_options#80.

## Summary
- Adds a public-synthetic Black-Scholes call parity fixture with analytical oracle, convergence table, tolerance, boundary assumptions, and resource controls.
- Adds `SolverEvidence` for route/backend/code/config/seed/convention evidence emission.
- Promotes the parity fixture into the blocking CI stable suite and documents the evidence contract.

## Verification
```text
./.venv/bin/ruff check src/contracts src/validation/black_scholes_parity.py tests/test_fd_black_scholes_parity_fixture.py tests/test_fd_backend_capabilities.py --select E9,F63,F7,F82,F401,F821,UP035
python3 -m compileall -q src tests
PYTHONPATH=$PWD ./.venv/bin/pytest -q tests/test_fd_black_scholes_parity_fixture.py tests/test_fd_backend_capabilities.py tests/architecture
PYTHONPATH=$PWD ./.venv/bin/pytest -q tests/test_boundary_conditions.py tests/test_callable_bond.py tests/test_fd_backend_capabilities.py tests/test_fd_black_scholes_parity_fixture.py tests/test_finite_difference_greeks.py tests/test_greeks.py tests/test_multidimensional_adapter_coefficients.py tests/test_option_pricer.py tests/test_option_pricer_result.py tests/test_options.py tests/test_pde_pricer.py tests/test_plot_api.py tests/test_plot_backends.py tests/test_pricing_engine_imports.py tests/test_unified_pricing_engine.py tests/test_unified_processes.py
PYTHONPATH=$PWD ./.venv/bin/pytest -q
```

Observed:
- Targeted parity/capability/architecture: `18 passed`.
- CI stable suite including new fixture: `108 passed, 1 xfailed`.
- Full suite: `126 passed, 1 xfailed`.
- `git diff --check`: clean.

## Risk / rollback
- Adds validation/evidence fixture and CI coverage; no solver numerical behavior changes.
- Rollback removes `SolverEvidence`, parity fixture, tests, and CI/doc entries.
