### PR TITLE
feat: add process generator contracts

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -225,7 +225,7 @@ Validation checks finite monotone coordinates, minimum node count, spacing ratio
 
 ## 10. Differential operators
 
-Operators are constructed from explicit grid and coefficient records. Each derivative declares order, local stencil, boundary closure and bias.
+Operators are constructed from explicit grid and coefficient records. Process objects expose an executable generator contract with a single normalized coefficient convention: `evaluate_coefficients(t, x)` returns batched `states (n,d)`, `drift (n,d)`, `covariance (n,d,d)`, and `discount (n,)` even when the caller supplies one state point. Exact affine covariance, when available, uses the tensor form `a(x,t)=a0(t)+sum_k x_k a_k(t)` through `AffineCovarianceForm`; models whose native covariance is quadratic/bilinear in the declared state fail closed instead of advertising an inexact affine form. Generator application uses `0.5 tr(a Hessian)+b·grad-c value+source`, with discount supplied explicitly and never inferred from drift. Each derivative declares order, local stencil, boundary closure and bias.
 
 Rules:
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -72,7 +72,7 @@ Uniform, nonuniform, transformed and multidimensional tensor grids have typed re
 
 ### FR-FD-004 — Differential operators
 
-First, second and mixed derivative operators declare stencil order, local-spacing assumptions, upwind/central bias, boundary closure and coordinate transform. Variable coefficients are evaluated at the correct locations. Consistency, dimensions, sparsity and signs are tested independently of products.
+First, second and mixed derivative operators declare stencil order, local-spacing assumptions, upwind/central bias, boundary closure and coordinate transform. Variable coefficients are evaluated at the correct locations. Consistency, dimensions, sparsity and signs are tested independently of products. Process-level generator contracts provide canonical batched drift/covariance/discount shapes, validated exact affine covariance tensors, PSD diagnostics and explicit generator application to polynomial fixtures. Inexact affine-covariance claims fail closed for quadratic/bilinear native covariances. Discount/reaction is an independent field and is never inferred from drift.
 
 ### FR-FD-005 — Boundary conditions
 

