### PR TITLE
fix: fail closed regulatory reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,10 @@ Endpoints:
 - `POST /price` → `{ "price": float }`
 - `POST /greeks` → `{ "delta": float, "gamma": float, "theta": float }`
 - `POST /pde_solution` → Full 2D grids for prices and Greeks visualization
-- `POST /reports/crif` → `{ "crif": str }`
-- `POST /reports/cuso` → `{ "status": str }`
-- `POST /reports/basel` → `{ "status": str }`
-- `POST /reports/frtb` → `{ "status": str }`
+- `POST /reports/crif` → HTTP 501 problem detail until an exact ISDA CRIF profile/version and conformance suite are implemented
+- `POST /reports/cuso` → HTTP 501 problem detail until an authoritative CUSO specification is identified
+- `POST /reports/basel` → HTTP 501 problem detail until a versioned Basel market-risk subset is implemented
+- `POST /reports/frtb` → HTTP 501 problem detail until a versioned FRTB calculation subset is implemented
 
 ## Next.js Client
 

--- a/api/main.py
+++ b/api/main.py
@@ -9,13 +9,14 @@ from __future__ import annotations
 from typing import Optional
 
 import numpy as np
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from src.pricing import OptionPricer
 from src.risk import (
     Exposure,
+    NotImplementedForStandard,
     RiskFactor,
     Trade,
 )
@@ -185,16 +186,17 @@ class ExposureModel(BaseModel):
     amount: float
 
 
-class CRIFResponse(BaseModel):
-    """String payload for CRIF report output."""
+class RegulatoryNotImplementedResponse(BaseModel):
+    """Machine-readable failure for disabled regulatory/reporting routes."""
 
-    crif: str
+    detail: dict
 
 
-class PlaceholderResponse(BaseModel):
-    """Generic response wrapper for non-production reporting stubs."""
+def _raise_regulatory_not_implemented(error: NotImplementedForStandard) -> None:
+    """Convert internal regulatory failures to HTTP 501 problem details."""
 
-    status: str
+    detail = error.to_problem_detail()
+    raise HTTPException(status_code=detail["http_status"], detail=detail) from error
 
 
 def _convert_exposures(models: list[ExposureModel]) -> list[Exposure]:
@@ -202,49 +204,53 @@ def _convert_exposures(models: list[ExposureModel]) -> list[Exposure]:
 
     return [
         Exposure(
-            trade=Trade(**m.trade.dict()),
-            risk_factor=RiskFactor(**m.risk_factor.dict()),
+            trade=Trade(**m.trade.model_dump()),
+            risk_factor=RiskFactor(**m.risk_factor.model_dump()),
             amount=m.amount,
         )
         for m in models
     ]
 
 
-@app.post("/reports/crif", response_model=CRIFResponse)
-def crif_report(exposures: list[ExposureModel]) -> CRIFResponse:
-    """Generate a CRIF report for the provided exposures.
-
-    Inputs are converted from API models to internal domain objects before
-    invoking the configured report strategy.
-    """
+@app.post("/reports/crif", response_model=RegulatoryNotImplementedResponse)
+def crif_report(exposures: list[ExposureModel]) -> None:
+    """Fail closed until an exact ISDA CRIF profile and conformance suite exist."""
 
     strategy = ReportFactory.get_strategy("crif")
-    crif = strategy.generate_report(_convert_exposures(exposures))
-    return CRIFResponse(**crif)
+    try:
+        strategy.generate_report(_convert_exposures(exposures))
+    except NotImplementedForStandard as exc:
+        _raise_regulatory_not_implemented(exc)
 
 
-@app.post("/reports/cuso", response_model=PlaceholderResponse)
-def cuso_report(exposures: list[ExposureModel]) -> PlaceholderResponse:
-    """Return placeholder CUSO report from the active strategy adapter."""
+@app.post("/reports/cuso", response_model=RegulatoryNotImplementedResponse)
+def cuso_report(exposures: list[ExposureModel]) -> None:
+    """Fail closed until an authoritative CUSO specification exists."""
 
     strategy = ReportFactory.get_strategy("cuso")
