### PR TITLE
fix: reject nonfinite positive scalar values

### DIFF
--- a/src/validation/validators.py
+++ b/src/validation/validators.py
@@ -14,7 +14,7 @@ from src.exceptions import ValidationError, GridError, ModelError, InstrumentErr
 
 
 def validate_positive(value: float, name: str) -> None:
-    """Validate that a value is positive.
+    """Validate that a value is finite and positive.
     
     Parameters
     ----------
@@ -26,9 +26,11 @@ def validate_positive(value: float, name: str) -> None:
     Raises
     ------
     ValidationError
-        If value is not positive.
+        If value is not finite and positive.
     """
-    if not isinstance(value, (int, float)) or value <= 0:
+    if not isinstance(value, (int, float)) or not np.isfinite(value):
+        raise ValidationError(f"{name} must be a finite positive number, got {value}")
+    if value <= 0:
         raise ValidationError(f"{name} must be a positive number, got {value}")
 
 

--- a/tests/test_factor_role_payoff_compatibility.py
+++ b/tests/test_factor_role_payoff_compatibility.py
@@ -179,6 +179,10 @@ def test_spread_option_has_separate_identity_and_non_normalized_coefficients() -
 @pytest.mark.parametrize(
     "kwargs, match",
     [
+        ({"strike": np.nan, "weights": np.array([1.0]), "maturity": 1.0}, "finite"),
+        ({"strike": np.inf, "weights": np.array([1.0]), "maturity": 1.0}, "finite"),
+        ({"strike": 100.0, "weights": np.array([1.0]), "maturity": np.nan}, "finite"),
+        ({"strike": 100.0, "weights": np.array([1.0]), "maturity": np.inf}, "finite"),
         ({"strike": 100.0, "weights": np.array([]), "maturity": 1.0}, "nonempty"),
         ({"strike": 100.0, "weights": np.array([0.5, np.nan]), "maturity": 1.0}, "finite"),
         ({"strike": 100.0, "weights": np.array([[0.5, 0.5]]), "maturity": 1.0}, "one-dimensional"),

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -5,6 +5,7 @@ import sys
 # Ensure project root on path
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
+import numpy as np
 import pytest
 from src.exceptions import ValidationError, GridError, InstrumentError, ModelError
 from src.validation import (
@@ -24,6 +25,14 @@ def test_validate_positive():
     
     with pytest.raises(ValidationError, match="test_param must be a positive number"):
         validate_positive(0.0, "test_param")
+
+
+@pytest.mark.parametrize("value", [np.nan, np.inf, -np.inf])
+def test_validate_positive_rejects_nonfinite_values(value):
+    """Positive scalar validation must fail closed on NaN/Infinity."""
+
+    with pytest.raises(ValidationError, match="finite positive number"):
+        validate_positive(value, "test_param")
 
 
 def test_validate_grid_parameters():


### PR DESCRIPTION
Closes #91.

## Summary
- Makes `validate_positive` fail closed on `NaN`, `+Infinity`, and `-Infinity` by requiring `np.isfinite(value)`.
- Adds direct validator coverage for non-finite positive scalar inputs.
- Adds product-level regression coverage for non-finite basket strike/maturity fields.

## Verification
```text
git diff --check origin/main...HEAD
.venv/bin/python -m pytest -q tests/test_validation.py tests/test_factor_role_payoff_compatibility.py
# 27 passed in 0.63s
.venv/bin/python -m pytest -q
# 175 passed, 14 warnings in 27.86s
.venv/bin/ruff check src/validation/validators.py tests/test_validation.py tests/test_factor_role_payoff_compatibility.py
# All checks passed!
```

Adversarial topology review returned `APPROVE` for tracking this as a standalone Project 5 issue.