--- a/src/processes/__init__.py
+++ b/src/processes/__init__.py
@@ -4,7 +4,16 @@ This package contains all stochastic process implementations organized by type.
 """
 
 # Base classes
-from .base import StochasticProcess, AffineProcess, NonAffineProcess, ProcessDimension, ProcessType
+from .base import (
+    AffineCovarianceForm,
+    AffineProcess,
+    CovarianceValidationResult,
+    NonAffineProcess,
+    ProcessCoefficientEvaluation,
+    ProcessDimension,
+    ProcessType,
+    StochasticProcess,
+)
 
 # Affine processes
 from .affine import (
@@ -28,8 +37,9 @@ from .nonaffine import (
 
 __all__ = [
     # Base classes
-    'StochasticProcess', 'AffineProcess', 'NonAffineProcess', 
-    'ProcessDimension', 'ProcessType',
+    "StochasticProcess", "AffineProcess", "NonAffineProcess",
+    "AffineCovarianceForm", "CovarianceValidationResult", "ProcessCoefficientEvaluation",
+    "ProcessDimension", "ProcessType",
     
     # Affine processes
     'GeometricBrownianMotion', 'OrnsteinUhlenbeck', 'CoxIngersollRoss', 'HestonModel',

--- a/src/processes/base.py
+++ b/src/processes/base.py
@@ -12,6 +12,7 @@ State coordinates are represented as NumPy arrays and validated against
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from enum import Enum
 from typing import Tuple
 import numpy as np
@@ -89,6 +90,83 @@ class ProcessType(Enum):
     """Enumeration of process types for optimization purposes."""
     AFFINE = "affine"
     NON_AFFINE = "non_affine"
+
+
+@dataclass(frozen=True)
+class ProcessCoefficientEvaluation:
+    """Canonical batched coefficient evaluation for a stochastic process."""
+
+    time: float
+    states: NDArray[np.float64]
+    is_single_point: bool
+    drift: NDArray[np.float64]
+    covariance: NDArray[np.float64]
+    discount: NDArray[np.float64]
+
+
+@dataclass(frozen=True)
+class CovarianceValidationResult:
+    """Diagnostics for covariance symmetry and PSD validation."""
+
+    min_eigenvalue: float
+    max_asymmetry: float
+    batch_size: int
+
+
+@dataclass(frozen=True)
+class AffineCovarianceForm:
+    r"""Affine covariance tensor ``a(x,t)=a0(t)+sum_k x_k a_k(t)``."""
+
+    constant: NDArray[np.float64]
+    linear: NDArray[np.float64]
+
+    def __post_init__(self) -> None:
+        constant = np.asarray(self.constant, dtype=float)
+        linear = np.asarray(self.linear, dtype=float)
+        if constant.ndim != 2 or constant.shape[0] != constant.shape[1]:
+            raise ValidationError(
+                "constant affine covariance term must be a square matrix, "
+                f"got shape {constant.shape}"
+            )
+        dimension = constant.shape[0]
+        if linear.shape != (dimension, dimension, dimension):
+            raise ValidationError(
+                "linear affine covariance tensor must have shape "
+                f"({dimension}, {dimension}, {dimension}), got {linear.shape}"
+            )
+        if not np.allclose(constant, constant.T, rtol=1e-10, atol=1e-12):
+            raise ValidationError("constant affine covariance term must be symmetric")
+        if not np.allclose(linear, np.swapaxes(linear, -1, -2), rtol=1e-10, atol=1e-12):
+            raise ValidationError("linear affine covariance tensor slices must be symmetric")
+        object.__setattr__(self, "constant", constant)
+        object.__setattr__(self, "linear", linear)
+
+    @classmethod
+    def from_coefficients(
+        cls,
+        constant: NDArray[np.float64],
+        linear: NDArray[np.float64],
+    ) -> "AffineCovarianceForm":
+        """Build and validate an affine covariance form from raw coefficients."""
+
+        constant_array = np.asarray(constant, dtype=float)
+        linear_array = np.asarray(linear, dtype=float)
+        if constant_array.shape == (1, 1) and linear_array.shape == (1, 1):
+            linear_array = linear_array.reshape(1, 1, 1)
+        return cls(constant=constant_array, linear=linear_array)
+
+    def evaluate(self, state: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Evaluate the affine tensor at one or more state points."""
+
+        states = ensure_state_array(state)
+        if states.ndim == 1:
+            states = states.reshape(1, -1)
+        if states.ndim != 2 or states.shape[1] != self.linear.shape[0]:
+            raise ValidationError(
+                "state for affine covariance evaluation must have shape "
+                f"(n, {self.linear.shape[0]}), got {states.shape}"
+            )
+        return self.constant[None, :, :] + np.einsum("nk,kij->nij", states, self.linear)
 
 
 class StochasticProcess(ABC):