-    data = strategy.generate_report(_convert_exposures(exposures))
-    return PlaceholderResponse(**data)
+    try:
+        strategy.generate_report(_convert_exposures(exposures))
+    except NotImplementedForStandard as exc:
+        _raise_regulatory_not_implemented(exc)
 
 
-@app.post("/reports/basel", response_model=PlaceholderResponse)
-def basel_report(exposures: list[ExposureModel]) -> PlaceholderResponse:
-    """Return placeholder Basel report from the active strategy adapter."""
+@app.post("/reports/basel", response_model=RegulatoryNotImplementedResponse)
+def basel_report(exposures: list[ExposureModel]) -> None:
+    """Fail closed until a versioned Basel market-risk subset is implemented."""
 
     strategy = ReportFactory.get_strategy("basel")
-    data = strategy.generate_report(_convert_exposures(exposures))
-    return PlaceholderResponse(**data)
+    try:
+        strategy.generate_report(_convert_exposures(exposures))
+    except NotImplementedForStandard as exc:
+        _raise_regulatory_not_implemented(exc)
 
 
-@app.post("/reports/frtb", response_model=PlaceholderResponse)
-def frtb_report(exposures: list[ExposureModel]) -> PlaceholderResponse:
-    """Placeholder FRTB report endpoint."""
+@app.post("/reports/frtb", response_model=RegulatoryNotImplementedResponse)
+def frtb_report(exposures: list[ExposureModel]) -> None:
+    """Fail closed until a versioned FRTB calculation subset is implemented."""
 
     strategy = ReportFactory.get_strategy("frtb")
-    data = strategy.generate_report(_convert_exposures(exposures))
-    return PlaceholderResponse(**data)
+    try:
+        strategy.generate_report(_convert_exposures(exposures))
+    except NotImplementedForStandard as exc:
+        _raise_regulatory_not_implemented(exc)

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -20,7 +20,7 @@ Status vocabulary:
 | Basket option payoff on true multi-asset factors | `unsupported` | none | No validated basket option route exists yet; Heston variance/rate factors are not tradable basket assets; tracked by #62. |
 | American/free-boundary exercise | `unsupported` | none | Requires diagnosed LCP/complementarity implementation; tracked by #66. |
 | Jump/PIDE and HJB/control terms | `unsupported` | none | Capability manifest rejects these terms fail-closed. |
-| CRIF/CUSO/Basel/FRTB regulatory report endpoints | `scaffold` | none | Placeholder reporting must fail closed or carry versioned standards; tracked by #64. |
+| CRIF/CUSO/Basel/FRTB regulatory report endpoints | `scaffold` | `REG-FAIL-CLOSED-V0` | Endpoints and Python strategy/converter entry points return typed HTTP 501 / `NotImplementedForStandard` metadata until exact standard/profile/version, effective date, jurisdiction, licensing status, and conformance fixtures exist. |
 | FastAPI/CLI/UI service contracts | `experimental` | `DOCS-README-SMOKE-V0` | Convenience interfaces only; numerical truth remains in the Python core. |
 
 Maintained documentation set:

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -118,7 +118,7 @@ Inventory legacy and newer pricers, processes, boundaries, Greeks and solvers. E
 
 ### FR-FD-014 — Optional applications
 
-CLI, FastAPI, Streamlit, plotting and Next.js are separately tested applications over the installed package. They are not core dependencies or alternate numerical implementations. Frontend and service contracts have independent locks and CI.
+CLI, FastAPI, Streamlit, plotting and Next.js are separately tested applications over the installed package. They are not core dependencies or alternate numerical implementations. Frontend and service contracts have independent locks and CI. Regulatory/reporting service routes must return HTTP 501 problem details unless the route declares an exact standard/profile/version, effective date, jurisdiction, licensing status and conformance fixture set.
 
 ## 5. Non-functional requirements
 

--- a/src/risk/__init__.py
+++ b/src/risk/__init__.py
@@ -2,7 +2,7 @@
 
 This package contains risk calculation functionality for the unified pricing framework.
 """
-from ..risk.models import Exposure, RiskFactor, Trade
+from ..risk.models import Exposure, NotImplementedForStandard, RegulatoryStandard, RiskFactor, Trade
 from ..risk.converters import (
     exposures_to_crif,
     calculate_cuso,
@@ -14,6 +14,8 @@ __all__ = [
     "Trade",
     "RiskFactor",
     "Exposure",
+    "NotImplementedForStandard",
+    "RegulatoryStandard",
     "exposures_to_crif",
     "calculate_cuso",
     "calculate_basel",

--- a/src/risk/converters.py
+++ b/src/risk/converters.py
@@ -1,32 +1,91 @@
-"""Risk data converters for regulatory reporting formats."""
+"""Risk data converters for regulatory reporting formats.
 
