### PR TITLE
test: consume QuantProblemSpec fixture in FD adapter

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -328,6 +328,8 @@ Unsupported dimensions, jump/PIDE or HJB/control terms, free-boundary/American e
 
 Issue #80 adds the public-synthetic Black-Scholes call parity fixture in `src/validation/black_scholes_parity.py`. The fixture defines its analytical oracle, convergence table, tolerance, boundary assumptions, resource controls, and `SolverEvidence` payload with route/backend/code/config/seed/convention fields. It uses only synthetic parameters and is part of the blocking CI stable suite so adapter/router evidence cannot drift silently.
 
+Issue #76 extends the adapter tests to consume the same public-synthetic `QuantProblemSpec` vanilla-call JSON fixture validated by `haircut-engine` #91. The fixture is vendored under `tests/fixtures/quant_problem_specs/` as a data contract, not as a Python import, and the adapter must preserve schema version, measure, numeraire, units, valuation/vintage timing, boundary details, and requested outputs before route support is claimed.
+
 ## 17. Canonical implementation consolidation
 
 For every duplicated capability, choose one canonical path based on correctness evidence, API clarity and maintainability. The other path becomes:

--- a/src/contracts/backend_capabilities.py
+++ b/src/contracts/backend_capabilities.py
@@ -95,8 +95,10 @@ class FDRouteRequest:
     measure: str | None
     numeraire: str | None
     units: Mapping[str, str] = field(default_factory=dict)
+    boundary_details: Mapping[str, str] = field(default_factory=dict)
     valuation_date: str | None = None
     maturity_date: str | None = None
+    time_domain: str | None = None
     source_schema_version: str | None = None
 
     @classmethod
@@ -112,30 +114,63 @@ class FDRouteRequest:
         solver = _mapping(payload.get("solver_plan"))
         context = _mapping(payload.get("valuation_context"))
         conventions = _mapping(payload.get("conventions"))
+        vintage = _mapping(payload.get("vintage"))
+        domain = _mapping(math.get("domain"))
+        boundary_details = _mapping(math.get("boundary_conditions"))
 