@@ -184,7 +262,163 @@ class StochasticProcess(ABC):
         """
         state = ensure_state_array(state)
         validate_state_dimensions(state, self.dimension.value, self.__class__.__name__)
-    
+
+    def _canonical_state_batch(
+        self,
+        state: NDArray[np.float64],
+    ) -> tuple[NDArray[np.float64], NDArray[np.float64], bool]:
+        """Return ``(original_state, batched_state, is_single_point)``."""
+
+        original = ensure_state_array(state)
+        self.validate_state(original)
+        is_single_point = original.ndim == 1
+        states = original.reshape(1, -1) if is_single_point else original
+        if not np.all(np.isfinite(states)):
+            raise ValidationError(f"{self.__class__.__name__} state contains non-finite values")
+        return original, states, is_single_point
+
+    def discount(self, time: float, state: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Return the reaction/discount field ``c(t,x)``.
+
+        The base process contract deliberately defaults to zero discount. A
+        pricing adapter must pass an explicit curve/rate when the PDE includes a
+        reaction term; it is never inferred from drift.
+        """
+
+        _ = time
+        _, states, _ = self._canonical_state_batch(state)
+        return np.zeros(states.shape[0], dtype=float)
+
+    def _normalise_vector_field(
+        self,
+        values: NDArray[np.float64],
+        field_name: str,
+        batch_size: int,
+    ) -> NDArray[np.float64]:
+        dimension = self.dimension.value
+        array = np.asarray(values, dtype=float)
+        if array.shape == (dimension,):
+            array = array.reshape(1, dimension)
+        if array.shape != (batch_size, dimension):
+            raise ValidationError(
+                f"{field_name} must have shape ({batch_size}, {dimension}) after batching, got {array.shape}"
+            )
+        if not np.all(np.isfinite(array)):
+            raise ValidationError(f"{field_name} contains non-finite values")
+        return array
+
+    def _normalise_matrix_field(
+        self,
+        values: NDArray[np.float64],
+        field_name: str,
+        batch_size: int,
+    ) -> NDArray[np.float64]:
+        dimension = self.dimension.value
+        array = np.asarray(values, dtype=float)
+        if array.shape == (dimension, dimension):
+            array = array.reshape(1, dimension, dimension)
+        if array.shape != (batch_size, dimension, dimension):
+            raise ValidationError(
+                f"{field_name} must have shape ({batch_size}, {dimension}, {dimension}) after batching, "
+                f"got {array.shape}"
+            )
+        if not np.all(np.isfinite(array)):
+            raise ValidationError(f"{field_name} contains non-finite values")
+        return array
+
+    @staticmethod
+    def _normalise_scalar_field(
+        values: NDArray[np.float64] | float,
+        field_name: str,
+        batch_size: int,
+    ) -> NDArray[np.float64]:
+        array = np.asarray(values, dtype=float)
+        if array.ndim == 0:
+            array = np.full(batch_size, float(array), dtype=float)
+        elif array.shape == (1,) and batch_size != 1:
+            array = np.full(batch_size, float(array[0]), dtype=float)
+        if array.shape != (batch_size,):
+            raise ValidationError(f"{field_name} must have shape ({batch_size},), got {array.shape}")
+        if not np.all(np.isfinite(array)):
+            raise ValidationError(f"{field_name} contains non-finite values")
+        return array
+
+    def evaluate_coefficients(
+        self,
+        time: float,
+        state: NDArray[np.float64],
+    ) -> ProcessCoefficientEvaluation:
+        """Evaluate drift, covariance and discount using canonical batch shapes."""
+
+        original, states, is_single_point = self._canonical_state_batch(state)
+        batch_size = states.shape[0]
+        drift = self._normalise_vector_field(self.drift(time, original), "drift", batch_size)
+        covariance = self._normalise_matrix_field(self.covariance(time, original), "covariance", batch_size)
+        discount = self._normalise_scalar_field(self.discount(time, original), "discount", batch_size)
+        return ProcessCoefficientEvaluation(
+            time=time,
+            states=states,
+            is_single_point=is_single_point,
+            drift=drift,
+            covariance=covariance,
+            discount=discount,
+        )
+
+    def validate_covariance(
+        self,
+        time: float,
+        state: NDArray[np.float64],
+        *,
+        tolerance: float = 1e-10,
+    ) -> CovarianceValidationResult:
+        """Validate covariance symmetry and positive semidefiniteness."""
+
+        coefficients = self.evaluate_coefficients(time, state)
+        covariance = coefficients.covariance
+        asymmetry = covariance - np.swapaxes(covariance, -1, -2)
+        max_asymmetry = float(np.max(np.abs(asymmetry)))
+        if max_asymmetry > tolerance:
+            raise ValidationError(f"process covariance must be symmetric; max asymmetry is {max_asymmetry:.2e}")
+        min_eigenvalue = float(np.min(np.linalg.eigvalsh(covariance)))
+        if min_eigenvalue < -tolerance:
+            raise ValidationError(
+                "process covariance must be positive semi-definite; "
+                f"minimum eigenvalue is {min_eigenvalue:.2e}"
+            )
+        return CovarianceValidationResult(
+            min_eigenvalue=min_eigenvalue,
+            max_asymmetry=max_asymmetry,
+            batch_size=covariance.shape[0],
+        )
+
+    def apply_generator(
+        self,
+        time: float,
+        state: NDArray[np.float64],
+        *,
+        value: NDArray[np.float64] | float,
+        gradient: NDArray[np.float64],
+        hessian: NDArray[np.float64],
+        discount: NDArray[np.float64] | float | None = None,
+        source: NDArray[np.float64] | float = 0.0,
+    ) -> NDArray[np.float64]:
+        r"""Apply ``0.5 tr(a Hessian) + b·grad - c value + source``."""
+
+        coefficients = self.evaluate_coefficients(time, state)
+        batch_size = coefficients.states.shape[0]
+        gradient_array = self._normalise_vector_field(gradient, "gradient", batch_size)
+        hessian_array = self._normalise_matrix_field(hessian, "hessian", batch_size)
+        value_array = self._normalise_scalar_field(value, "value", batch_size)
+        discount_array = (
+            coefficients.discount
+            if discount is None
+            else self._normalise_scalar_field(discount, "discount", batch_size)
+        )
+        source_array = self._normalise_scalar_field(source, "source", batch_size)
+        diffusion_term = 0.5 * np.einsum("nij,nij->n", coefficients.covariance, hessian_array)
+        drift_term = np.einsum("ni,ni->n", coefficients.drift, gradient_array)
+        return diffusion_term + drift_term - discount_array * value_array + source_array
+
     def diffusion(self, time: float, state: NDArray[np.float64]) -> NDArray[np.float64]:
         r"""Compute diffusion matrix :math:`\sigma(t, x)` from covariance.
 
@@ -254,62 +488,95 @@ class AffineProcess(StochasticProcess):
     
     @abstractmethod
     def affine_covariance_coefficients(
-        self, 
+        self,
         time: float = 0.0
     ) -> Tuple[NDArray[np.float64], NDArray[np.float64]]:
-        """Get affine covariance coefficients γ(t), δ(t).
-        
+        r"""Get affine covariance coefficients ``a0(t), a_linear(t)``.
+
         Returns
         -------
         Tuple[NDArray[np.float64], NDArray[np.float64]]
-            (γ, δ) where Σ(x,t) = γ + δ⊙x (⊙ is element-wise or appropriate operation)
+            ``(a0, a_linear)`` where ``a0`` has shape ``(d, d)`` and
+            ``a_linear`` has shape ``(d, d, d)`` with convention
+            ``a(x,t) = a0(t) + sum_k x_k a_linear[k](t)``.
         """
         ...
