### PR TITLE
Validate API route contracts fail closed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           PYTHONPATH=. pytest -q \
             tests/test_api_request_guards.py \
             tests/test_api_schema_contracts.py \
+            tests/test_api_route_validation.py \
             tests/test_regulatory_fail_closed.py \
             tests/test_boundary_conditions.py \
             tests/test_callable_bond.py \

--- a/README.md
+++ b/README.md
@@ -154,10 +154,15 @@ The service allows cross-origin requests from `http://localhost:5173`.
 uvicorn api.main:app --reload
 ```
 
-Pricing requests use a versioned schema with explicit `spot`, enum `option_type`, finite/range numeric validation, a pre-solve node budget, and full-grid output disabled by default:
+Pricing requests use a versioned schema with explicit model/payoff/process contracts, explicit `spot`, enum `option_type`, finite/range numeric validation, a pre-solve node budget, and full-grid output disabled by default:
 
 ```json
 {
+  "model": "black_scholes",
+  "process": "geometric_brownian_motion",
+  "payoff_family": "vanilla_european",
+  "exercise_style": "european",
+  "underlying_factor_role": "tradable_spot",
   "option_type": "Call",
   "spot": 100.0,
   "strike": 100.0,
@@ -182,7 +187,7 @@ Endpoints:
 - `POST /reports/basel` → HTTP 501 `ErrorResponse` until a versioned Basel market-risk subset is implemented
 - `POST /reports/frtb` → HTTP 501 `ErrorResponse` until a versioned FRTB calculation subset is implemented
 
-Validation, bad-request, internal, and unsupported-route failures are concise machine-readable `ErrorResponse` objects with stable `error.code`, `error.http_status`, route, request/run IDs, and original diagnostic `detail`. OpenAPI compatibility tests guard these public schema components from unreviewed drift.
+Validation, bad-request, internal, and unsupported-route failures are concise machine-readable `ErrorResponse` objects with stable `error.code`, `error.http_status`, route, request/run IDs, and original diagnostic `detail`. The pricing, Greeks, and PDE routes currently execute only the explicit Black-Scholes / geometric-Brownian-motion / vanilla-European / tradable-spot contract; recognized but unsupported model, process, payoff, exercise-style, or factor-role combinations fail closed with HTTP 501 before numerical work. OpenAPI compatibility tests guard these public schema components from unreviewed drift.
 
 ## Next.js Client
 

--- a/api/main.py
+++ b/api/main.py
@@ -48,6 +48,48 @@ class OptionType(str, Enum):
     PUT = "Put"
 
 
+class PricingModel(str, Enum):
+    """Recognized pricing model contracts at the API boundary."""
+
+    BLACK_SCHOLES = "black_scholes"
+    HESTON = "heston"
+    LOCAL_VOLATILITY = "local_volatility"
+
+
+class ProcessType(str, Enum):
+    """Recognized stochastic-process contracts at the API boundary."""
+
+    GEOMETRIC_BROWNIAN_MOTION = "geometric_brownian_motion"
+    HESTON = "heston"
+    SABR = "sabr"
+
+
+class PayoffFamily(str, Enum):
+    """Recognized payoff families at the API boundary."""
+
+    VANILLA_EUROPEAN = "vanilla_european"
+    BASKET = "basket"
+    SPREAD = "spread"
+    DIGITAL = "digital"
+
+
+class ExerciseStyle(str, Enum):
+    """Recognized exercise styles at the API boundary."""
+
+    EUROPEAN = "european"
+    AMERICAN = "american"
+
+
+class FactorRole(str, Enum):
+    """Recognized state-factor roles for payoff compatibility checks."""
+
+    TRADABLE_SPOT = "tradable_spot"
+    VARIANCE = "variance"
+    VOLATILITY = "volatility"
+    SHORT_RATE = "short_rate"
+    AUXILIARY_STATE = "auxiliary_state"
+
+
 class OptionRequest(BaseModel):
     """Validated request payload for option pricing endpoints.
 
@@ -61,6 +103,11 @@ class OptionRequest(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    model: PricingModel = PricingModel.BLACK_SCHOLES
+    process: ProcessType = ProcessType.GEOMETRIC_BROWNIAN_MOTION
+    payoff_family: PayoffFamily = PayoffFamily.VANILLA_EUROPEAN
+    exercise_style: ExerciseStyle = ExerciseStyle.EUROPEAN
+    underlying_factor_role: FactorRole = FactorRole.TRADABLE_SPOT
     option_type: OptionType = OptionType.CALL
     spot: float = Field(..., gt=0.0, allow_inf_nan=False)
     strike: float = Field(..., gt=0.0, allow_inf_nan=False)
@@ -72,10 +119,19 @@ class OptionRequest(BaseModel):
     t_steps: int = Field(default=100, ge=3, le=5_000)
     include_full_grid: bool = False
     max_output_nodes: int = Field(default=50_000, ge=1, le=50_000)
+    correlation: Optional[float] = Field(
+        default=None, ge=-1.0, le=1.0, allow_inf_nan=False
+    )
+    variance: Optional[float] = Field(default=None, ge=0.0, allow_inf_nan=False)
+    long_run_variance: Optional[float] = Field(
+        default=None, ge=0.0, allow_inf_nan=False
+    )
+    mean_reversion: Optional[float] = Field(default=None, gt=0.0, allow_inf_nan=False)
+    vol_of_vol: Optional[float] = Field(default=None, ge=0.0, allow_inf_nan=False)
 
     @model_validator(mode="after")
-    def validate_api_budget_and_domain(self) -> "OptionRequest":
-        """Reject impossible or unbounded requests before numerical work."""
+    def validate_api_budget_domain_and_model_fields(self) -> "OptionRequest":
+        """Reject impossible, unbounded, or mismatched requests before numerical work."""
 
         s_max = self.resolved_s_max
         if self.spot > s_max:
@@ -87,6 +143,23 @@ class OptionRequest(BaseModel):
             raise ValueError(
                 f"request exceeds node budget: {node_count} > {self.max_output_nodes}"
             )
+        if self.model == PricingModel.BLACK_SCHOLES:
+            extra_model_fields = [
+                name
+                for name in (
+                    "correlation",
+                    "variance",
+                    "long_run_variance",
+                    "mean_reversion",
+                    "vol_of_vol",
+                )
+                if getattr(self, name) is not None
+            ]
+            if extra_model_fields:
+                raise ValueError(
+                    "black_scholes route does not accept model-specific fields: "
+                    + ", ".join(extra_model_fields)
+                )
         return self
 
     @property
@@ -124,7 +197,11 @@ class SolverMetadata(BaseModel):
     """Numerical route metadata exposed without claiming production maturity."""
 
     engine: str
+    model: str
     process: str
+    payoff_family: str
+    exercise_style: str
+    underlying_factor_role: str
     scheme: str
     s_steps: int
     t_steps: int
@@ -223,6 +300,7 @@ API_ERROR_RESPONSES: dict[int | str, dict[str, Any]] = {
     400: {"model": ErrorResponse},
     422: {"model": ErrorResponse},
     500: {"model": ErrorResponse},
+    501: {"model": ErrorResponse},
 }
 UNSUPPORTED_ROUTE_RESPONSES: dict[int | str, dict[str, Any]] = {
     501: {"model": ErrorResponse},
@@ -269,7 +347,11 @@ def _solver_metadata(
 
     return SolverMetadata(
         engine="OptionPricer",
-        process="GeometricBrownianMotion",
+        model=request.model.value,
+        process=request.process.value,
+        payoff_family=request.payoff_family.value,
+        exercise_style=request.exercise_style.value,
+        underlying_factor_role=request.underlying_factor_role.value,
         scheme="finite_difference_black_scholes_reference",
         s_steps=request.s_steps,
         t_steps=request.t_steps,
@@ -399,6 +481,21 @@ def _error_response(
     return JSONResponse(status_code=status_code, content=body.model_dump(mode="json"))
 
 
+def _validation_error_details(exc: RequestValidationError) -> list[dict[str, Any]]:
+    """Return validation errors without non-JSON-serializable exception objects."""
+
+    details: list[dict[str, Any]] = []
+    for error in exc.errors():
+        clean_error = {key: value for key, value in error.items() if key != "ctx"}
+        ctx = error.get("ctx")
+        if isinstance(ctx, dict):
+            clean_context = {key: str(value) for key, value in ctx.items()}
+            if clean_context:
+                clean_error["ctx"] = clean_context
+        details.append(clean_error)
+    return details
+
+
 @app.exception_handler(RequestValidationError)
 def _validation_exception_handler(
     http_request: Request, exc: RequestValidationError
@@ -408,7 +505,7 @@ def _validation_exception_handler(
     return _error_response(
         http_request,
         status_code=422,
-        detail=exc.errors(),
+        detail=_validation_error_details(exc),
         source="request_validation",
     )
 
@@ -441,6 +538,69 @@ def _option_class(option_type: OptionType) -> type[EuropeanCall] | type[European
     return EuropeanCall if option_type == OptionType.CALL else EuropeanPut
 
 
+def _contract_dict(request: OptionRequest) -> dict[str, str]:
+    """Return the model/payoff/process contract fields as JSON-safe strings."""
+
+    return {
+        "model": request.model.value,
+        "process": request.process.value,
+        "payoff_family": request.payoff_family.value,
+        "exercise_style": request.exercise_style.value,
+        "underlying_factor_role": request.underlying_factor_role.value,
+    }
+
+
+def _supported_contract() -> dict[str, str]:
+    """Return the only numerical route contract currently implemented."""
+
+    return {
+        "model": PricingModel.BLACK_SCHOLES.value,
+        "process": ProcessType.GEOMETRIC_BROWNIAN_MOTION.value,
+        "payoff_family": PayoffFamily.VANILLA_EUROPEAN.value,
+        "exercise_style": ExerciseStyle.EUROPEAN.value,
+        "underlying_factor_role": FactorRole.TRADABLE_SPOT.value,
+    }
+
+
+def _unsupported_contract_reason(request: OptionRequest) -> str | None:
+    """Explain why a recognized contract is unsupported, or None if supported."""
+
+    if request.model != PricingModel.BLACK_SCHOLES:
+        return f"model {request.model.value} is not enabled"
+    if request.process != ProcessType.GEOMETRIC_BROWNIAN_MOTION:
+        return (
+            f"process {request.process.value} is incompatible with model black_scholes"
+        )
+    if request.payoff_family != PayoffFamily.VANILLA_EUROPEAN:
+        return f"payoff family {request.payoff_family.value} is incompatible with model black_scholes"
+    if request.exercise_style != ExerciseStyle.EUROPEAN:
+        return f"exercise style {request.exercise_style.value} is incompatible with model black_scholes"
+    if request.underlying_factor_role != FactorRole.TRADABLE_SPOT:
+        return (
+            f"factor role {request.underlying_factor_role.value} is incompatible "
+            "with one-dimensional tradable-spot Black-Scholes"
+        )
+    return None
+
+
+def _ensure_supported_contract(request: OptionRequest, *, route: str) -> None:
+    """Fail closed for recognized but currently unimplemented route contracts."""
+
+    reason = _unsupported_contract_reason(request)
+    if reason is None:
+        return
+    raise HTTPException(
+        status_code=501,
+        detail={
+            "capability_status": "unsupported",
+            "reason": reason,
+            "route": route,
+            "requested_contract": _contract_dict(request),
+            "supported_contract": _supported_contract(),
+        },
+    )
+
+
 def _compute_grid(request: OptionRequest, *, return_greeks: bool = False):
     model = GeometricBrownianMotion(mu=request.rate, sigma=request.sigma)
     instrument = _option_class(request.option_type)(
@@ -469,6 +629,7 @@ def _grid_payload(res) -> PriceGrid:
 def price(request: OptionRequest, http_request: Request) -> PriceResponse:
     """Return requested-spot price and optional bounded grid for an option."""
 
+    _ensure_supported_contract(request, route="/price")
     res = _compute_grid(request)
     return PriceResponse(
         **_response_identity(http_request),
@@ -489,6 +650,7 @@ def price(request: OptionRequest, http_request: Request) -> PriceResponse:
 def greeks(request: OptionRequest, http_request: Request) -> GreeksResponse:
     """Return scalar Greeks at the explicitly requested spot."""
 
+    _ensure_supported_contract(request, route="/greeks")
     res = _compute_grid(request, return_greeks=True)
     if (
         res.delta is None or res.gamma is None or res.theta is None
@@ -516,6 +678,7 @@ def greeks(request: OptionRequest, http_request: Request) -> GreeksResponse:
 def pde_solution(request: OptionRequest, http_request: Request) -> FullPDEResponse:
     """Return complete solution and Greeks grids only after explicit opt-in."""
 
+    _ensure_supported_contract(request, route="/pde_solution")
     if not request.include_full_grid:
         raise HTTPException(
             status_code=400,

--- a/docs/CI_POLICY.md
+++ b/docs/CI_POLICY.md
@@ -18,7 +18,7 @@ The Python job uses Python 3.12 and reports failures by command group:
 3. architecture fitness gate:
    - `pytest -q tests/architecture`;
 4. stable regression suite:
-   - `PYTHONPATH=. pytest -q` with API request guards, schema contracts, and regulatory fail-closed envelopes;
+   - `PYTHONPATH=. pytest -q` with API request guards, schema contracts, route validation, and regulatory fail-closed envelopes;
    - boundary conditions;
    - callable bond;
    - FD backend capability manifest;

--- a/tests/architecture/test_ci_policy_contracts.py
+++ b/tests/architecture/test_ci_policy_contracts.py
@@ -19,6 +19,7 @@ def test_blocking_ci_has_actionable_python_and_stable_suite_contract() -> None:
     assert "Stable regression suite" in workflow
     assert "PYTHONPATH=. pytest -q" in workflow
     assert "tests/test_api_schema_contracts.py" in workflow
+    assert "tests/test_api_route_validation.py" in workflow
     assert "tests/test_unified_pricing_engine.py" in workflow
 
 

--- a/tests/test_api_route_validation.py
+++ b/tests/test_api_route_validation.py
@@ -1,0 +1,182 @@
+"""API model/payoff/process fail-closed validation tests for issue #98."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import API_SCHEMA_VERSION, app
+
+
+def _payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "model": "black_scholes",
+        "process": "geometric_brownian_motion",
+        "payoff_family": "vanilla_european",
+        "exercise_style": "european",
+        "underlying_factor_role": "tradable_spot",
+        "option_type": "Call",
+        "spot": 100.0,
+        "strike": 100.0,
+        "maturity": 0.25,
+        "rate": 0.03,
+        "sigma": 0.2,
+        "s_max": 250.0,
+        "s_steps": 31,
+        "t_steps": 21,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _assert_unsupported(
+    response, *, route: str, reason_fragment: str
+) -> dict[str, object]:
+    assert response.status_code == 501
+    body = response.json()
+    assert body["schema_version"] == API_SCHEMA_VERSION
+    assert body["error"]["code"] == "unsupported_route"
+    assert body["error"]["route"] == route
+    assert body["metadata"]["route_maturity"] == "unsupported"
+    assert body["detail"]["capability_status"] == "unsupported"
+    assert reason_fragment in body["detail"]["reason"]
+    assert body["detail"]["supported_contract"]["model"] == "black_scholes"
+    return body
+
+
+def test_supported_black_scholes_vanilla_contract_is_explicit_and_still_prices() -> (
+    None
+):
+    response = TestClient(app).post("/price", json=_payload())
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["schema_version"] == API_SCHEMA_VERSION
+    solver = body["metadata"]["solver"]
+    assert solver["model"] == "black_scholes"
+    assert solver["process"] == "geometric_brownian_motion"
+    assert solver["payoff_family"] == "vanilla_european"
+    assert solver["exercise_style"] == "european"
+
+
+@pytest.mark.parametrize(
+    ("field", "bad_value"),
+    [
+        ("model", "merton_jump_diffusion"),
+        ("process", "unknown_process"),
+        ("payoff_family", "quanto_cliquet"),
+        ("exercise_style", "bermudan"),
+        ("underlying_factor_role", "inflation_index"),
+    ],
+)
+def test_unknown_model_payoff_process_enum_values_are_validation_errors(
+    field: str,
+    bad_value: str,
+) -> None:
+    response = TestClient(app).post("/price", json=_payload(**{field: bad_value}))
+
+    assert response.status_code == 422
+    body = response.json()
+    assert body["error"]["code"] == "validation_error"
+    assert field in str(body["detail"])
+
+
+@pytest.mark.parametrize(
+    ("overrides", "reason_fragment"),
+    [
+        ({"model": "heston", "process": "heston"}, "model heston is not enabled"),
+        ({"process": "heston"}, "process heston is incompatible"),
+        ({"payoff_family": "basket"}, "payoff family basket is incompatible"),
+        ({"payoff_family": "digital"}, "payoff family digital is incompatible"),
+        ({"exercise_style": "american"}, "exercise style american is incompatible"),
+        (
+            {"underlying_factor_role": "variance"},
+            "factor role variance is incompatible",
+        ),
+    ],
+)
+def test_known_but_unsupported_route_contracts_fail_closed_before_pricing(
+    overrides: dict[str, object],
+    reason_fragment: str,
+) -> None:
+    response = TestClient(app).post("/price", json=_payload(**overrides))
+
+    body = _assert_unsupported(
+        response, route="/price", reason_fragment=reason_fragment
+    )
+    assert (
+        body["detail"]["requested_contract"]["model"] == _payload(**overrides)["model"]
+    )
+
+
+def test_unsupported_contracts_fail_closed_on_greeks_and_full_pde_routes() -> None:
+    client = TestClient(app)
+
+    greeks = client.post("/greeks", json=_payload(model="heston", process="heston"))
+    pde = client.post(
+        "/pde_solution",
+        json=_payload(model="heston", process="heston", include_full_grid=True),
+    )
+
+    _assert_unsupported(
+        greeks, route="/greeks", reason_fragment="model heston is not enabled"
+    )
+    _assert_unsupported(
+        pde, route="/pde_solution", reason_fragment="model heston is not enabled"
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "bad_value"),
+    [
+        ("correlation", 1.5),
+        ("correlation", -1.5),
+        ("variance", -0.01),
+        ("long_run_variance", -0.01),
+        ("mean_reversion", 0.0),
+        ("vol_of_vol", -0.01),
+    ],
+)
+def test_model_specific_scalar_constraints_are_validated(
+    field: str, bad_value: float
+) -> None:
+    response = TestClient(app).post(
+        "/price", json=_payload(model="heston", **{field: bad_value})
+    )
+
+    assert response.status_code == 422
+    body = response.json()
+    assert body["error"]["code"] == "validation_error"
+    assert field in str(body["detail"])
+
+
+def test_supported_black_scholes_route_rejects_unused_heston_parameters() -> None:
+    response = TestClient(app).post("/price", json=_payload(variance=0.04))
+
+    assert response.status_code == 422
+    body = response.json()
+    assert body["error"]["code"] == "validation_error"
+    assert "black_scholes route does not accept model-specific fields" in str(
+        body["detail"]
+    )
+
+
+def test_openapi_exposes_explicit_model_payoff_process_enums() -> None:
+    schema = TestClient(app).get("/openapi.json").json()
+    components = schema["components"]["schemas"]
+
+    for enum_name in [
+        "PricingModel",
+        "ProcessType",
+        "PayoffFamily",
+        "ExerciseStyle",
+        "FactorRole",
+    ]:
+        assert enum_name in components
+
+    option_request = components["OptionRequest"]["properties"]
+    assert option_request["model"]["$ref"].endswith("/PricingModel")
+    assert option_request["process"]["$ref"].endswith("/ProcessType")
+    assert option_request["payoff_family"]["$ref"].endswith("/PayoffFamily")
+    assert option_request["exercise_style"]["$ref"].endswith("/ExerciseStyle")
+    assert option_request["underlying_factor_role"]["$ref"].endswith("/FactorRole")


