### PR TITLE
Guard API pricing requests and bounded grid output

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,18 +146,34 @@ python -m cli plot --option-type Call --strike 1 --maturity 1 --output plot.png
 
 ## FastAPI Service
 
-Start a REST API that exposes pricing and Greek calculations.
-The service allows cross-origin requests from `https://your-domain.com`.
+Start a REST API that exposes experimental pricing and Greek calculations.
+The service allows cross-origin requests from `http://localhost:5173`.
 
 ```bash
 uvicorn api.main:app --reload
 ```
 
+Pricing requests use a versioned schema with explicit `spot`, enum `option_type`, finite/range numeric validation, a pre-solve node budget, and full-grid output disabled by default:
+
+```json
+{
+  "option_type": "Call",
+  "spot": 100.0,
+  "strike": 100.0,
+  "maturity": 0.25,
+  "rate": 0.05,
+  "sigma": 0.2,
+  "s_steps": 101,
+  "t_steps": 51,
+  "include_full_grid": false
+}
+```
+
 Endpoints:
 
-- `POST /price` → `{ "price": float }`
-- `POST /greeks` → `{ "delta": float, "gamma": float, "theta": float }`
-- `POST /pde_solution` → Full 2D grids for prices and Greeks visualization
+- `POST /price` → scalar requested-spot response `{ "schema_version": "fd-api-v1", "spot": float, "price": float, "grid": null }`
+- `POST /greeks` → requested-spot Greeks `{ "schema_version": "fd-api-v1", "spot": float, "delta": float, "gamma": float, "theta": float }`
+- `POST /pde_solution` → bounded full grids for prices and Greeks only when `include_full_grid` is `true`
 - `POST /reports/crif` → HTTP 501 problem detail until an exact ISDA CRIF profile/version and conformance suite are implemented
 - `POST /reports/cuso` → HTTP 501 problem detail until an authoritative CUSO specification is identified
 - `POST /reports/basel` → HTTP 501 problem detail until a versioned Basel market-risk subset is implemented

--- a/api/main.py
+++ b/api/main.py
@@ -133,7 +133,7 @@ class FullPDEResponse(BaseModel):
 
 
 def _option_class(option_type: OptionType) -> type[EuropeanCall] | type[EuropeanPut]:
-    return EuropeanCall if option_type is OptionType.CALL else EuropeanPut
+    return EuropeanCall if option_type == OptionType.CALL else EuropeanPut
 
 
 def _compute_grid(request: OptionRequest, *, return_greeks: bool = False):

--- a/api/main.py
+++ b/api/main.py
@@ -6,12 +6,13 @@ front-end integrations and smoke testing.
 
 from __future__ import annotations
 