-    
+
+    def affine_covariance_form(self, time: float = 0.0) -> AffineCovarianceForm:
+        """Return a validated affine covariance tensor form."""
+
+        constant, linear = self.affine_covariance_coefficients(time)
+        form = AffineCovarianceForm.from_coefficients(constant, linear)
+        if type(self).covariance is not AffineProcess.covariance:
+            self._validate_affine_covariance_form_matches_covariance(form, time)
+        return form
+
+    def _validate_affine_covariance_form_matches_covariance(
+        self,
+        form: AffineCovarianceForm,
+        time: float,
+    ) -> None:
+        """Fail closed when advertised affine coefficients are not exact."""
+
+        dimension = self.dimension.value
+        probes = [np.ones(dimension), 2.0 * np.ones(dimension)]
+        for index in range(dimension):
+            point = np.ones(dimension)
+            point[index] = 3.0
+            probes.append(point)
+        states = np.asarray(probes, dtype=float)
+        expected = form.evaluate(states)
+        actual = self._normalise_matrix_field(
+            self.covariance(time, states),
+            "covariance",
+            states.shape[0],
+        )
+        if not np.allclose(actual, expected, rtol=1e-10, atol=1e-12):
+            max_error = float(np.max(np.abs(actual - expected)))
+            raise ValidationError(
+                "affine covariance coefficients do not exactly reproduce process covariance; "
+                f"max error on certification probes is {max_error:.2e}"
+            )
+
     def drift(
-        self, 
-        time: float, 
+        self,
+        time: float,
         state: NDArray[np.float64]
     ) -> NDArray[np.float64]:
         """Compute affine drift μ(x,t) = α(t) + β(t)x."""
-        # Ensure state is array
         state = ensure_state_array(state)
         self.validate_state(state)
-        
         alpha, beta = self.affine_drift_coefficients(time)
-        
+        alpha = np.asarray(alpha, dtype=float)
+        beta = np.asarray(beta, dtype=float)
+        dimension = self.dimension.value
+        if alpha.shape != (dimension,):
+            raise ValidationError(f"affine drift alpha must have shape ({dimension},), got {alpha.shape}")
+        if beta.shape == (dimension,):
+            if dimension != 1:
+                raise ValidationError(
+                    "one-dimensional affine drift beta shorthand is only valid for one-factor processes"
+                )
+            beta = beta.reshape(1, 1)
+        if beta.shape != (dimension, dimension):
+            raise ValidationError(
+                f"affine drift beta must have shape ({dimension}, {dimension}), got {beta.shape}"
+            )
+
         if state.ndim == 1:
-            # For single state, alpha is (d,) and beta is (d, d)
-            # Return alpha + beta @ state
             return alpha + beta @ state