-        dimension = int(_first_present(math, ("dimension", "dimensions", "state_dimension"), default=1))
+        dimension = int(
+            _first_present(
+                math,
+                ("dimension", "dimensions", "state_dimension"),
+                default=_state_dimension(math.get("state_variables")),
+            )
+        )
         grid_type = str(_first_present(solver, ("grid_type", "grid", "grid_family"), default="uniform"))
         exercise_style = str(_first_present(math, ("exercise_style", "exercise"), default="european"))
 
         return cls(
             dimension=dimension,
             grid_type=grid_type,
-            pde_terms=_tuple_of_strings(_first_present(math, ("pde_terms", "terms"), default=("drift", "diffusion", "reaction"))),
-            boundary_conditions=_tuple_of_strings(
-                _first_present(math, ("boundary_conditions", "boundary_types", "boundaries"), default=("dirichlet",))
+            pde_terms=_tuple_of_strings(
+                _first_present(math, ("pde_terms", "terms"), default=("drift", "diffusion", "reaction"))
+            ),
+            boundary_conditions=_boundary_condition_classes(
+                _first_present(math, ("boundary_types", "boundaries", "boundary_conditions"), default=("dirichlet",))
             ),
             exercise_style=exercise_style,
             requested_outputs=_tuple_of_strings(
-                _first_present(solver, ("requested_outputs", "outputs"), default=("value",))
+                _first_present(solver, ("requested_outputs", "required_outputs", "outputs"), default=("value",))
             ),
             stability_controls=_tuple_of_strings(
                 _first_present(solver, ("stability_controls", "stability"), default=("theta",))
             ),
-            measure=_optional_string(_first_present(context, ("measure",), default=conventions.get("measure"))),
-            numeraire=_optional_string(_first_present(context, ("numeraire",), default=conventions.get("numeraire"))),
-            units=_mapping(_first_present(context, ("units",), default=conventions.get("units", {}))),
-            valuation_date=_optional_string(_first_present(context, ("valuation_date", "as_of_date"), default=None)),
-            maturity_date=_optional_string(_first_present(context, ("maturity_date",), default=None)),
+            measure=_optional_string(
+                _first_present(
+                    context,
+                    ("measure",),
+                    default=_first_present(math, ("measure_id", "measure"), default=conventions.get("measure")),
+                )
+            ),
+            numeraire=_optional_string(
+                _first_present(
+                    context,
+                    ("numeraire",),
+                    default=_first_present(math, ("numeraire_id", "numeraire"), default=conventions.get("numeraire")),
+                )
+            ),
+            units=_mapping(
+                _first_present(
+                    context,
+                    ("units",),
+                    default=_first_present(math, ("units",), default=conventions.get("units", {})),
+                )
+            ),
+            boundary_details={str(key): str(value) for key, value in boundary_details.items()},
+            valuation_date=_optional_string(
+                _first_present(context, ("valuation_date", "as_of_date"), default=vintage.get("valuation_date"))
+            ),
+            maturity_date=_optional_string(_first_present(context, ("maturity_date",), default=vintage.get("maturity_date"))),
+            time_domain=_optional_string(_first_present(context, ("time_domain",), default=domain.get("t"))),
             source_schema_version=_optional_string(payload.get("schema_version")),
         )
 
@@ -221,7 +256,7 @@ def diagnose_unsupported_route(
         "numeraire": request.numeraire,
         "units": request.units,
         "valuation_date": request.valuation_date,
-        "maturity_date": request.maturity_date,
+        "maturity_date": request.maturity_date or request.time_domain,
     }
     for field_name in manifest.required_conventions:
         if not conventions.get(field_name):
@@ -312,6 +347,44 @@ def _tuple_of_strings(value: Any) -> tuple[str, ...]:
     if isinstance(value, Iterable) and not isinstance(value, Mapping):
         return tuple(str(item) for item in value)
     return (str(value),)
+
+
+def _state_dimension(value: Any) -> int:
+    if isinstance(value, str):
+        return 1
+    if isinstance(value, Iterable) and not isinstance(value, Mapping):
+        values = tuple(value)
+        return len(values) or 1
+    return 1
+
+
+def _boundary_condition_classes(value: Any) -> tuple[str, ...]:
+    """Normalize public schema boundary formulas to FD capability classes."""
+
+    raw_items: Iterable[Any]
+    if isinstance(value, Mapping):
+        raw_items = value.values()
+    else:
+        raw_items = _tuple_of_strings(value)
+
+    classes: list[str] = []
+    for item in raw_items:
+        text = str(item).lower().replace("-", "_")
+        if "robin" in text:
+            boundary_class = "robin"
+        elif "second" in text:
+            boundary_class = "second_derivative"
+        elif "linear" in text or "slope" in text or "growth" in text:
+            boundary_class = "neumann"
+        elif "neumann" in text:
+            boundary_class = "neumann"
+        elif "dirichlet" in text or "absorbing" in text or text.strip() in {"0", "zero"}:
+            boundary_class = "dirichlet"
+        else:
+            boundary_class = text
+        if boundary_class not in classes:
+            classes.append(boundary_class)
+    return tuple(classes) or ("dirichlet",)
 
 
 def _optional_string(value: Any) -> str | None:

--- a/tests/fixtures/quant_problem_specs/README.md
+++ b/tests/fixtures/quant_problem_specs/README.md
@@ -1,0 +1,10 @@
+# QuantProblemSpec consumer fixtures
+
+`vanilla_call.json` is a public-synthetic copy of the Haircut Engine QuantProblemSpec v0 fixture validated in `googa27/haircut-engine` for Project 5 issue #91.
+
+Rules:
+
+- The fixture is public synthetic only; no client, bank, RUT, token, private market, or Deloitte data belongs here.
+- FD tests consume this JSON as an external contract fixture, not as a Haircut Engine Python import.
+- Changes must preserve measure, numeraire, units, valuation/vintage dates, boundary details, requested outputs, and schema version.
+- If the upstream fixture changes incompatibly, update this copy and the adapter test in the same PR, or raise a compatibility issue in Project 5.

--- a/tests/fixtures/quant_problem_specs/vanilla_call.json
+++ b/tests/fixtures/quant_problem_specs/vanilla_call.json
@@ -1,0 +1,191 @@
+{
+  "artifact_manifest": {
+    "artifacts": [
+      {
+        "artifact_id": "option-fixture-json",
+        "artifact_type": "json_fixture",
+        "privacy_class": "public_synthetic",
+        "sha256": null,
+        "uri": "artifact://quant-problem-spec/vanilla-call-v0"
+      }
+    ],
+    "manifest_id": "public-synthetic-manifest-v0"
+  },
+  "data_requirement_plan": {
+    "fixture_policy": "public-synthetic-only",
+    "requirements": [
+      {
+        "contract": "public-synthetic-option-contract",
+        "lineage_id": "public-synthetic",
+        "name": "option_parameters",
+        "privacy_class": "public_synthetic",
+        "required_fields": [
+          "spot",
+          "strike",
+          "rate",
+          "volatility",
+          "maturity"
+        ],
+        "version": "v0"
+      }
+    ],
+    "restricted_data_policy": "reject"
+  },
+  "family": "vanilla_option",
+  "financial_graph": {
+    "graph_role": "derivative benchmark graph",
+    "required_solver_features": [
+      "delta",
+      "family:exact",
+      "family:fem",
+      "family:transform",
+      "gamma",
+      "value"
+    ],
+    "translation_notes": "Shared exact/FD/FEM parity fixture; no private market data.",
+    "valuation_graph": {
+      "cashflows": [
+        {
+          "cashflow_id": "terminal_payoff",
+          "currency": "CLP",
+          "direction": "inflow",
+          "formula": "max(S_T-K,0)",
+          "metadata": {},
+          "node_id": "expiry",
+          "timing": "terminal"
+        }
+      ],
+      "graph_id": "public-synthetic-vanilla-call-graph-v0",
+      "measure_id": "risk_neutral",
+      "metadata": {
+        "product_adapter": "vanilla_derivative"
+      },
+      "nodes": [
+        {
+          "kind": "economic_state",
+          "label": "Contract alive",
+          "metadata": {},
+          "node_id": "alive",
+          "state_variables": [
+            "S"
+          ],
+          "terminal": false
+        },
+        {
+          "kind": "terminal",
+          "label": "Expiry payoff",
+          "metadata": {},
+          "node_id": "expiry",
+          "state_variables": [],
+          "terminal": true
+        }
+      ],
+      "solver_hints": {
+        "benchmark_ids": [
+          "black-scholes-call-001"
+        ],
+        "error_budget": null,
+        "fallback_family": "fem",
+        "preferred_families": [
+          "exact",
+          "transform",
+          "fem"
+        ],
+        "required_outputs": [
+          "value",
+          "delta",
+          "gamma"
+        ]
+      },
+      "transitions": [
+        {
+          "intensity_id": null,
+          "metadata": {},
+          "payoff_formula": null,
+          "probability_formula": "t == T",
+          "source_node_id": "alive",
+          "target_node_id": "expiry",
+          "transition_id": "expiry"
+        }
+      ],
+      "version": "1.0"
+    }
+  },
+  "lineage_run_record": {
+    "lineage_id": "public-synthetic-option-lineage-v0",
+    "producer_repo": "googa27/haircut-engine",
+    "schema_owner": "Quant PDE Platform Evolutionary Architecture",
+    "source_issue_refs": [
+      "googa27/haircut-engine#103",
+      "googa27/finite_difference_options#76",
+      "googa27/finite_element_options#64"
+    ]
+  },
+  "mathematical_problem": {
+    "boundary_conditions": {
+      "S=0": "0",
+      "S=S_max": "linear growth"
+    },
+    "domain": {
+      "S": "[0, 400]",
+      "t": "[0, 1]"
+    },
+    "measure_id": "risk_neutral_money_market",
+    "numeraire_id": "money_market_account_CLP",
+    "objective": "price and Greeks",
+    "operator": "Black-Scholes parabolic PDE with constant volatility",
+    "state_variables": [
+      "S"
+    ],
+    "terminal_condition": "max(S-K,0)",
+    "time_variable": "t",
+    "units": {
+      "S": "CLP",
+      "rate": "ACT/365F annualized",
+      "t": "years",
+      "volatility": "annualized decimal"
+    }
+  },
+  "metadata": {
+    "fixture_kind": "public_synthetic",
+    "units": "dimensionless price inputs"
+  },
+  "privacy_class": "public_synthetic",
+  "problem_id": "public-synthetic-vanilla-call-v0",
+  "result_bundle": {
+    "benchmark_ids": [
+      "black-scholes-call-001"
+    ],
+    "diagnostics": {},
+    "status": "schema_only",
+    "values": {}
+  },
+  "schema_version": "quant-problem-spec/v0",
+  "solver_plan": {
+    "benchmark_ids": [
+      "black-scholes-call-001"
+    ],
+    "fallback_policy": "fail_closed",
+    "max_runtime_seconds": 30.0,
+    "preferred_families": [
+      "exact",
+      "finite_difference",
+      "finite_element"
+    ],
+    "required_outputs": [
+      "value",
+      "delta",
+      "gamma"
+    ],
+    "tolerance": 0.001
+  },
+  "title": "Public synthetic Black--Scholes European call",
+  "vintage": {
+    "calendar_id": "CL-business-following-public-synthetic-v1",
+    "convention_id": "CL-RAN21-10-CLP-ACT365F-FOLLOWING-v1",
+    "observation_date": "2026-06-30",
+    "valuation_date": "2026-06-30",
+    "vintage_date": "2026-06-30",
+    "vintage_id": "public-synthetic-2026-06-v0"
+  }
+}

--- a/tests/test_fd_backend_capabilities.py
+++ b/tests/test_fd_backend_capabilities.py
@@ -1,6 +1,7 @@
 """FD capability-manifest and unsupported-route diagnostics tests."""
 from __future__ import annotations
 
+import json
 import pathlib
 import sys
 
@@ -16,6 +17,9 @@ from src.contracts import (  # noqa: E402
     diagnose_unsupported_route,
     ensure_route_supported,
 )
+
+
+FIXTURE_DIR = pathlib.Path(__file__).parent / "fixtures" / "quant_problem_specs"
 
 
 def _supported_payload() -> dict[str, object]:
@@ -68,6 +72,28 @@ def test_quant_problem_spec_mapping_preserves_conventions_and_outputs() -> None:
     assert request.units == {"underlying": "USD", "time": "ACT/365F"}
     assert request.valuation_date == "2026-01-02"
     assert request.maturity_date == "2027-01-02"
+    assert diagnose_unsupported_route(request) == ()
+
+
+def test_haircut_engine_vanilla_call_fixture_maps_to_supported_fd_route() -> None:
+    """Consume the same public QuantProblemSpec fixture that Haircut Engine validates."""
+
+    payload = json.loads((FIXTURE_DIR / "vanilla_call.json").read_text())
+
+    request = FDRouteRequest.from_quant_problem_spec(payload)
+
+    assert request.source_schema_version == "quant-problem-spec/v0"
+    assert request.dimension == 1
+    assert request.grid_type == "uniform"
+    assert request.pde_terms == ("drift", "diffusion", "reaction")
+    assert request.boundary_conditions == ("dirichlet", "neumann")
+    assert request.boundary_details == {"S=0": "0", "S=S_max": "linear growth"}
+    assert request.requested_outputs == ("value", "delta", "gamma")
+    assert request.measure == "risk_neutral_money_market"
+    assert request.numeraire == "money_market_account_CLP"
+    assert request.units["S"] == "CLP"
+    assert request.valuation_date == "2026-06-30"
+    assert request.time_domain == "[0, 1]"
     assert diagnose_unsupported_route(request) == ()
 
 


### PR DESCRIPTION
Closes #76.
Closes googa27/finite_difference_options#76.

## Summary
- Extends `FDRouteRequest.from_quant_problem_spec()` to consume the actual Haircut Engine `QuantProblemSpec` v0 fixture shape.
- Vendors the public-synthetic `vanilla_call.json` fixture as a cross-repo data-contract fixture without importing Haircut Engine Python internals.
- Preserves schema version, measure, numeraire, units, valuation/time-domain convention, raw boundary details, normalized boundary capability classes, and required outputs before route support is claimed.

## Verification
```text
./.venv/bin/ruff check src/contracts/backend_capabilities.py tests/test_fd_backend_capabilities.py --select E9,F63,F7,F82,F401,F821,UP035
python3 -m compileall -q src tests
PYTHONPATH=$PWD ./.venv/bin/pytest -q tests/test_fd_backend_capabilities.py tests/test_fd_black_scholes_parity_fixture.py tests/architecture
PYTHONPATH=$PWD ./.venv/bin/pytest -q
git diff --check
```

Observed:
- Targeted adapter/parity/architecture: `19 passed`.
- Full suite: `127 passed, 1 xfailed`.
- `git diff --check`: clean.

## Risk / rollback
- Contract-only adapter/test/docs change; no numerical solver execution path changes.
- Rollback removes the vendored fixture, adapter shape extensions, and the regression test.