-from typing import List, Dict, Any
-from .models import Exposure
+These functions are retained as compatibility entry points, but all named
+regulatory routes fail closed until an exact standard/profile/version and a
+complete conformance suite exist. They deliberately do not emit toy multipliers,
+partial CRIF-like rows, or success dictionaries.
+"""
+from __future__ import annotations
+
+from typing import NoReturn
+
+from .models import Exposure, NotImplementedForStandard, RegulatoryStandard
+
+REGULATORY_STANDARDS: dict[str, RegulatoryStandard] = {
+    "crif": RegulatoryStandard(
+        route="crif",
+        standard_id="ISDA-CRIF-UNSPECIFIED",
+        display_name="ISDA Common Risk Interchange Format",
+        capability_status="scaffold",
+        licensing_status="not-evaluated",
+        reason=(
+            "CRIF export is disabled because no exact ISDA CRIF profile/version, licensing status, "
+            "field order, casing policy, extension-field policy, or golden conformance fixtures are configured."
+        ),
+    ),
+    "cuso": RegulatoryStandard(
+        route="cuso",
+        standard_id="CUSO-UNSPECIFIED-NO-AUTHORITATIVE-SPEC",
+        display_name="CUSO regulatory/reporting route",
+        capability_status="unsupported",
+        licensing_status="no-authoritative-specification",
+        reason=(
+            "CUSO is disabled because no authoritative specification, owner, jurisdiction, or field contract has "
+            "been identified. The route cannot infer a regulatory definition from the acronym."
+        ),
+    ),
+    "basel": RegulatoryStandard(
+        route="basel",
+        standard_id="BCBS-MAR21-UNSPECIFIED",
+        display_name="Basel Framework market-risk standardised approach",
+        capability_status="scaffold",
+        licensing_status="not-evaluated",
+        reason=(
+            "Basel/FRTB calculation is disabled because no exact framework chapter/version/effective date, "
+            "risk-class subset, risk weights, correlations, rounding policy, or reconciliation fixture is configured."
+        ),
+    ),
+    "frtb": RegulatoryStandard(
+        route="frtb",
+        standard_id="BCBS-FRTB-UNSPECIFIED",
+        display_name="Fundamental Review of the Trading Book capital calculation",
+        capability_status="scaffold",
+        licensing_status="not-evaluated",
+        reason=(
+            "FRTB calculation is disabled because no exact standard/version/effective date, risk-class subset, "
+            "risk weights, correlations, scenario rules, or reconciliation fixture is configured."
+        ),
+    ),
+}
 
 
-def exposures_to_crif(exposures: List[Exposure]) -> List[Dict[str, Any]]:
-    """Convert exposures to CRIF (Common Risk Interchange Format)."""
-    return [
-        {
-            "trade_id": exp.trade_id,
-            "risk_factor": exp.risk_factor.name,
-            "sensitivity": exp.sensitivity,
-            "description": exp.description or "",
-        }
-        for exp in exposures
-    ]
+def _raise_not_implemented(route: str) -> NoReturn:
+    raise NotImplementedForStandard(REGULATORY_STANDARDS[route])
 
 
-def calculate_cuso(exposures: List[Exposure]) -> Dict[str, float]:
-    """Calculate CUSO (Credit Unit Specific Offset) metrics."""
-    return {"total_exposure": sum(exp.sensitivity for exp in exposures)}
+def exposures_to_crif(exposures: list[Exposure]) -> NoReturn:
+    """Fail closed instead of emitting partial CRIF-like records."""
+
+    _ = exposures
+    _raise_not_implemented("crif")
 
 
-def calculate_basel(exposures: List[Exposure]) -> Dict[str, float]:
-    """Calculate Basel regulatory capital metrics."""
-    return {"risk_weighted_assets": sum(abs(exp.sensitivity) * 1.2 for exp in exposures)}
+def calculate_cuso(exposures: list[Exposure]) -> NoReturn:
+    """Fail closed because no authoritative CUSO standard is configured."""
+
+    _ = exposures
+    _raise_not_implemented("cuso")
 
 
-def calculate_frtb(exposures: List[Exposure]) -> Dict[str, float]:
-    """Calculate FRTB (Fundamental Review of Trading Book) metrics."""
-    return {"market_risk_capital": sum(abs(exp.sensitivity) * 0.8 for exp in exposures)}
+def calculate_basel(exposures: list[Exposure]) -> NoReturn:
+    """Fail closed instead of returning scalar placeholder Basel capital."""
+
+    _ = exposures
+    _raise_not_implemented("basel")
+
+
+def calculate_frtb(exposures: list[Exposure]) -> NoReturn:
+    """Fail closed instead of returning scalar placeholder FRTB capital."""
+
+    _ = exposures
+    _raise_not_implemented("frtb")

--- a/src/risk/models.py
+++ b/src/risk/models.py
@@ -1,8 +1,35 @@
 """Data models for regulatory risk reporting."""
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import Any, Literal, Optional
+
+CapabilityStatus = Literal["production", "validated", "experimental", "scaffold", "unsupported"]
+
+REQUIRED_REGULATORY_CONTRACT_FIELDS: tuple[str, ...] = (
+    "trade_id",
+    "portfolio_id",
+    "legal_entity_id",
+    "source_system",
+    "value_date",
+    "reporting_currency",
+    "amount_currency",
+    "amount_unit",
+    "risk_class",
+    "risk_type",
+    "qualifier",
+    "bucket",
+    "label_1",
+    "label_2",
+    "tenor",
+    "curve",
+    "jurisdiction",
+    "standard_profile",
+    "standard_version",
+    "effective_date",
+    "methodology_version",
+    "input_contract_hash",
+)
 
 
 @dataclass
@@ -32,3 +59,58 @@ class Exposure:
     trade: Trade
     risk_factor: RiskFactor
     amount: float
+
+
+@dataclass(frozen=True)
+class RegulatoryStandard:
+    """Declared status for a regulatory/reporting route.
+
+    The route is intentionally not executable unless an exact standard/profile,
+    version, effective date, jurisdiction, licensing status, and complete input
+    contract are supplied by a future implementation.
+    """
+
+    route: str
+    standard_id: str
+    display_name: str
+    capability_status: CapabilityStatus
+    reason: str
+    profile: str = "not-selected"
+    version: str = "not-selected"
+    effective_date: str = "not-selected"
+    jurisdiction: str = "not-selected"
+    licensing_status: str = "not-evaluated"
+    required_contract_fields: tuple[str, ...] = field(default_factory=lambda: REQUIRED_REGULATORY_CONTRACT_FIELDS)
+
+    def to_problem_detail(self) -> dict[str, Any]:
+        """Return RFC-7807-like machine-readable failure details."""
+
+        return {
+            "type": "https://googa27.github.io/finite_difference_options/problems/regulatory-standard-not-implemented",
+            "title": "Regulatory/reporting route is not implemented for a declared standard",
+            "http_status": 501,
+            "route": self.route,
+            "standard_id": self.standard_id,
+            "display_name": self.display_name,
+            "capability_status": self.capability_status,
+            "profile": self.profile,
+            "version": self.version,
+            "effective_date": self.effective_date,
+            "jurisdiction": self.jurisdiction,
+            "licensing_status": self.licensing_status,
+            "required_contract_fields": list(self.required_contract_fields),
+            "reason": self.reason,
+        }
+
+
+class NotImplementedForStandard(RuntimeError):
+    """Raised when a regulatory route lacks a conformance-backed standard."""
+
+    def __init__(self, standard: RegulatoryStandard):
+        self.standard = standard
+        super().__init__(standard.reason)
+
+    def to_problem_detail(self) -> dict[str, Any]:
+        """Return serialisable problem details for API and tests."""
+
+        return self.standard.to_problem_detail()

--- a/src/risk/reporting_strategies.py
+++ b/src/risk/reporting_strategies.py
@@ -1,65 +1,84 @@
-from abc import ABC, abstractmethod
-import csv
-import io
-from typing import Iterable
+"""Regulatory report strategy registry.
 