+from enum import Enum
 from typing import Optional
 
 import numpy as np
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from src.pricing import OptionPricer
 from src.risk import (
@@ -35,51 +36,94 @@ app.add_middleware(
 )
 
 
+class OptionType(str, Enum):
+    """Supported vanilla option payoffs for the reference API."""
+
+    CALL = "Call"
+    PUT = "Put"
+
+
 class OptionRequest(BaseModel):
-    """Request payload for option pricing endpoints.
+    """Validated request payload for option pricing endpoints.
 
     Units follow model conventions:
 
     - rates in annual decimal units,
     - maturities in years,
+    - ``spot`` is the requested market state,
     - ``s_steps`` and ``t_steps`` are integer grid resolutions.
     """
 
-    option_type: str = "Call"
-    strike: float
-    maturity: float
-    rate: float
-    sigma: float
-    s_max: Optional[float] = None
-    s_steps: int = 100
-    t_steps: int = 100
+    model_config = ConfigDict(extra="forbid")
+
+    option_type: OptionType = OptionType.CALL
+    spot: float = Field(..., gt=0.0, allow_inf_nan=False)
+    strike: float = Field(..., gt=0.0, allow_inf_nan=False)
+    maturity: float = Field(..., gt=0.0, allow_inf_nan=False)
+    rate: float = Field(..., ge=-1.0, le=1.0, allow_inf_nan=False)
+    sigma: float = Field(..., gt=0.0, le=5.0, allow_inf_nan=False)
+    s_max: Optional[float] = Field(default=None, gt=0.0, allow_inf_nan=False)
+    s_steps: int = Field(default=100, ge=5, le=5_000)
+    t_steps: int = Field(default=100, ge=3, le=5_000)
+    include_full_grid: bool = False
+    max_output_nodes: int = Field(default=50_000, ge=1, le=50_000)
+
+    @model_validator(mode="after")
+    def validate_api_budget_and_domain(self) -> "OptionRequest":
+        """Reject impossible or unbounded requests before numerical work."""
+
+        s_max = self.resolved_s_max
+        if self.spot > s_max:
+            raise ValueError("spot must lie inside the spatial grid [0, s_max]")
+        if self.strike > s_max:
+            raise ValueError("strike must lie inside the spatial grid [0, s_max]")
+        node_count = self.s_steps * self.t_steps
+        if node_count > self.max_output_nodes:
+            raise ValueError(f"request exceeds node budget: {node_count} > {self.max_output_nodes}")
+        return self
+
+    @property
+    def resolved_s_max(self) -> float:
+        """Return explicit or default spatial upper bound."""
+
+        return float(self.s_max if self.s_max is not None else max(self.spot, self.strike) * 3.0)
 
 
-class PriceResponse(BaseModel):
-    """Response containing dense price grid for a requested option.
-
-    The full surface is returned to simplify downstream plotting and debugging.
-    """
+class PriceGrid(BaseModel):
+    """Bounded grid payload returned only when explicitly requested."""
 
     s: list[float]
     t: list[float]
     values: list[list[float]]
 
 
-class GreeksResponse(BaseModel):
-    """Scalar Greeks sampled at spot for backward-compatible API consumers."""
+class PriceResponse(BaseModel):
+    """Scalar option price response with optional bounded grid payload."""
 
+    schema_version: str = "fd-api-v1"
+    option_type: OptionType
+    spot: float
+    price: float
+    grid: PriceGrid | None = None
+
+
+class GreeksResponse(BaseModel):
+    """Scalar Greeks sampled at the explicitly requested spot."""
+
+    schema_version: str = "fd-api-v1"
+    option_type: OptionType
+    spot: float
     delta: float
     gamma: float
     theta: float
 
 
 class FullPDEResponse(BaseModel):
-    """Full PDE grid and Greeks for visualisation.
+    """Explicitly requested complete solution and Greeks grids."""
 
-    All arrays are in nested list form to keep FastAPI/JSON serialization simple.
-    """
-    
+    schema_version: str = "fd-api-v1"
+    option_type: OptionType
+    spot: float
     s: list[float]
     t: list[float]
     prices: list[list[float]]
@@ -88,69 +132,78 @@ class FullPDEResponse(BaseModel):
     theta: list[list[float]]
 
 
-@app.post("/price", response_model=PriceResponse)
-def price(request: OptionRequest) -> PriceResponse:
-    """Return full PDE-generated value grid for the requested option.
+def _option_class(option_type: OptionType) -> type[EuropeanCall] | type[EuropeanPut]:
+    return EuropeanCall if option_type is OptionType.CALL else EuropeanPut
 
-    The endpoint uses default grid settings when ``s_max`` is omitted.
-    """
-    s_max = request.s_max or request.strike * 3
+
+def _compute_grid(request: OptionRequest, *, return_greeks: bool = False):
     model = GeometricBrownianMotion(mu=request.rate, sigma=request.sigma)
-    option_cls = EuropeanCall if request.option_type == "Call" else EuropeanPut
-    instrument = option_cls(strike=request.strike, maturity=request.maturity, model=model)
+    instrument = _option_class(request.option_type)(
+        strike=request.strike,
+        maturity=request.maturity,
+        model=model,
+    )
     pricer = OptionPricer(instrument=instrument)
-    res = pricer.compute_grid(
-        s_max=s_max,
+    return pricer.compute_grid(
+        s_max=request.resolved_s_max,
         s_steps=request.s_steps,
         t_steps=request.t_steps,
+        return_greeks=return_greeks,
     )
+
+
+def _interp_at_spot(values: np.ndarray, grid: np.ndarray, spot: float) -> float:
+    return float(np.interp(spot, grid, values))
+
+
+def _grid_payload(res) -> PriceGrid:
+    return PriceGrid(s=res.s.tolist(), t=res.t.tolist(), values=res.values.tolist())
+
+
+@app.post("/price", response_model=PriceResponse)
+def price(request: OptionRequest) -> PriceResponse:
+    """Return requested-spot price and optional bounded grid for an option."""
+
+    res = _compute_grid(request)
     return PriceResponse(
-        s=res.s.tolist(),
-        t=res.t.tolist(),
-        values=res.values.tolist(),
+        option_type=request.option_type,
+        spot=request.spot,
+        price=_interp_at_spot(res.values[-1], res.s, request.spot),
+        grid=_grid_payload(res) if request.include_full_grid else None,
     )
 
 
 @app.post("/greeks", response_model=GreeksResponse)
 def greeks(request: OptionRequest) -> GreeksResponse:
-    """Return scalar Greeks at spot for the requested option contract."""
-    s_max = request.s_max or request.strike * 3
-    model = GeometricBrownianMotion(mu=request.rate, sigma=request.sigma)
-    option_cls = EuropeanCall if request.option_type == "Call" else EuropeanPut
-    instrument = option_cls(strike=request.strike, maturity=request.maturity, model=model)
-    pricer = OptionPricer(instrument=instrument)
-    res = pricer.compute_grid(
-        s_max=s_max,
-        s_steps=request.s_steps,
-        t_steps=request.t_steps,
-        return_greeks=True,
-    )
-    s_idx = int(np.searchsorted(res.s, request.strike))
+    """Return scalar Greeks at the explicitly requested spot."""
+
+    res = _compute_grid(request, return_greeks=True)
+    if res.delta is None or res.gamma is None or res.theta is None:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail="Greek grid was not computed")
     return GreeksResponse(
-        delta=float(res.delta[-1, s_idx]),
-        gamma=float(res.gamma[-1, s_idx]),
-        theta=float(res.theta[-1, s_idx]),
+        option_type=request.option_type,
+        spot=request.spot,
+        delta=_interp_at_spot(res.delta[-1], res.s, request.spot),
+        gamma=_interp_at_spot(res.gamma[-1], res.s, request.spot),
+        theta=_interp_at_spot(res.theta[-1], res.s, request.spot),
     )
 
 
 @app.post("/pde_solution", response_model=FullPDEResponse)
 def pde_solution(request: OptionRequest) -> FullPDEResponse:
-    """Return complete solution and Greeks grids.
+    """Return complete solution and Greeks grids only after explicit opt-in."""
 
-    This is the most visualization-friendly API endpoint for frontend charts.
-    """
-    s_max = request.s_max or request.strike * 3
-    model = GeometricBrownianMotion(mu=request.rate, sigma=request.sigma)
-    option_cls = EuropeanCall if request.option_type == "Call" else EuropeanPut
-    instrument = option_cls(strike=request.strike, maturity=request.maturity, model=model)
-    pricer = OptionPricer(instrument=instrument)
-    res = pricer.compute_grid(
-        s_max=s_max,
-        s_steps=request.s_steps,
-        t_steps=request.t_steps,
-        return_greeks=True,
-    )
+    if not request.include_full_grid:
+        raise HTTPException(
+            status_code=400,
+            detail="include_full_grid must be true to return the full PDE grid",
+        )
+    res = _compute_grid(request, return_greeks=True)
+    if res.delta is None or res.gamma is None or res.theta is None:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail="Greek grid was not computed")
     return FullPDEResponse(
+        option_type=request.option_type,
+        spot=request.spot,
         s=res.s.tolist(),
         t=res.t.tolist(),
         prices=res.values.tolist(),

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -21,7 +21,7 @@ Status vocabulary:
 | American/free-boundary exercise | `unsupported` | none | Requires diagnosed LCP/complementarity implementation; tracked by #66. |
 | Jump/PIDE and HJB/control terms | `unsupported` | none | Capability manifest rejects these terms fail-closed. |
 | CRIF/CUSO/Basel/FRTB regulatory report endpoints | `scaffold` | `REG-FAIL-CLOSED-V0` | Endpoints and Python strategy/converter entry points return typed HTTP 501 / `NotImplementedForStandard` metadata until exact standard/profile/version, effective date, jurisdiction, licensing status, and conformance fixtures exist. |
-| FastAPI/CLI/UI service contracts | `experimental` | `DOCS-README-SMOKE-V0` | Convenience interfaces only; numerical truth remains in the Python core. |
+| FastAPI/CLI/UI service contracts | `experimental` | `DOCS-README-SMOKE-V0`, `API-REQUEST-GUARDS-V0` | FastAPI pricing endpoints use versioned schemas, enum payoff validation, explicit spot semantics, finite/range request checks, pre-solve node budgets, and explicit opt-in for full grids. Convenience interfaces only; numerical truth remains in the Python core. |
 
 Maintained documentation set:
 

--- a/tests/test_api_request_guards.py
+++ b/tests/test_api_request_guards.py
@@ -1,0 +1,127 @@
+"""API request validation and bounded-output tests for issue #53."""
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError as PydanticValidationError
+
+from api.main import OptionRequest, app
+from src.instruments.base import EuropeanCall
+from src.pricing import OptionPricer
+from src.processes.affine import GeometricBrownianMotion
+
+
+def _payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "option_type": "Call",
+        "spot": 150.0,
+        "strike": 100.0,
+        "maturity": 0.5,
+        "rate": 0.03,
+        "sigma": 0.2,
+        "s_max": 250.0,
+        "s_steps": 101,
+        "t_steps": 51,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _expected_greeks_at_spot(payload: dict[str, object]) -> tuple[float, float, float]:
+    model = GeometricBrownianMotion(mu=float(payload["rate"]), sigma=float(payload["sigma"]))
+    option = EuropeanCall(
+        strike=float(payload["strike"]),
+        maturity=float(payload["maturity"]),
+        model=model,
+    )
+    res = OptionPricer(instrument=option).compute_grid(
+        s_max=float(payload["s_max"]),
+        s_steps=int(payload["s_steps"]),
+        t_steps=int(payload["t_steps"]),
+        return_greeks=True,
+    )
+    spot = float(payload["spot"])
+    return (
+        float(np.interp(spot, res.s, res.delta[-1])),
+        float(np.interp(spot, res.s, res.gamma[-1])),
+        float(np.interp(spot, res.s, res.theta[-1])),
+    )
+
+
+def test_price_endpoint_rejects_unknown_option_type_instead_of_defaulting_to_put() -> None:
+    client = TestClient(app)
+
+    response = client.post("/price", json=_payload(option_type="Digital"))
+
+    assert response.status_code == 422
+    assert "option_type" in str(response.json()["detail"])
+
+
+def test_price_endpoint_returns_scalar_at_explicit_spot_without_full_grid_by_default() -> None:
+    client = TestClient(app)
+
+    response = client.post("/price", json=_payload())
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["schema_version"] == "fd-api-v1"
+    assert body["spot"] == 150.0
+    assert math.isfinite(body["price"])
+    assert body["grid"] is None
+    assert "values" not in body
+
+
+def test_greeks_endpoint_samples_explicit_spot_not_strike() -> None:
+    client = TestClient(app)
+    payload = _payload()
+
+    response = client.post("/greeks", json=payload)
+
+    assert response.status_code == 200
+    body = response.json()
+    expected_delta, expected_gamma, expected_theta = _expected_greeks_at_spot(payload)
+    assert body["spot"] == payload["spot"]
+    assert body["delta"] == pytest.approx(expected_delta, abs=1e-12)
+    assert body["gamma"] == pytest.approx(expected_gamma, abs=1e-12)
+    assert body["theta"] == pytest.approx(expected_theta, abs=1e-12)
+
+    strike_delta, _, _ = _expected_greeks_at_spot({**payload, "spot": payload["strike"]})
+    assert abs(body["delta"] - strike_delta) > 1e-3
+
+
+def test_request_budget_rejects_oversized_grids_before_solver_allocation() -> None:
+    with pytest.raises(PydanticValidationError, match="node budget"):
+        OptionRequest(**_payload(s_steps=1001, t_steps=101))
+
+
+@pytest.mark.parametrize("field", ["spot", "strike", "maturity", "sigma", "s_max"])
+def test_request_rejects_nonfinite_positive_numeric_fields(field: str) -> None:
+    kwargs = _payload(**{field: math.inf})
+
+    with pytest.raises(PydanticValidationError):
+        OptionRequest(**kwargs)
+
+
+def test_pde_solution_full_grid_requires_explicit_opt_in() -> None:
+    client = TestClient(app)
+
+    response = client.post("/pde_solution", json=_payload(s_steps=21, t_steps=21))
+
+    assert response.status_code == 400
+    assert "include_full_grid" in response.json()["detail"]
+
+
+def test_pde_solution_full_grid_is_bounded_when_explicitly_requested() -> None:
+    client = TestClient(app)
+
+    response = client.post("/pde_solution", json=_payload(include_full_grid=True, s_steps=21, t_steps=21))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["schema_version"] == "fd-api-v1"
+    assert len(body["s"]) == 21
+    assert len(body["t"]) == 21
+    assert len(body["prices"]) == 21

--- a/tests/test_api_request_guards.py
+++ b/tests/test_api_request_guards.py
@@ -97,9 +97,10 @@ def test_request_budget_rejects_oversized_grids_before_solver_allocation() -> No
         OptionRequest(**_payload(s_steps=1001, t_steps=101))
 
 
-@pytest.mark.parametrize("field", ["spot", "strike", "maturity", "sigma", "s_max"])
-def test_request_rejects_nonfinite_positive_numeric_fields(field: str) -> None:
-    kwargs = _payload(**{field: math.inf})
+@pytest.mark.parametrize("field", ["spot", "strike", "maturity", "rate", "sigma", "s_max"])
+@pytest.mark.parametrize("bad_value", [math.inf, math.nan])
+def test_request_rejects_nonfinite_numeric_fields(field: str, bad_value: float) -> None:
+    kwargs = _payload(**{field: bad_value})
 
     with pytest.raises(PydanticValidationError):
         OptionRequest(**kwargs)

--- a/tests/test_documentation_capabilities.py
+++ b/tests/test_documentation_capabilities.py
@@ -32,12 +32,28 @@ def test_capability_matrix_is_authoritative_and_cites_evidence_ids() -> None:
         "RANNACHER-GAMMA-V0",
         "QPS-VANILLA-CALL-V0",
         "FACTOR-ROLE-COMPAT-V0",
+        "API-REQUEST-GUARDS-V0",
     ]:
         assert evidence_id in text
     assert "Heston stochastic volatility" in text
     assert "basket option" in text
     assert "two-leg spreads" in text