-        else:
-            # Vectorized computation for multiple states
-            # state is (n, d), alpha is (d,), beta is (d, d)
-            # For each row of state, compute alpha + beta @ state[i]
-            n_states = state.shape[0]
-            result = np.zeros((n_states, self.dimension.value))
-            for i in range(n_states):
-                result[i] = alpha + beta @ state[i]
-            return result
-    
+        return state @ beta.T + alpha
+
     def covariance(
         self,
         time: float,
         state: NDArray[np.float64]
     ) -> NDArray[np.float64]:
-        """Compute affine covariance Σ(x,t) = γ(t) + δ(t)⊙x."""
-        # Ensure state is array
+        r"""Compute affine covariance ``a0(t)+sum_k x_k a_k(t)``."""
         state = ensure_state_array(state)
         self.validate_state(state)
-        
-        gamma, delta = self.affine_covariance_coefficients(time)
-        
-        if state.ndim == 1:
-            # For 1D case, delta operation is element-wise multiplication
-            return gamma + delta * state
-        else:
-            # Vectorized computation for multiple states
-            return gamma[None, :, :] + delta[None, :, :] * state[:, :, None]
+        covariance = self.affine_covariance_form(time).evaluate(state)
+        return covariance[0] if state.ndim == 1 else covariance
 
 
 class NonAffineProcess(StochasticProcess):