-from src.risk.models import Exposure
+The public strategy names are kept for API compatibility, but every regulatory
+route currently fails closed through :class:`NotImplementedForStandard` until a
+versioned standard/profile and conformance suite are implemented.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Iterable
+from typing import NoReturn
+
+from src.risk.converters import REGULATORY_STANDARDS
+from src.risk.models import Exposure, NotImplementedForStandard
 
 
 class ReportStrategy(ABC):
     """Abstract base class for regulatory report generation strategies."""
 
     @abstractmethod
-    def generate_report(self, exposures: Iterable[Exposure]) -> dict:
-        """Generate a regulatory report from a list of exposures."""
-        pass
+    def generate_report(self, exposures: Iterable[Exposure]) -> NoReturn:
+        """Generate a regulatory report or fail closed before producing output."""
+
+        _ = exposures
+        raise NotImplementedError
+
+class UnsupportedRegulatoryReportStrategy(ReportStrategy):
+    """Fail-closed strategy for a named but unimplemented regulatory route."""
+
+    def __init__(self, report_type: str):
+        self.report_type = report_type
+
+    def generate_report(self, exposures: Iterable[Exposure]) -> NoReturn:
+        """Raise typed metadata instead of returning a partial/success payload."""
+
+        _ = list(exposures)
+        raise NotImplementedForStandard(REGULATORY_STANDARDS[self.report_type])
 
 
-class CRIFReportStrategy(ReportStrategy):
-    """Strategy for generating CRIF reports."""
+class CRIFReportStrategy(UnsupportedRegulatoryReportStrategy):
+    """CRIF scaffold: disabled until an exact ISDA CRIF profile is implemented."""
 