+    assert "explicit spot semantics" in text
+    assert "pre-solve node budgets" in text
     assert "unsupported" in text
+
+
+def test_readme_fastapi_section_documents_guarded_request_contract() -> None:
+    text = README.read_text(encoding="utf-8")
+    fastapi_section = text.split("## FastAPI Service", maxsplit=1)[1].split(
+        "## Next.js Client", maxsplit=1
+    )[0]
+
+    assert '"schema_version": "fd-api-v1"' in fastapi_section
+    assert '"spot": 100.0' in fastapi_section
+    assert '"include_full_grid": false' in fastapi_section
+    assert "full-grid output disabled by default" in fastapi_section
+    assert "requested-spot Greeks" in fastapi_section
 
 
 def test_readme_black_scholes_quickstart_executes() -> None:


### PR DESCRIPTION
## Summary
- Implements a scoped #53 API safety slice for pricing endpoints without claiming the whole #53 API redesign is complete.
- Adds versioned request/response contracts with explicit `spot`, enum `option_type`, finite/range Pydantic validation, and a pre-solve node budget.
- Makes `/price` and `/greeks` return requested-spot scalar outputs by default; full PDE grids require explicit `include_full_grid=true` and remain bounded.
- Updates README/capability evidence with `API-REQUEST-GUARDS-V0`.
- Addresses Kilo review warnings: enum comparison now uses equality, and non-finite request-field tests cover `rate`, `inf`, and `nan`.

Refs #53

## Evidence
- RED: `pytest -q tests/test_api_request_guards.py` initially failed 11/11 on unknown option type, missing scalar schema, strike-based Greeks, unbounded grids, and non-finite request fields.
- GREEN: `pytest -q tests/test_api_request_guards.py` → 11 passed before review fixes; non-finite edge coverage expanded afterward.
- Focused docs/API/regression after review fixes: `pytest -q tests/test_api_request_guards.py tests/test_regulatory_fail_closed.py tests/test_documentation_capabilities.py tests/architecture/test_architecture_contracts.py` → 41 passed.
- Changed-file lint: `ruff check api/main.py tests/test_api_request_guards.py tests/test_documentation_capabilities.py` → All checks passed.
- `git diff --check` → passed.
- Full tests after review fixes: `pytest -q` → 194 passed, 14 warnings.

## Note
- `ruff check .` still reports pre-existing unrelated lint debt in `.agent_workspace/ai_protocol.py`, `src/solvers/adi.py`, `src/utils/*`, and `tests/test_options.py`; changed-file ruff is clean.
- #53 should remain open after this PR because broader API work remains: deployment controls, cancellation/rate limits, OpenAPI snapshot, async/full-grid paging, and wider model-specific validation.
