### PR TITLE
Implement fd-api-v1 stable response and error schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           pip install -r requirements.txt -r requirements-dev.txt
       - name: Static smoke gate
         run: |
-          python -m compileall -q src tests
+          python -m compileall -q api src tests
           ruff check . --select E9,F63,F7,F82
       - name: Architecture contract
         run: python scripts/check_architecture_contract.py
@@ -30,7 +30,7 @@ jobs:
         run: pytest -q tests/architecture
       - name: Stable regression suite
         run: |
-          pytest -q \
+          PYTHONPATH=. pytest -q \
             tests/test_api_request_guards.py \
             tests/test_api_schema_contracts.py \
             tests/test_regulatory_fail_closed.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Stable regression suite
         run: |
           pytest -q \
+            tests/test_api_request_guards.py \
+            tests/test_api_schema_contracts.py \
+            tests/test_regulatory_fail_closed.py \
             tests/test_boundary_conditions.py \
             tests/test_callable_bond.py \
             tests/test_fd_backend_capabilities.py \

--- a/README.md
+++ b/README.md
@@ -170,15 +170,19 @@ Pricing requests use a versioned schema with explicit `spot`, enum `option_type`
 }
 ```
 
+All public responses use the stable `fd-api-v1` envelope. Successful routes include top-level `schema_version`, `request_id`, `run_id`, and `metadata`; callers may supply `X-Request-ID` for trace propagation. `metadata` records route maturity, warnings, units, solver/grid dimensions, and explicit `not_assessed` convergence status. This is a service-contract shape, not a production validation claim.
+
 Endpoints:
 
-- `POST /price` → scalar requested-spot response `{ "schema_version": "fd-api-v1", "spot": float, "price": float, "grid": null }`
-- `POST /greeks` → requested-spot Greeks `{ "schema_version": "fd-api-v1", "spot": float, "delta": float, "gamma": float, "theta": float }`
+- `POST /price` → scalar requested-spot response with `{ "schema_version": "fd-api-v1", "request_id": str, "run_id": str, "metadata": {...}, "spot": float, "price": float, "grid": null }`
+- `POST /greeks` → requested-spot Greeks with the same envelope plus `delta`, `gamma`, and `theta`
 - `POST /pde_solution` → bounded full grids for prices and Greeks only when `include_full_grid` is `true`
-- `POST /reports/crif` → HTTP 501 problem detail until an exact ISDA CRIF profile/version and conformance suite are implemented
-- `POST /reports/cuso` → HTTP 501 problem detail until an authoritative CUSO specification is identified
-- `POST /reports/basel` → HTTP 501 problem detail until a versioned Basel market-risk subset is implemented
-- `POST /reports/frtb` → HTTP 501 problem detail until a versioned FRTB calculation subset is implemented
+- `POST /reports/crif` → HTTP 501 `ErrorResponse` until an exact ISDA CRIF profile/version and conformance suite are implemented
+- `POST /reports/cuso` → HTTP 501 `ErrorResponse` until an authoritative CUSO specification is identified
+- `POST /reports/basel` → HTTP 501 `ErrorResponse` until a versioned Basel market-risk subset is implemented
+- `POST /reports/frtb` → HTTP 501 `ErrorResponse` until a versioned FRTB calculation subset is implemented
+
+Validation, bad-request, internal, and unsupported-route failures are concise machine-readable `ErrorResponse` objects with stable `error.code`, `error.http_status`, route, request/run IDs, and original diagnostic `detail`. OpenAPI compatibility tests guard these public schema components from unreviewed drift.
 
 ## Next.js Client
 

--- a/api/main.py
+++ b/api/main.py
@@ -7,14 +7,19 @@ front-end integrations and smoke testing.
 from __future__ import annotations
 
 from enum import Enum
-from typing import Optional
+from typing import Any, Literal, Optional
+from uuid import uuid4
 
 import numpy as np
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from src.instruments.base import EuropeanCall, EuropeanPut
 from src.pricing import OptionPricer
+from src.processes.affine import GeometricBrownianMotion
 from src.risk import (
     Exposure,
     NotImplementedForStandard,
@@ -22,8 +27,8 @@ from src.risk import (
     Trade,
 )
 from src.risk.reporting_strategies import ReportFactory
-from src.processes.affine import GeometricBrownianMotion
-from src.instruments.base import EuropeanCall, EuropeanPut
+
+API_SCHEMA_VERSION: Literal["fd-api-v1"] = "fd-api-v1"
 
 app = FastAPI(title="Finite Difference Option Pricing")
 
@@ -79,14 +84,99 @@ class OptionRequest(BaseModel):
             raise ValueError("strike must lie inside the spatial grid [0, s_max]")
         node_count = self.s_steps * self.t_steps
         if node_count > self.max_output_nodes:
-            raise ValueError(f"request exceeds node budget: {node_count} > {self.max_output_nodes}")
+            raise ValueError(
+                f"request exceeds node budget: {node_count} > {self.max_output_nodes}"
+            )
         return self
 
     @property
     def resolved_s_max(self) -> float:
         """Return explicit or default spatial upper bound."""
 
-        return float(self.s_max if self.s_max is not None else max(self.spot, self.strike) * 3.0)
+        return float(
+            self.s_max if self.s_max is not None else max(self.spot, self.strike) * 3.0
+        )
+
+
+class RouteWarning(BaseModel):
+    """Machine-readable non-blocking route warning."""
+
+    code: str
+    message: str
+    severity: Literal["info", "warning"] = "warning"
+
+
+class UnitMetadata(BaseModel):
+    """Unit conventions for the public API schema."""
+
+    price: str = "same currency as underlying; examples use dimensionless inputs"
+    spot: str = "underlying price level"
+    strike: str = "underlying price level"
+    rate: str = "annual_decimal"
+    volatility: str = "annual_decimal"
+    time: str = "years"
+    greek_delta: str = "price per spot unit"
+    greek_gamma: str = "price per squared spot unit"
+    greek_theta: str = "price per year"
+
+
+class SolverMetadata(BaseModel):
+    """Numerical route metadata exposed without claiming production maturity."""
+
+    engine: str
+    process: str
+    scheme: str
+    s_steps: int
+    t_steps: int
+    grid_nodes: int
+    output_grid_included: bool
+    requested_outputs: list[str]
+
+
+class ConvergenceDiagnostics(BaseModel):
+    """Schema placeholder for convergence evidence attached to API results."""
+
+    status: Literal["not_assessed", "not_applicable"] = "not_assessed"
+    message: str
+    residual_norm: float | None = None
+    benchmark_error: float | None = None
+
+
+class ResponseMetadata(BaseModel):
+    """Stable metadata envelope shared by success and error responses."""
+
+    route: str
+    route_maturity: Literal["experimental", "scaffold", "unsupported"]
+    warnings: list[RouteWarning]
+    units: UnitMetadata = Field(default_factory=UnitMetadata)
+    solver: SolverMetadata | None = None
+    convergence: ConvergenceDiagnostics | None = None
+
+
+class APIResponseBase(BaseModel):
+    """Common top-level stable fields for every public API response."""
+
+    schema_version: Literal["fd-api-v1"] = API_SCHEMA_VERSION
+    request_id: str
+    run_id: str
+    metadata: ResponseMetadata
+
+
+class ErrorBody(BaseModel):
+    """Machine-readable error summary."""
+
+    code: str
+    message: str
+    http_status: int
+    route: str
+    source: str = "api"
+
+
+class ErrorResponse(APIResponseBase):
+    """Stable error envelope for validation, bad-request, and unsupported routes."""
+
+    error: ErrorBody
+    detail: dict[str, Any] | list[dict[str, Any]] | str | None = None
 
 
 class PriceGrid(BaseModel):
@@ -97,20 +187,18 @@ class PriceGrid(BaseModel):
     values: list[list[float]]
 
 
-class PriceResponse(BaseModel):
+class PriceResponse(APIResponseBase):
     """Scalar option price response with optional bounded grid payload."""
 
-    schema_version: str = "fd-api-v1"
     option_type: OptionType
     spot: float
     price: float
     grid: PriceGrid | None = None
 
 
-class GreeksResponse(BaseModel):
+class GreeksResponse(APIResponseBase):
     """Scalar Greeks sampled at the explicitly requested spot."""
 
-    schema_version: str = "fd-api-v1"
     option_type: OptionType
     spot: float
     delta: float
@@ -118,10 +206,9 @@ class GreeksResponse(BaseModel):
     theta: float
 
 
-class FullPDEResponse(BaseModel):
+class FullPDEResponse(APIResponseBase):
     """Explicitly requested complete solution and Greeks grids."""
 
-    schema_version: str = "fd-api-v1"
     option_type: OptionType
     spot: float
     s: list[float]
@@ -130,6 +217,224 @@ class FullPDEResponse(BaseModel):
     delta: list[list[float]]
     gamma: list[list[float]]
     theta: list[list[float]]
+
+
+API_ERROR_RESPONSES: dict[int | str, dict[str, Any]] = {
+    400: {"model": ErrorResponse},
+    422: {"model": ErrorResponse},
+    500: {"model": ErrorResponse},
+}
+UNSUPPORTED_ROUTE_RESPONSES: dict[int | str, dict[str, Any]] = {
+    501: {"model": ErrorResponse},
+    422: {"model": ErrorResponse},
+}
+
+
+def _new_run_id() -> str:
+    """Return an opaque run identifier for a single route evaluation."""
+
+    return f"fd-run-{uuid4().hex}"
+
+
+def _request_id(http_request: Request) -> str:
+    """Propagate a caller-supplied request ID or create an opaque one."""
+
+    return http_request.headers.get("x-request-id") or f"fd-req-{uuid4().hex}"
+
+
+def _route_warning(route: str, *, route_maturity: str) -> RouteWarning:
+    """Return the standard maturity warning for a public route."""
+
+    if route_maturity == "unsupported":
+        return RouteWarning(
+            code="unsupported_route",
+            message=f"{route} is intentionally fail-closed until its contract is implemented.",
+        )
+    return RouteWarning(
+        code="experimental_api",
+        message=(
+            f"{route} is an experimental finite-difference service contract; "
+            "results require independent numerical validation before production use."
+        ),
+    )
+
+
+def _solver_metadata(
+    request: OptionRequest,
+    *,
+    include_grid: bool,
+    requested_outputs: list[str],
+) -> SolverMetadata:
+    """Build stable metadata for the current finite-difference route."""
+
+    return SolverMetadata(
+        engine="OptionPricer",
+        process="GeometricBrownianMotion",
+        scheme="finite_difference_black_scholes_reference",
+        s_steps=request.s_steps,
+        t_steps=request.t_steps,
+        grid_nodes=request.s_steps * request.t_steps,
+        output_grid_included=include_grid,
+        requested_outputs=requested_outputs,
+    )
+
+
+def _convergence_metadata() -> ConvergenceDiagnostics:
+    """Return explicit non-claim convergence metadata for experimental routes."""
+
+    return ConvergenceDiagnostics(
+        status="not_assessed",
+        message=(
+            "This endpoint returns a single-grid experimental solve; convergence, "
+            "oracle parity, and production model-risk evidence are tracked by separate gates."
+        ),
+    )
+
+
+def _success_metadata(
+    route: str,
+    request: OptionRequest,
+    *,
+    include_grid: bool,
+    requested_outputs: list[str],
+) -> ResponseMetadata:
+    """Build the success metadata envelope required by the v1 API schema."""
+
+    return ResponseMetadata(
+        route=route,
+        route_maturity="experimental",
+        warnings=[_route_warning(route, route_maturity="experimental")],
+        solver=_solver_metadata(
+            request,
+            include_grid=include_grid,
+            requested_outputs=requested_outputs,
+        ),
+        convergence=_convergence_metadata(),
+    )
+
+
+def _error_metadata(route: str, *, code: str) -> ResponseMetadata:
+    """Build the error metadata envelope without invoking numerical work."""
+
+    route_maturity: Literal["experimental", "unsupported"] = (
+        "unsupported" if code == "unsupported_route" else "experimental"
+    )
+    return ResponseMetadata(
+        route=route,
+        route_maturity=route_maturity,
+        warnings=[_route_warning(route, route_maturity=route_maturity)],
+        convergence=ConvergenceDiagnostics(
+            status="not_applicable",
+            message="No numerical solve was executed for this error response.",
+        ),
+    )
+
+
+def _response_identity(http_request: Request) -> dict[str, str]:
+    """Return common response identifiers."""
+
+    return {"request_id": _request_id(http_request), "run_id": _new_run_id()}
+
+
+def _error_code(status_code: int, detail: Any) -> str:
+    """Classify HTTP failures into stable public error codes."""
+
+    if status_code == 501:
+        return "unsupported_route"
+    if isinstance(detail, dict) and detail.get("capability_status") in {
+        "scaffold",
+        "unsupported",
+    }:
+        return "unsupported_route"
+    if status_code == 422:
+        return "validation_error"
+    if status_code == 400:
+        return "bad_request"
+    if status_code >= 500:
+        return "internal_error"
+    return "http_error"
+
+
+def _error_message(code: str, detail: Any) -> str:
+    """Return a concise human-readable message for the stable error envelope."""
+
+    if isinstance(detail, str):
+        return detail
+    if isinstance(detail, dict):
+        for key in ("message", "detail", "reason"):
+            if isinstance(detail.get(key), str):
+                return detail[key]
+    if code == "validation_error":
+        return "Request validation failed"
+    if code == "unsupported_route":
+        return "Route is unsupported or not implemented for the declared contract"
+    if code == "internal_error":
+        return "Internal server error"
+    return "Request failed"
+
+
+def _error_response(
+    http_request: Request,
+    *,
+    status_code: int,
+    detail: Any,
+    source: str,
+) -> JSONResponse:
+    """Serialize all public API errors through the stable v1 envelope."""
+
+    route = http_request.url.path
+    code = _error_code(status_code, detail)
+    body = ErrorResponse(
+        **_response_identity(http_request),
+        metadata=_error_metadata(route, code=code),
+        error=ErrorBody(
+            code=code,
+            message=_error_message(code, detail),
+            http_status=status_code,
+            route=route,
+            source=source,
+        ),
+        detail=detail,
+    )
+    return JSONResponse(status_code=status_code, content=body.model_dump(mode="json"))
+
+
+@app.exception_handler(RequestValidationError)
+def _validation_exception_handler(
+    http_request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    """Return Pydantic/FastAPI validation failures as stable v1 error responses."""
+
+    return _error_response(
+        http_request,
+        status_code=422,
+        detail=exc.errors(),
+        source="request_validation",
+    )
+
+
+@app.exception_handler(HTTPException)
+def _http_exception_handler(http_request: Request, exc: HTTPException) -> JSONResponse:
+    """Return explicit HTTP failures as stable v1 error responses."""
+
+    return _error_response(
+        http_request,
+        status_code=exc.status_code,
+        detail=exc.detail,
+        source="http_exception",
+    )
+
+
+@app.exception_handler(Exception)
+def _unhandled_exception_handler(http_request: Request, exc: Exception) -> JSONResponse:
+    """Return unexpected failures as redacted stable v1 error responses."""
+
+    return _error_response(
+        http_request,
+        status_code=500,
+        detail={"exception_type": type(exc).__name__},
+        source="unhandled_exception",
+    )
 
 
 def _option_class(option_type: OptionType) -> type[EuropeanCall] | type[EuropeanPut]:
@@ -160,12 +465,19 @@ def _grid_payload(res) -> PriceGrid:
     return PriceGrid(s=res.s.tolist(), t=res.t.tolist(), values=res.values.tolist())
 
 
-@app.post("/price", response_model=PriceResponse)
-def price(request: OptionRequest) -> PriceResponse:
+@app.post("/price", response_model=PriceResponse, responses=API_ERROR_RESPONSES)
+def price(request: OptionRequest, http_request: Request) -> PriceResponse:
     """Return requested-spot price and optional bounded grid for an option."""
 
     res = _compute_grid(request)
     return PriceResponse(
+        **_response_identity(http_request),
+        metadata=_success_metadata(
+            "/price",
+            request,
+            include_grid=request.include_full_grid,
+            requested_outputs=["price"],
+        ),
         option_type=request.option_type,
         spot=request.spot,
         price=_interp_at_spot(res.values[-1], res.s, request.spot),
@@ -173,14 +485,23 @@ def price(request: OptionRequest) -> PriceResponse:
     )
 
 
-@app.post("/greeks", response_model=GreeksResponse)
-def greeks(request: OptionRequest) -> GreeksResponse:
+@app.post("/greeks", response_model=GreeksResponse, responses=API_ERROR_RESPONSES)
+def greeks(request: OptionRequest, http_request: Request) -> GreeksResponse:
     """Return scalar Greeks at the explicitly requested spot."""
 
     res = _compute_grid(request, return_greeks=True)
-    if res.delta is None or res.gamma is None or res.theta is None:  # pragma: no cover - defensive
+    if (
+        res.delta is None or res.gamma is None or res.theta is None
+    ):  # pragma: no cover - defensive
         raise HTTPException(status_code=500, detail="Greek grid was not computed")
     return GreeksResponse(
+        **_response_identity(http_request),
+        metadata=_success_metadata(
+            "/greeks",
+            request,
+            include_grid=False,
+            requested_outputs=["delta", "gamma", "theta"],
+        ),
         option_type=request.option_type,
         spot=request.spot,
         delta=_interp_at_spot(res.delta[-1], res.s, request.spot),
@@ -189,8 +510,10 @@ def greeks(request: OptionRequest) -> GreeksResponse:
     )
 
 
-@app.post("/pde_solution", response_model=FullPDEResponse)
-def pde_solution(request: OptionRequest) -> FullPDEResponse:
+@app.post(
+    "/pde_solution", response_model=FullPDEResponse, responses=API_ERROR_RESPONSES
+)
+def pde_solution(request: OptionRequest, http_request: Request) -> FullPDEResponse:
     """Return complete solution and Greeks grids only after explicit opt-in."""
 
     if not request.include_full_grid:
@@ -199,9 +522,18 @@ def pde_solution(request: OptionRequest) -> FullPDEResponse:
             detail="include_full_grid must be true to return the full PDE grid",
         )
     res = _compute_grid(request, return_greeks=True)
-    if res.delta is None or res.gamma is None or res.theta is None:  # pragma: no cover - defensive
+    if (
+        res.delta is None or res.gamma is None or res.theta is None
+    ):  # pragma: no cover - defensive
         raise HTTPException(status_code=500, detail="Greek grid was not computed")
     return FullPDEResponse(
+        **_response_identity(http_request),
+        metadata=_success_metadata(
+            "/pde_solution",
+            request,
+            include_grid=True,
+            requested_outputs=["price_grid", "delta_grid", "gamma_grid", "theta_grid"],
+        ),
         option_type=request.option_type,
         spot=request.spot,
         s=res.s.tolist(),
@@ -239,12 +571,6 @@ class ExposureModel(BaseModel):
     amount: float
 
 
-class RegulatoryNotImplementedResponse(BaseModel):
-    """Machine-readable failure for disabled regulatory/reporting routes."""
-
-    detail: dict
-
-
 def _raise_regulatory_not_implemented(error: NotImplementedForStandard) -> None:
     """Convert internal regulatory failures to HTTP 501 problem details."""
 
@@ -265,7 +591,12 @@ def _convert_exposures(models: list[ExposureModel]) -> list[Exposure]:
     ]
 
 
-@app.post("/reports/crif", response_model=RegulatoryNotImplementedResponse)
+@app.post(
+    "/reports/crif",
+    response_model=ErrorResponse,
+    status_code=501,
+    responses=UNSUPPORTED_ROUTE_RESPONSES,
+)
 def crif_report(exposures: list[ExposureModel]) -> None:
     """Fail closed until an exact ISDA CRIF profile and conformance suite exist."""
 
@@ -276,7 +607,12 @@ def crif_report(exposures: list[ExposureModel]) -> None:
         _raise_regulatory_not_implemented(exc)
 
 
-@app.post("/reports/cuso", response_model=RegulatoryNotImplementedResponse)
+@app.post(
+    "/reports/cuso",
+    response_model=ErrorResponse,
+    status_code=501,
+    responses=UNSUPPORTED_ROUTE_RESPONSES,
+)
 def cuso_report(exposures: list[ExposureModel]) -> None:
     """Fail closed until an authoritative CUSO specification exists."""
 
@@ -287,7 +623,12 @@ def cuso_report(exposures: list[ExposureModel]) -> None:
         _raise_regulatory_not_implemented(exc)
 
 
-@app.post("/reports/basel", response_model=RegulatoryNotImplementedResponse)
+@app.post(
+    "/reports/basel",
+    response_model=ErrorResponse,
+    status_code=501,
+    responses=UNSUPPORTED_ROUTE_RESPONSES,
+)
 def basel_report(exposures: list[ExposureModel]) -> None:
     """Fail closed until a versioned Basel market-risk subset is implemented."""
 
@@ -298,7 +639,12 @@ def basel_report(exposures: list[ExposureModel]) -> None:
         _raise_regulatory_not_implemented(exc)
 
 
-@app.post("/reports/frtb", response_model=RegulatoryNotImplementedResponse)
+@app.post(
+    "/reports/frtb",
+    response_model=ErrorResponse,
+    status_code=501,
+    responses=UNSUPPORTED_ROUTE_RESPONSES,
+)
 def frtb_report(exposures: list[ExposureModel]) -> None:
     """Fail closed until a versioned FRTB calculation subset is implemented."""
 

--- a/docs/CI_POLICY.md
+++ b/docs/CI_POLICY.md
@@ -13,12 +13,12 @@ The Python job uses Python 3.12 and reports failures by command group:
 
 1. install dependencies from `requirements.txt` and `requirements-dev.txt`;
 2. static smoke gate:
-   - `python -m compileall -q src tests`;
+   - `python -m compileall -q api src tests`;
    - `ruff check . --select E9,F63,F7,F82`;
 3. architecture fitness gate:
    - `pytest -q tests/architecture`;
 4. stable regression suite:
-   - API request guards, schema contracts, and regulatory fail-closed envelopes;
+   - `PYTHONPATH=. pytest -q` with API request guards, schema contracts, and regulatory fail-closed envelopes;
    - boundary conditions;
    - callable bond;
    - FD backend capability manifest;

--- a/docs/CI_POLICY.md
+++ b/docs/CI_POLICY.md
@@ -18,6 +18,7 @@ The Python job uses Python 3.12 and reports failures by command group:
 3. architecture fitness gate:
    - `pytest -q tests/architecture`;
 4. stable regression suite:
+   - API request guards, schema contracts, and regulatory fail-closed envelopes;
    - boundary conditions;
    - callable bond;
    - FD backend capability manifest;

--- a/tests/architecture/test_ci_policy_contracts.py
+++ b/tests/architecture/test_ci_policy_contracts.py
@@ -12,11 +12,13 @@ def test_blocking_ci_has_actionable_python_and_stable_suite_contract() -> None:
     workflow = _read(".github/workflows/ci.yml")
 
     assert "Static smoke gate" in workflow
-    assert "python -m compileall -q src tests" in workflow
+    assert "python -m compileall -q api src tests" in workflow
     assert "ruff check . --select E9,F63,F7,F82" in workflow
     assert "Architecture fitness gate" in workflow
     assert "pytest -q tests/architecture" in workflow
     assert "Stable regression suite" in workflow
+    assert "PYTHONPATH=. pytest -q" in workflow
+    assert "tests/test_api_schema_contracts.py" in workflow
     assert "tests/test_unified_pricing_engine.py" in workflow
 
 
@@ -35,7 +37,10 @@ def test_gemini_review_and_issue_triage_failures_are_advisory() -> None:
 
     assert "continue-on-error: true" in pr_review
     assert "Classify unavailable Gemini PR review as advisory" in pr_review
-    assert "review-service events, not as Python/Node/package validation failures" in pr_review
+    assert (
+        "review-service events, not as Python/Node/package validation failures"
+        in pr_review
+    )
     assert "Post PR review failure comment" not in pr_review
 
     assert "continue-on-error: true" in issue_triage

--- a/tests/test_api_schema_contracts.py
+++ b/tests/test_api_schema_contracts.py
@@ -1,0 +1,216 @@
+"""Stable API schema and OpenAPI contract tests for issue #97."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+import api.main as api_main
+from api.main import API_SCHEMA_VERSION, app
+
+
+def _payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "option_type": "Call",
+        "spot": 100.0,
+        "strike": 100.0,
+        "maturity": 0.25,
+        "rate": 0.03,
+        "sigma": 0.2,
+        "s_max": 250.0,
+        "s_steps": 31,
+        "t_steps": 21,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _assert_base_success_contract(body: dict[str, Any], route: str) -> None:
+    assert body["schema_version"] == API_SCHEMA_VERSION
+    assert isinstance(body["request_id"], str) and body["request_id"]
+    assert isinstance(body["run_id"], str) and body["run_id"].startswith("fd-run-")
+    metadata = body["metadata"]
+    assert isinstance(metadata, dict)
+    assert metadata["route"] == route
+    assert metadata["route_maturity"] == "experimental"
+    assert metadata["warnings"]
+    assert metadata["units"]["time"] == "years"
+    assert metadata["units"]["rate"] == "annual_decimal"
+    assert metadata["solver"]["engine"] == "OptionPricer"
+    assert metadata["solver"]["grid_nodes"] == 31 * 21
+    assert metadata["convergence"]["status"] == "not_assessed"
+
+
+def _assert_error_envelope(
+    body: dict[str, Any], *, code: str, route: str, status: int
+) -> None:
+    assert body["schema_version"] == API_SCHEMA_VERSION
+    assert isinstance(body["request_id"], str) and body["request_id"]
+    assert isinstance(body["run_id"], str) and body["run_id"].startswith("fd-run-")
+    error = body["error"]
+    assert error["code"] == code
+    assert error["route"] == route
+    assert error["http_status"] == status
+    assert body["metadata"]["route"] == route
+
+
+def test_successful_price_greeks_and_pde_routes_share_versioned_metadata_contract() -> (
+    None
+):
+    client = TestClient(app)
+
+    price = client.post(
+        "/price", json=_payload(), headers={"X-Request-ID": "req-schema-97"}
+    )
+    greeks = client.post("/greeks", json=_payload())
+    pde = client.post("/pde_solution", json=_payload(include_full_grid=True))
+
+    assert price.status_code == 200
+    assert price.json()["request_id"] == "req-schema-97"
+    _assert_base_success_contract(price.json(), "/price")
+
+    assert greeks.status_code == 200
+    _assert_base_success_contract(greeks.json(), "/greeks")
+    assert {"delta", "gamma", "theta"}.issubset(greeks.json())
+
+    assert pde.status_code == 200
+    _assert_base_success_contract(pde.json(), "/pde_solution")
+    assert {"prices", "delta", "gamma", "theta"}.issubset(pde.json())
+
+
+def test_validation_errors_are_machine_readable_and_preserve_stable_ids() -> None:
+    client = TestClient(app)
+
+    response = client.post(
+        "/price",
+        json=_payload(option_type="Digital"),
+        headers={"X-Request-ID": "bad-option-type"},
+    )
+
+    assert response.status_code == 422
+    body = response.json()
+    _assert_error_envelope(body, code="validation_error", route="/price", status=422)
+    assert body["request_id"] == "bad-option-type"
+    assert "option_type" in str(body["detail"])
+    assert body["metadata"]["route_maturity"] == "experimental"
+
+
+def test_unhandled_internal_errors_are_machine_readable_without_leaking_tracebacks(
+    monkeypatch,
+) -> None:
+    client = TestClient(app, raise_server_exceptions=False)
+
+    def fail_solver(*args: object, **kwargs: object) -> object:
+        raise RuntimeError("synthetic solver failure with private internals")
+
+    monkeypatch.setattr(api_main, "_compute_grid", fail_solver)
+    response = client.post(
+        "/price",
+        json=_payload(),
+        headers={"X-Request-ID": "internal-failure"},
+    )
+
+    assert response.status_code == 500
+    body = response.json()
+    _assert_error_envelope(body, code="internal_error", route="/price", status=500)
+    assert body["request_id"] == "internal-failure"
+    assert body["error"]["message"] == "Internal server error"
+    assert body["detail"] == {"exception_type": "RuntimeError"}
+    assert "private internals" not in str(body)
+
+
+def test_unsupported_and_bad_request_routes_use_the_same_error_envelope() -> None:
+    client = TestClient(app)
+
+    bad_request = client.post("/pde_solution", json=_payload())
+    unsupported = client.post("/reports/crif", json=[])
+
+    assert bad_request.status_code == 400
+    bad_body = bad_request.json()
+    _assert_error_envelope(
+        bad_body,
+        code="bad_request",
+        route="/pde_solution",
+        status=400,
+    )
+    assert "include_full_grid" in bad_body["error"]["message"]
+
+    assert unsupported.status_code == 501
+    unsupported_body = unsupported.json()
+    _assert_error_envelope(
+        unsupported_body,
+        code="unsupported_route",
+        route="/reports/crif",
+        status=501,
+    )
+    assert unsupported_body["detail"]["capability_status"] in {
+        "scaffold",
+        "unsupported",
+    }
+
+
+def test_openapi_schema_contains_reviewed_v1_response_error_components() -> None:
+    schema = TestClient(app).get("/openapi.json").json()
+    components = schema["components"]["schemas"]
+
+    required_components = {
+        "PriceResponse",
+        "GreeksResponse",
+        "FullPDEResponse",
+        "ErrorResponse",
+        "ErrorBody",
+        "ResponseMetadata",
+        "SolverMetadata",
+        "ConvergenceDiagnostics",
+        "UnitMetadata",
+        "RouteWarning",
+    }
+    assert required_components.issubset(components)
+
+    for name in ("PriceResponse", "GreeksResponse", "FullPDEResponse"):
+        properties = components[name]["properties"]
+        assert {"schema_version", "request_id", "run_id", "metadata"}.issubset(
+            properties
+        )
+
+    error_properties = components["ErrorResponse"]["properties"]
+    assert {
+        "schema_version",
+        "request_id",
+        "run_id",
+        "metadata",
+        "error",
+        "detail",
+    }.issubset(error_properties)
+
+    success_refs = {
+        "/price": "PriceResponse",
+        "/greeks": "GreeksResponse",
+        "/pde_solution": "FullPDEResponse",
+    }
+    for path, model_name in success_refs.items():
+        response_schema = schema["paths"][path]["post"]["responses"]["200"]["content"][
+            "application/json"
+        ]["schema"]
+        assert response_schema["$ref"].endswith(f"/{model_name}")
+
+    for path in [
+        "/price",
+        "/greeks",
+        "/pde_solution",
+        "/reports/crif",
+        "/reports/cuso",
+        "/reports/basel",
+        "/reports/frtb",
+    ]:
+        operation = schema["paths"][path]["post"]
+        assert "422" in operation["responses"]
+        assert operation["responses"]["422"]["content"]["application/json"]["schema"][
+            "$ref"
+        ].endswith("/ErrorResponse")
+
+    for path in ["/reports/crif", "/reports/cuso", "/reports/basel", "/reports/frtb"]:
+        assert schema["paths"][path]["post"]["responses"]["501"]["content"][
+            "application/json"
+        ]["schema"]["$ref"].endswith("/ErrorResponse")


### PR DESCRIPTION
## Summary

Closes #97.

Implements the issue #53 API-schema slice by making the FastAPI public surface use stable `fd-api-v1` success and error envelopes.

## What changed

- Added versioned success response metadata: `schema_version`, `request_id`, `run_id`, route maturity, warnings, units, solver/grid metadata, and explicit convergence status.
- Added `ErrorResponse` / `ErrorBody` envelopes for validation, bad-request, unsupported-route, and redacted internal errors.
- Added OpenAPI compatibility tests for response components, success route refs, error refs, and all unsupported report routes.
- Added the API schema tests to blocking CI and documented the schema maturity in the README/CI policy.

## Verification

Local verification on Python 3.12 in `/tmp/qpe-fdo-venv`:

- `python -m compileall -q api src tests`
- `ruff check . --select E9,F63,F7,F82`
- `black --check api/main.py tests/test_api_schema_contracts.py`
- `python scripts/check_architecture_contract.py`
- `pytest -q tests/architecture` → 11 passed
- `pytest -q` → 207 passed, 14 third-party matplotlib/pyparsing warnings
- Node profile check: `nextjs-client` absent, matching CI skip behavior

## Notes

Parent #53 remains open until child slices #98-#101 are implemented or explicitly superseded with evidence.