-    def generate_report(self, exposures: Iterable[Exposure]) -> dict:
-        output = io.StringIO()
-        writer = csv.writer(output)
-        writer.writerow(["TradeId", "RiskFactor", "Amount"])
-        for exp in exposures:
-            writer.writerow([exp.trade.trade_id, exp.risk_factor.name, exp.amount])
-        return {"crif": output.getvalue()}
+    def __init__(self) -> None:
+        super().__init__("crif")
 
 
-class CUSOReportStrategy(ReportStrategy):
-    """Strategy for generating CUSO reports (placeholder)."""
+class CUSOReportStrategy(UnsupportedRegulatoryReportStrategy):
+    """CUSO route: unsupported until an authoritative specification exists."""
 
-    def generate_report(self, exposures: Iterable[Exposure]) -> dict:
-        return {"status": "CUSO calculation not implemented"}
-
-
-class BaselReportStrategy(ReportStrategy):
-    """Strategy for generating Basel reports (placeholder)."""
-
-    def generate_report(self, exposures: Iterable[Exposure]) -> dict:
-        return {"status": "Basel calculation not implemented"}
+    def __init__(self) -> None:
+        super().__init__("cuso")
 
 
-class FRTBReportStrategy(ReportStrategy):
-    """Strategy for generating FRTB reports (placeholder)."""
+class BaselReportStrategy(UnsupportedRegulatoryReportStrategy):
+    """Basel route: disabled until a versioned Basel/FRTB subset is implemented."""
 
-    def generate_report(self, exposures: Iterable[Exposure]) -> dict:
-        return {"status": "FRTB calculation not implemented"}
+    def __init__(self) -> None:
+        super().__init__("basel")
+
+
+class FRTBReportStrategy(UnsupportedRegulatoryReportStrategy):
+    """FRTB route: disabled until a versioned calculation subset is implemented."""
+
+    def __init__(self) -> None:
+        super().__init__("frtb")
 
 
 class ReportFactory:
-    """Factory for creating ReportStrategy instances."""
+    """Factory for creating report strategy instances."""
 
     @staticmethod
     def get_strategy(report_type: str) -> ReportStrategy:
-        if report_type == "crif":
-            return CRIFReportStrategy()
-        elif report_type == "cuso":
-            return CUSOReportStrategy()
-        elif report_type == "basel":
-            return BaselReportStrategy()
-        elif report_type == "frtb":
-            return FRTBReportStrategy()
-        else:
-            raise ValueError(f"Unknown report type: {report_type}")
+        """Return a named strategy or reject unknown report types."""
+
+        strategies: dict[str, type[ReportStrategy]] = {
+            "crif": CRIFReportStrategy,
+            "cuso": CUSOReportStrategy,
+            "basel": BaselReportStrategy,
+            "frtb": FRTBReportStrategy,
+        }
+        try:
+            return strategies[report_type]()
+        except KeyError as exc:
+            raise ValueError(f"Unknown report type: {report_type}") from exc

