### PR TITLE
docs: publish capability matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Unified Multi-Dimensional PDE Option Pricing Framework
 
-[![CI](https://github.com/PLACEHOLDER/finite_difference_options/actions/workflows/ci.yml/badge.svg)](https://github.com/PLACEHOLDER/finite_difference_options/actions/workflows/ci.yml)
+[![CI](https://github.com/googa27/finite_difference_options/actions/workflows/ci.yml/badge.svg)](https://github.com/googa27/finite_difference_options/actions/workflows/ci.yml)
 
-A comprehensive framework for pricing financial derivatives using finite difference methods to solve partial differential equations (PDEs). Supports both 1D and multi-dimensional stochastic processes through a unified interface.
+A finite-difference PDE framework for option-pricing experiments and backend-contract validation. Public capability claims are governed by [docs/CAPABILITY_MATRIX.md](docs/CAPABILITY_MATRIX.md); unsupported routes must fail closed rather than returning plausible placeholder values.
 
 ![PDE Solution Visualization](pde_solution_example.png)
 
@@ -52,7 +52,7 @@ pip install -r requirements.txt -r requirements-dev.txt
 
 ## Quick Start
 
-### Basic European Option Pricing
+### Validated Black-Scholes European call smoke example
 
 ```python
 import numpy as np
@@ -60,7 +60,7 @@ from src.processes import create_black_scholes_process
 from src.pricing import create_unified_european_call, create_unified_pricing_engine, create_log_grid
 
 # Create Black-Scholes process
-process = create_black_scholes_process(risk_free_rate=0.05, volatility=0.2)
+process = create_black_scholes_process(mu=0.05, sigma=0.2)
 
 # Create European call option
 option = create_unified_european_call(strike=100.0, maturity=0.25)
@@ -69,19 +69,23 @@ option = create_unified_european_call(strike=100.0, maturity=0.25)
 engine = create_unified_pricing_engine(process)
 
 # Create spatial grid
-grid = create_log_grid(s_min=50.0, s_max=150.0, n_points=101)
+grid = create_log_grid(s_min=50.0, s_max=150.0, n_points=101, center=100.0)
+times = np.linspace(0.0, option.maturity, 12)
 
 # Price the option
-prices = engine.price_option(option, grid)
-print(f"Option price at S=100: {prices[50]:.4f}")
+prices = engine.price_option(option, grid, time_grid=times)
+spot_idx = int(np.argmin(np.abs(grid - 100.0)))
+print(f"Option price at S=100: {prices[0, spot_idx]:.4f}")
 ```
 
-### Multi-Dimensional Heston Model
+### Heston stochastic-volatility smoke example
+
+This example is an experimental shape/finite-value smoke path for a vanilla equity call under Heston state `(spot, variance)`. It is not a basket option and is not advertised as a production Heston benchmark.
 
 ```python
 import numpy as np
 from src.processes import create_standard_heston
-from src.pricing import create_unified_european_call, create_unified_pricing_engine
+from src.pricing import create_unified_european_call, create_unified_pricing_engine, create_log_grid
 
 # Create Heston stochastic volatility model
 heston = create_standard_heston()
@@ -89,37 +93,20 @@ heston = create_standard_heston()
 # Create pricing engine for 2D process
 engine = create_unified_pricing_engine(heston)
 
-# Create option and grids
+# Create a vanilla call and model-state grids
 option = create_unified_european_call(strike=100.0, maturity=0.25)
-s_grid = np.linspace(50.0, 150.0, 51)   # Stock price grid
-v_grid = np.linspace(0.01, 0.5, 26)     # Volatility grid
+s_grid = create_log_grid(40.0, 220.0, 17, center=100.0)  # Stock price grid
+v_grid = np.linspace(0.01, 0.30, 8)                       # Variance grid
+times = np.linspace(0.0, option.maturity, 10)
 
 # Price with 2D process
-prices = engine.price_option(option, s_grid, v_grid)
+prices = engine.price_option(option, s_grid, v_grid, time_grid=times)
 print(f"2D Heston option prices shape: {prices.shape}")
 ```
 
-### Basket Options
+### Unsupported basket payoff route
 
-```python
-import numpy as np
-from src.processes import create_standard_heston
-from src.pricing import create_unified_basket_call, create_unified_pricing_engine
-
-# Multi-asset basket option
-strikes = np.array([100.0, 110.0])
-weights = np.array([0.6, 0.4])
-basket = create_unified_basket_call(strikes, weights, maturity=0.25)
-
-# Use 2D process for basket
-process = create_standard_heston()
-engine = create_unified_pricing_engine(process)
-
-# Price basket option
-s1_grid = np.linspace(80.0, 120.0, 21)
-s2_grid = np.linspace(90.0, 130.0, 21)
-prices = engine.price_option(basket, s1_grid, s2_grid)
-```
+Basket payoff routing is currently `unsupported` unless a true multi-asset process/factor map is supplied and validated. Heston variance is a volatility state, not a second tradable basket asset. See #62 and the capability matrix.
 
 ## Development
 
@@ -234,8 +221,9 @@ src/
 
 - **Mathematical Foundation**: [docs/explanation/black_scholes_fdm.md](docs/explanation/black_scholes_fdm.md)
 - **PDE Models**: [docs/explanation/pde_models.md](docs/explanation/pde_models.md)
-- **Regulatory Notes**: [docs/regulatory.md](docs/regulatory.md)
+- **Regulatory Notes**: [docs/compliance/regulatory.md](docs/compliance/regulatory.md)
 - **Architecture Decisions**: [docs/adr/](docs/adr/)
+- **Capability Matrix**: [docs/CAPABILITY_MATRIX.md](docs/CAPABILITY_MATRIX.md)
 - **Refactoring Summary**: [REFACTOR_SUMMARY.md](REFACTOR_SUMMARY.md)
 
 ## License

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -1,0 +1,33 @@
+# FD capability and maturity matrix
+
+This is the authoritative public status matrix for `finite_difference_options` until the package has a generated API-reference pipeline. A README example or application endpoint is not a production claim unless the route below is marked `production` or `validated` and cites evidence.
+
+Status vocabulary:
+
+- `production`: validated, documented, release-gated, and intended for external use.
+- `validated`: tested against a public oracle/fixture or regression gate, but not yet release-hardened.
+- `experimental`: implemented smoke path with known limitations and no production claim.
+- `scaffold`: API or placeholder exists but must not be selected for real valuation.
+- `unsupported`: fail closed; do not route or silently approximate.
+
+| Capability | Status | Evidence / benchmark ID | Notes |
+|---|---:|---|---|
+| 1D Black-Scholes European call value on uniform/log-uniform grids | `validated` | `BS-CALL-PARITY-V0`, `QPS-VANILLA-CALL-V0` | Public-synthetic analytical oracle and QuantProblemSpec fixture. |
+| 1D Black-Scholes Delta/Gamma from finite-difference price grids | `validated` | `BS-CALL-PARITY-V0` | Greeks share grid metadata; use only with validated value route. |
+| Rannacher startup before Crank-Nicolson for kinked payoffs | `validated` | `RANNACHER-GAMMA-V0` | Two/four Backward-Euler half-step schedules are explicit and recorded. |
+| Heston stochastic volatility vanilla call smoke route | `experimental` | `HESTON-SMOKE-DOCSTRING-V0` | Shape/finite-value smoke only; not a production benchmark or calibration claim. |
+| ADI multidimensional routes | `experimental` | `ADI-SMOKE-V0` | Mixed-derivative/reaction completeness remains tracked by #46. |
+| Basket option payoff on true multi-asset factors | `unsupported` | none | No validated basket option route exists yet; Heston variance/rate factors are not tradable basket assets; tracked by #62. |
+| American/free-boundary exercise | `unsupported` | none | Requires diagnosed LCP/complementarity implementation; tracked by #66. |
+| Jump/PIDE and HJB/control terms | `unsupported` | none | Capability manifest rejects these terms fail-closed. |
+| CRIF/CUSO/Basel/FRTB regulatory report endpoints | `scaffold` | none | Placeholder reporting must fail closed or carry versioned standards; tracked by #64. |
+| FastAPI/CLI/UI service contracts | `experimental` | `DOCS-README-SMOKE-V0` | Convenience interfaces only; numerical truth remains in the Python core. |
+
+Maintained documentation set:
+
+- Product requirements: `docs/PRD.md`
+- Architecture and migration map: `docs/ARCHITECTURE.md`
+- Capability matrix: this file
+- CI policy: `docs/CI_POLICY.md`
+
+Archived planning material under `docs/planning/` and `docs/archive/` is not a current capability source of truth.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -52,7 +52,7 @@ Cross-repository integration uses independently versioned wheels and fixtures, n
 | Backend consumer | Clean wheel, capability manifest and no private-module coupling |
 | Application developer | Thin clients over one public numerical API |
 
-Capabilities are `implemented`, `validated`, `production`, `experimental`, `proxy`, `deprecated` or `unsupported`. A unified facade, example or endpoint is not evidence of a validated numerical capability.
+Capabilities are `production`, `validated`, `experimental`, `scaffold`, `deprecated` or `unsupported`. `docs/CAPABILITY_MATRIX.md` is the authoritative current-status matrix; a unified facade, example or endpoint is not evidence of a validated numerical capability.
 
 ## 4. Functional requirements
 

--- a/tests/test_documentation_capabilities.py
+++ b/tests/test_documentation_capabilities.py
@@ -1,0 +1,68 @@
+"""Documentation maturity and README example safety tests."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from src.processes.affine import create_black_scholes_process, create_standard_heston
+from src.pricing import create_log_grid, create_unified_european_call, create_unified_pricing_engine
+
+ROOT = Path(__file__).resolve().parents[1]
+README = ROOT / "README.md"
+CAPABILITY_MATRIX = ROOT / "docs" / "CAPABILITY_MATRIX.md"
+
+
+def test_readme_has_live_links_and_no_placeholder_badges() -> None:
+    text = README.read_text(encoding="utf-8")
+
+    assert "PLACEHOLDER" not in text
+    assert "github.com/googa27/finite_difference_options/actions/workflows/ci.yml" in text
+    assert "docs/CAPABILITY_MATRIX.md" in text
+
+
+def test_capability_matrix_is_authoritative_and_cites_evidence_ids() -> None:
+    text = CAPABILITY_MATRIX.read_text(encoding="utf-8")
+
+    assert "# FD capability and maturity matrix" in text
+    for status in ["validated", "experimental", "unsupported"]:
+        assert f"`{status}`" in text
+    for evidence_id in ["BS-CALL-PARITY-V0", "RANNACHER-GAMMA-V0", "QPS-VANILLA-CALL-V0"]:
+        assert evidence_id in text
+    assert "Heston stochastic volatility" in text
+    assert "basket option" in text
+    assert "unsupported" in text
+
+
+def test_readme_black_scholes_quickstart_executes() -> None:
+    process = create_black_scholes_process(mu=0.05, sigma=0.2)
+    option = create_unified_european_call(strike=100.0, maturity=0.25)
+    engine = create_unified_pricing_engine(process)
+    grid = create_log_grid(s_min=50.0, s_max=150.0, n_points=101, center=100.0)
+    times = np.linspace(0.0, option.maturity, 12)
+
+    prices = engine.price_option(option, grid, time_grid=times)
+
+    assert prices.shape == (len(times), len(grid))
+    assert np.all(np.isfinite(prices))
+
+
+def test_readme_heston_example_is_not_a_basket_proxy() -> None:
+    text = README.read_text(encoding="utf-8")
+
+    heston_section = text.split("### Heston stochastic-volatility smoke example", maxsplit=1)[1].split(
+        "### Unsupported basket payoff route", maxsplit=1
+    )[0]
+    assert "create_unified_basket_call" not in heston_section
+
+    process = create_standard_heston(r=0.03, kappa=1.8, theta=0.05, sigma=0.35, rho=-0.35)
+    option = create_unified_european_call(strike=100.0, maturity=0.25)
+    engine = create_unified_pricing_engine(process)
+    s_grid = create_log_grid(40.0, 220.0, 17, center=100.0)
+    v_grid = np.linspace(0.01, 0.30, 8)
+    times = np.linspace(0.0, option.maturity, 10)
+
+    prices = engine.price_option(option, s_grid, v_grid, time_grid=times)
+
+    assert prices.shape == (len(times), len(s_grid), len(v_grid))
+    assert np.all(np.isfinite(prices))


### PR DESCRIPTION
Closes #54.

## Summary
- Replaces placeholder README CI badge with the live repository workflow link.
- Adds `docs/CAPABILITY_MATRIX.md` as the authoritative capability/maturity matrix.
- Cites evidence IDs for validated routes and marks unsupported/scaffold routes explicitly.
- Fixes README examples so Black-Scholes uses the real public API and Heston is documented as an experimental vanilla-call smoke route, not a basket proxy.
- Documents basket payoff routing as unsupported until a true multi-asset factor map is validated.
- Adds tests that fail on placeholder docs, missing matrix evidence IDs, and Heston-as-basket drift.

## Verification
```bash
git diff --check
.venv/bin/python -m pytest -q tests/test_documentation_capabilities.py tests/test_docstring_smoke.py tests/test_fd_backend_capabilities.py
.venv/bin/python -m compileall -q src tests
.venv/bin/ruff check tests/test_documentation_capabilities.py
.venv/bin/python -m pytest -q
```

Observed:
- Focused docs/capability suite: 13 passed.
- Full local test suite: 133 passed, 1 xfailed, 14 dependency warnings.
- compileall, Ruff, and diff whitespace gates passed.