### PR DESCRIPTION
## Summary
- Add explicit API route contract enums for model, process, payoff family, exercise style, and underlying factor role.
- Fail closed with stable HTTP 501 `ErrorResponse` before numerical work for recognized but unsupported API route contracts.
- Keep the supported Black-Scholes / GBM / vanilla-European / tradable-spot route backward-compatible through defaults.
- Add route-validation tests to the blocking CI stable suite and update README/CI policy docs.

Closes #98

## Evidence
- `/tmp/qpe-fdo-venv/bin/python -m pytest -q tests/test_api_route_validation.py` -> 21 passed
- API/architecture focused suite -> 60 passed
- Local CI stable suite -> 166 passed, 14 existing matplotlib/pyparsing warnings
- `/tmp/qpe-fdo-venv/bin/python -m pytest -q` -> 228 passed, 14 existing matplotlib/pyparsing warnings
- `git diff --check` -> clean
- Added-line secret/injection scan -> no findings
- Independent pre-commit review -> no blocking issues

## Acceptance criteria mapping
- Unsupported model/payoff/process pairs fail closed before solver invocation.
- Placeholder/unsupported route semantics use stable machine-readable 501 envelopes.
- Model-specific scalar constraints cover correlations, variances, volatilities, and mean reversion.
- Tests cover malformed enum values, invalid known pairings, route maturity, and OpenAPI enum exposure.

## Closure topology mapping
- predecessor: #97
- successor: #99, #100, #101 under parent #53