--- a/tests/test_regulatory_fail_closed.py
+++ b/tests/test_regulatory_fail_closed.py
@@ -1,0 +1,99 @@
+"""Fail-closed tests for regulatory-reporting placeholder routes."""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+from src.risk import Exposure, RiskFactor, Trade
+from src.risk.converters import calculate_basel, calculate_cuso, calculate_frtb, exposures_to_crif
+from src.risk.models import NotImplementedForStandard
+from src.risk.reporting_strategies import ReportFactory
+
+
+def _sample_exposures() -> list[Exposure]:
+    return [
+        Exposure(
+            trade=Trade(trade_id="T-1", product_type="IRS", notional=1_000_000.0, currency="USD"),
+            risk_factor=RiskFactor(name="USD-SOFR-5Y", value=0.042),
+            amount=12_345.67,
+        )
+    ]
+
+
+def _sample_payload() -> list[dict]:
+    return [
+        {
+            "trade": {
+                "trade_id": "T-1",
+                "product_type": "IRS",
+                "notional": 1_000_000.0,
+                "currency": "USD",
+            },
+            "risk_factor": {"name": "USD-SOFR-5Y", "value": 0.042},
+            "amount": 12_345.67,
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ("name", "function"),
+    [
+        ("crif", exposures_to_crif),
+        ("cuso", calculate_cuso),
+        ("basel", calculate_basel),
+        ("frtb", calculate_frtb),
+    ],
+)
+def test_regulatory_converters_raise_typed_not_implemented_instead_of_placeholder_results(name, function) -> None:
+    with pytest.raises(NotImplementedForStandard) as exc_info:
+        function(_sample_exposures())
+
+    detail = exc_info.value.to_problem_detail()
+    assert detail["route"] == name
+    assert detail["http_status"] == 501
+    assert detail["capability_status"] in {"scaffold", "unsupported"}
+    assert detail["standard_id"]
+    assert detail["profile"] == "not-selected"
+    assert detail["version"] == "not-selected"
+    assert detail["effective_date"] == "not-selected"
+    assert detail["jurisdiction"] == "not-selected"
+    assert detail["licensing_status"] in {"not-evaluated", "no-authoritative-specification"}
+    assert detail["required_contract_fields"]
+    assert "placeholder" not in repr(detail).lower()
+
+
+@pytest.mark.parametrize("report_type", ["crif", "cuso", "basel", "frtb"])
+def test_report_strategies_fail_closed_instead_of_success_dictionaries(report_type: str) -> None:
+    strategy = ReportFactory.get_strategy(report_type)
+
+    with pytest.raises(NotImplementedForStandard) as exc_info:
+        strategy.generate_report(_sample_exposures())
+
+    detail = exc_info.value.to_problem_detail()
+    assert detail["route"] == report_type
+    assert "status" not in detail
+    assert "crif" not in detail
+    assert "risk_weighted_assets" not in detail
+    assert "market_risk_capital" not in detail
+    assert "total_exposure" not in detail
+
+
+@pytest.mark.parametrize("report_type", ["crif", "cuso", "basel", "frtb"])
+def test_report_api_routes_return_http_501_with_standard_metadata(report_type: str) -> None:
+    client = TestClient(app)
+
+    response = client.post(f"/reports/{report_type}", json=_sample_payload())
+
+    assert response.status_code == 501
+    body = response.json()
+    detail = body["detail"]
+    assert detail["route"] == report_type
+    assert detail["http_status"] == 501
+    assert detail["standard_id"]
+    assert detail["capability_status"] in {"scaffold", "unsupported"}
+    assert detail["profile"] == "not-selected"
+    assert detail["version"] == "not-selected"
+    assert detail["required_contract_fields"]
+    assert "crif" not in body
+    assert "status" not in body


### PR DESCRIPTION
Closes #64.

## Summary
- Adds typed `RegulatoryStandard` / `NotImplementedForStandard` metadata for regulatory-reporting routes.
- Replaces CRIF/CUSO/Basel/FRTB placeholder converters and report strategies with fail-closed behavior.
- Changes `/reports/{crif,cuso,basel,frtb}` to HTTP 501 problem details instead of success-looking CSV/status/scalar outputs.
- Records required standard metadata fields: profile, version, effective date, jurisdiction, licensing status, and required input-contract fields.
- Updates README/PRD/capability matrix with `REG-FAIL-CLOSED-V0` evidence.
- Adds regression tests for converters, strategies, and API endpoints.

## Adversarial review
- Independent re-review: no blockers.

## Verification
```bash
git diff --check
.venv/bin/python -m pytest -q tests/test_regulatory_fail_closed.py tests/test_documentation_capabilities.py tests/architecture/test_architecture_contracts.py
.venv/bin/python -m compileall -q api src tests
.venv/bin/ruff check api/main.py src/risk tests/test_regulatory_fail_closed.py
.venv/bin/python -m pytest -q
```

Observed:
- Focused issue64 suite: 22 passed.
- Full local suite: 145 passed, 1 xfailed, 14 dependency warnings.
- compileall, Ruff, and diff whitespace gates passed.