--- a/tests/test_process_generator_contracts.py
+++ b/tests/test_process_generator_contracts.py
@@ -1,0 +1,156 @@
+"""Executable process-generator contract tests for issue #44."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from src.exceptions import ValidationError
+from src.processes import (
+    AffineProcess,
+    ProcessDimension,
+    GeometricBrownianMotion,
+    HestonModel,
+    OrnsteinUhlenbeck,
+    CoxIngersollRoss,
+    ConstantElasticityVariance,
+)
+from src.processes.base import AffineCovarianceForm, ProcessType
+
+
+class TwoFactorLinearCovarianceProcess(AffineProcess):
+    """Minimal process with genuine affine covariance tensor."""
+
+    @property
+    def dimension(self) -> ProcessDimension:
+        return ProcessDimension(value=2)
+
+    def affine_drift_coefficients(self, time: float = 0.0):
+        return np.array([0.1, -0.2]), np.array([[1.0, 0.5], [-0.25, 2.0]])
+
+    def affine_covariance_coefficients(self, time: float = 0.0):
+        a0 = np.array([[2.0, 0.1], [0.1, 1.0]])
+        a_linear = np.array(
+            [
+                [[0.5, 0.0], [0.0, 0.2]],
+                [[0.0, 0.3], [0.3, 0.4]],
+            ]
+        )
+        return a0, a_linear
+
+class NonPSDAffineProcess(TwoFactorLinearCovarianceProcess):
+    """Process with explicit non-PSD covariance for negative tests."""
+
+    def affine_covariance_coefficients(self, time: float = 0.0):
+        return np.array([[1.0, 0.0], [0.0, -0.1]]), np.zeros((2, 2, 2))
+
+
+def test_process_coefficient_evaluation_has_one_batch_shape_convention() -> None:
+    process = TwoFactorLinearCovarianceProcess()
+
+    single = process.evaluate_coefficients(0.0, np.array([1.0, 2.0]))
+    batch = process.evaluate_coefficients(0.0, np.array([[1.0, 2.0], [3.0, 4.0]]))
+
+    assert single.is_single_point
+    assert single.states.shape == (1, 2)
+    assert single.drift.shape == (1, 2)
+    assert single.covariance.shape == (1, 2, 2)
+    assert single.discount.shape == (1,)
+    assert_allclose(single.discount, [0.0])
+
+    assert not batch.is_single_point
+    assert batch.states.shape == (2, 2)
+    assert batch.drift.shape == (2, 2)
+    assert batch.covariance.shape == (2, 2, 2)
+    assert batch.discount.shape == (2,)
+
+
+def test_affine_covariance_tensor_evaluates_a0_plus_sum_xk_ak_exactly() -> None:
+    process = TwoFactorLinearCovarianceProcess()
+    states = np.array([[1.0, 2.0], [3.0, 4.0]])
+    a0, a_linear = process.affine_covariance_coefficients()
+
+    expected = np.stack([a0 + states[i, 0] * a_linear[0] + states[i, 1] * a_linear[1] for i in range(2)])
+
+    form = process.affine_covariance_form()
+    assert isinstance(form, AffineCovarianceForm)
+    assert_allclose(form.evaluate(states), expected)
+    assert_allclose(process.covariance(0.0, states), expected)
+
+
+def test_affine_covariance_rejects_ambiguous_non_tensor_shapes() -> None:
+    with pytest.raises(ValidationError, match="linear affine covariance tensor"):
+        AffineCovarianceForm.from_coefficients(np.eye(2), np.ones((2, 2)))
+
+
+def test_affine_covariance_form_matches_builtin_models_or_fails_closed() -> None:
+    short_rate_states = np.array([[0.03], [0.07]])
+    for process in [
+        OrnsteinUhlenbeck(kappa=2.0, theta=0.04, sigma=0.1),
+        CoxIngersollRoss(kappa=2.0, theta=0.04, sigma=0.2),
+    ]:
+        form = process.affine_covariance_form()
+        evaluated = process.evaluate_coefficients(0.0, short_rate_states)
+        assert_allclose(form.evaluate(short_rate_states), evaluated.covariance)
+
+    with pytest.raises(ValidationError, match="do not exactly reproduce process covariance"):
+        GeometricBrownianMotion(mu=0.05, sigma=0.2).affine_covariance_form()
+
+    with pytest.raises(ValidationError, match="do not exactly reproduce process covariance"):
+        HestonModel(
+            risk_free_rate=0.05,
+            kappa=2.0,
+            theta=0.04,
+            sigma=0.3,
+            rho=-0.7,
+        ).affine_covariance_form()
+
+
+def test_generator_application_matches_analytical_one_factor_processes() -> None:
+    processes = [
+        GeometricBrownianMotion(mu=0.05, sigma=0.2),
+        OrnsteinUhlenbeck(kappa=2.0, theta=0.04, sigma=0.1),
+        CoxIngersollRoss(kappa=2.0, theta=0.04, sigma=0.2),
+        ConstantElasticityVariance(mu=0.05, sigma=0.2, beta=0.5),
+    ]
+    states = np.array([[0.03], [0.07]])
+    value = states[:, 0] ** 2
+    gradient = 2.0 * states
+    hessian = np.repeat(np.array([[[2.0]]]), repeats=len(states), axis=0)
+
+    for process in processes:
+        coefficients = process.evaluate_coefficients(0.0, states)
+        actual = process.apply_generator(
+            0.0,
+            states,
+            value=value,
+            gradient=gradient,
+            hessian=hessian,
+        )
+        expected = coefficients.covariance[:, 0, 0] + 2.0 * states[:, 0] * coefficients.drift[:, 0]
+        assert_allclose(actual, expected)
+
+
+def test_discount_is_not_inferred_from_drift_in_generator_application() -> None:
+    process = GeometricBrownianMotion(mu=0.05, sigma=0.2)
+    state = np.array([100.0])
+
+    no_discount = process.apply_generator(
+        0.0,
+        state,
+        value=1.0,
+        gradient=np.array([0.0]),
+        hessian=np.array([[0.0]]),
+    )
+    explicit_discount = process.apply_generator(
+        0.0,
+        state,
+        value=1.0,
+        gradient=np.array([0.0]),
+        hessian=np.array([[0.0]]),
+        discount=0.03,
+    )
+
+    assert_allclose(no_discount, [0.0])
+    assert_allclose(explicit_discount, [-0.03])
+    assert process.process_type == ProcessType.AFFINE


### PR DESCRIPTION
Closes #44.

## Summary
- Adds canonical process coefficient records and a normalized `evaluate_coefficients(t, x)` contract for drift/covariance/discount fields.
- Adds `apply_generator(...)` for executable polynomial generator checks with explicit discount/reaction handling.
- Adds exact affine covariance tensor support through `AffineCovarianceForm` with fail-closed certification against native process covariance.
- Prevents inexact affine-covariance overclaims for GBM/Heston native-state covariances while preserving exact OU/CIR affine forms.
- Exports the new process contract records and documents the contract in PRD/architecture docs.

## Adversarial review
- Round 1 found a correctness blocker: GBM/Heston could advertise inexact affine covariance forms.
- Round 2 approved after the fail-closed certification fix and tests for exact/failing built-in models.

## Verification
```text
git diff --check
.venv/bin/python -m pytest -q tests/test_process_generator_contracts.py tests/test_unified_processes.py
# 49 passed
.venv/bin/python -m pytest -q
# 151 passed, 1 xfailed, 14 warnings
.venv/bin/ruff check src/processes/base.py src/processes/__init__.py tests/test_process_generator_contracts.py
# All checks passed
```
