### PR TITLE
Add API requested-state sampling diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
             tests/test_api_request_guards.py \
             tests/test_api_schema_contracts.py \
             tests/test_api_route_validation.py \
+            tests/test_api_interpolation_diagnostics.py \
             tests/test_regulatory_fail_closed.py \
             tests/test_boundary_conditions.py \
             tests/test_callable_bond.py \

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Pricing requests use a versioned schema with explicit model/payoff/process contr
 }
 ```
 
-All public responses use the stable `fd-api-v1` envelope. Successful routes include top-level `schema_version`, `request_id`, `run_id`, and `metadata`; callers may supply `X-Request-ID` for trace propagation. `metadata` records route maturity, warnings, units, solver/grid dimensions, and explicit `not_assessed` convergence status. This is a service-contract shape, not a production validation claim.
+All public responses use the stable `fd-api-v1` envelope. Successful scalar routes include top-level `schema_version`, `request_id`, `run_id`, and `metadata`; callers may supply `X-Request-ID` for trace propagation. `metadata` records route maturity, warnings, units, solver/grid dimensions, requested-state sampling diagnostics, and explicit `not_assessed` convergence status. This is a service-contract shape, not a production validation claim.
 
 Endpoints:
 

--- a/api/main.py
+++ b/api/main.py
@@ -219,6 +219,28 @@ class ConvergenceDiagnostics(BaseModel):
     benchmark_error: float | None = None
 
 
+class SamplingDiagnostics(BaseModel):
+    """Requested-state sampling metadata for scalar API outputs."""
+
+    requested_spot: float
+    reference_grid: Literal["asset_price"] = "asset_price"
+    method: Literal["grid_node", "linear_interpolation"]
+    lower_index: int
+    upper_index: int
+    lower_spot: float
+    upper_spot: float
+    interpolation_weight: float
+    bounded_policy: Literal["reject_outside_grid"] = "reject_outside_grid"
+    extrapolated: bool = False
+
+
+class GridSample(BaseModel):
+    """Internal value plus diagnostics for requested-state grid sampling."""
+
+    value: float
+    sampling: SamplingDiagnostics
+
+
 class ResponseMetadata(BaseModel):
     """Stable metadata envelope shared by success and error responses."""
 
@@ -228,6 +250,7 @@ class ResponseMetadata(BaseModel):
     units: UnitMetadata = Field(default_factory=UnitMetadata)
     solver: SolverMetadata | None = None
     convergence: ConvergenceDiagnostics | None = None
+    sampling: SamplingDiagnostics | None = None
 
 
 class APIResponseBase(BaseModel):
@@ -379,6 +402,7 @@ def _success_metadata(
     *,
     include_grid: bool,
     requested_outputs: list[str],
+    sampling: SamplingDiagnostics | None = None,
 ) -> ResponseMetadata:
     """Build the success metadata envelope required by the v1 API schema."""
 
@@ -392,6 +416,7 @@ def _success_metadata(
             requested_outputs=requested_outputs,
         ),
         convergence=_convergence_metadata(),
+        sampling=sampling,
     )
 
 
@@ -617,8 +642,97 @@ def _compute_grid(request: OptionRequest, *, return_greeks: bool = False):
     )
 
 
-def _interp_at_spot(values: np.ndarray, grid: np.ndarray, spot: float) -> float:
-    return float(np.interp(spot, grid, values))
+def _sample_grid_at_spot(
+    values: np.ndarray, grid: np.ndarray, spot: float
+) -> GridSample:
+    """Sample a one-dimensional solution grid at the requested spot with diagnostics."""
+
+    values_array = np.asarray(values, dtype=float)
+    grid_array = np.asarray(grid, dtype=float)
+    if values_array.ndim != 1 or grid_array.ndim != 1:
+        raise HTTPException(
+            status_code=500,
+            detail="requested-state sampling expects one-dimensional grid arrays",
+        )
+    if len(values_array) != len(grid_array):
+        raise HTTPException(
+            status_code=500,
+            detail="requested-state sampling grid/value dimensions do not match",
+        )
+    if len(grid_array) == 0:
+        raise HTTPException(
+            status_code=500,
+            detail="requested-state sampling cannot use an empty grid",
+        )
+
+    requested_spot = float(spot)
+    grid_min = float(grid_array[0])
+    grid_max = float(grid_array[-1])
+    if requested_spot < grid_min or requested_spot > grid_max:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "message": "requested spot is outside computed grid bounds",
+                "bounded_policy": "reject_outside_grid",
+                "requested_spot": requested_spot,
+                "grid_min": grid_min,
+                "grid_max": grid_max,
+            },
+        )
+
+    upper_index = int(np.searchsorted(grid_array, requested_spot, side="left"))
+    if upper_index < len(grid_array) and np.isclose(
+        grid_array[upper_index], requested_spot, rtol=0.0, atol=1e-12
+    ):
+        value = float(values_array[upper_index])
+        diagnostics = SamplingDiagnostics(
+            requested_spot=requested_spot,
+            method="grid_node",
+            lower_index=upper_index,
+            upper_index=upper_index,
+            lower_spot=float(grid_array[upper_index]),
+            upper_spot=float(grid_array[upper_index]),
+            interpolation_weight=0.0,
+        )
+        return GridSample(value=value, sampling=diagnostics)
+
+    if upper_index <= 0 or upper_index >= len(
+        grid_array
+    ):  # pragma: no cover - defensive
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "message": "requested spot is outside computed interpolation brackets",
+                "bounded_policy": "reject_outside_grid",
+                "requested_spot": requested_spot,
+                "grid_min": grid_min,
+                "grid_max": grid_max,
+            },
+        )
+
+    lower_index = upper_index - 1
+    lower_spot = float(grid_array[lower_index])
+    upper_spot = float(grid_array[upper_index])
+    bracket_width = upper_spot - lower_spot
+    if bracket_width <= 0.0:  # pragma: no cover - defensive
+        raise HTTPException(
+            status_code=500,
+            detail="requested-state sampling requires a strictly increasing grid",
+        )
+    weight = (requested_spot - lower_spot) / bracket_width
+    value = float(
+        (1.0 - weight) * values_array[lower_index] + weight * values_array[upper_index]
+    )
+    diagnostics = SamplingDiagnostics(
+        requested_spot=requested_spot,
+        method="linear_interpolation",
+        lower_index=lower_index,
+        upper_index=upper_index,
+        lower_spot=lower_spot,
+        upper_spot=upper_spot,
+        interpolation_weight=float(weight),
+    )
+    return GridSample(value=value, sampling=diagnostics)
 
 
 def _grid_payload(res) -> PriceGrid:
@@ -631,6 +745,7 @@ def price(request: OptionRequest, http_request: Request) -> PriceResponse:
 
     _ensure_supported_contract(request, route="/price")
     res = _compute_grid(request)
+    price_sample = _sample_grid_at_spot(res.values[-1], res.s, request.spot)
     return PriceResponse(
         **_response_identity(http_request),
         metadata=_success_metadata(
@@ -638,10 +753,11 @@ def price(request: OptionRequest, http_request: Request) -> PriceResponse:
             request,
             include_grid=request.include_full_grid,
             requested_outputs=["price"],
+            sampling=price_sample.sampling,
         ),
         option_type=request.option_type,
         spot=request.spot,
-        price=_interp_at_spot(res.values[-1], res.s, request.spot),
+        price=price_sample.value,
         grid=_grid_payload(res) if request.include_full_grid else None,
     )
 
@@ -656,6 +772,9 @@ def greeks(request: OptionRequest, http_request: Request) -> GreeksResponse:
         res.delta is None or res.gamma is None or res.theta is None
     ):  # pragma: no cover - defensive
         raise HTTPException(status_code=500, detail="Greek grid was not computed")
+    delta_sample = _sample_grid_at_spot(res.delta[-1], res.s, request.spot)
+    gamma_sample = _sample_grid_at_spot(res.gamma[-1], res.s, request.spot)
+    theta_sample = _sample_grid_at_spot(res.theta[-1], res.s, request.spot)
     return GreeksResponse(
         **_response_identity(http_request),
         metadata=_success_metadata(
@@ -663,12 +782,13 @@ def greeks(request: OptionRequest, http_request: Request) -> GreeksResponse:
             request,
             include_grid=False,
             requested_outputs=["delta", "gamma", "theta"],
+            sampling=delta_sample.sampling,
         ),
         option_type=request.option_type,
         spot=request.spot,
-        delta=_interp_at_spot(res.delta[-1], res.s, request.spot),
-        gamma=_interp_at_spot(res.gamma[-1], res.s, request.spot),
-        theta=_interp_at_spot(res.theta[-1], res.s, request.spot),
+        delta=delta_sample.value,
+        gamma=gamma_sample.value,
+        theta=theta_sample.value,
     )
 
 

--- a/docs/CI_POLICY.md
+++ b/docs/CI_POLICY.md
@@ -18,7 +18,7 @@ The Python job uses Python 3.12 and reports failures by command group:
 3. architecture fitness gate:
    - `pytest -q tests/architecture`;
 4. stable regression suite:
-   - `PYTHONPATH=. pytest -q` with API request guards, schema contracts, route validation, and regulatory fail-closed envelopes;
+   - `PYTHONPATH=. pytest -q` with API request guards, schema contracts, route validation, interpolation diagnostics, and regulatory fail-closed envelopes;
    - boundary conditions;
    - callable bond;
    - FD backend capability manifest;

--- a/tests/architecture/test_ci_policy_contracts.py
+++ b/tests/architecture/test_ci_policy_contracts.py
@@ -20,6 +20,7 @@ def test_blocking_ci_has_actionable_python_and_stable_suite_contract() -> None:
     assert "PYTHONPATH=. pytest -q" in workflow
     assert "tests/test_api_schema_contracts.py" in workflow
     assert "tests/test_api_route_validation.py" in workflow
+    assert "tests/test_api_interpolation_diagnostics.py" in workflow
     assert "tests/test_unified_pricing_engine.py" in workflow
 
 

--- a/tests/test_api_interpolation_diagnostics.py
+++ b/tests/test_api_interpolation_diagnostics.py
@@ -1,0 +1,138 @@
+"""Requested-state interpolation diagnostics tests for API issue #99."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import API_SCHEMA_VERSION, app
+from src.instruments.base import EuropeanCall, EuropeanPut
+from src.pricing import OptionPricer
+from src.processes.affine import GeometricBrownianMotion
+
+
+def _payload(**overrides: object) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "model": "black_scholes",
+        "process": "geometric_brownian_motion",
+        "payoff_family": "vanilla_european",
+        "exercise_style": "european",
+        "underlying_factor_role": "tradable_spot",
+        "option_type": "Call",
+        "spot": 137.5,
+        "strike": 100.0,
+        "maturity": 0.5,
+        "rate": 0.03,
+        "sigma": 0.2,
+        "s_max": 250.0,
+        "s_steps": 31,
+        "t_steps": 21,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _expected_samples(payload: dict[str, object]) -> dict[str, float]:
+    model = GeometricBrownianMotion(
+        mu=float(payload["rate"]), sigma=float(payload["sigma"])
+    )
+    instrument_cls = EuropeanCall if payload["option_type"] == "Call" else EuropeanPut
+    instrument = instrument_cls(
+        strike=float(payload["strike"]),
+        maturity=float(payload["maturity"]),
+        model=model,
+    )
+    res = OptionPricer(instrument=instrument).compute_grid(
+        s_max=float(payload["s_max"]),
+        s_steps=int(payload["s_steps"]),
+        t_steps=int(payload["t_steps"]),
+        return_greeks=True,
+    )
+    assert res.delta is not None and res.gamma is not None and res.theta is not None
+    spot = float(payload["spot"])
+    strike = float(payload["strike"])
+    return {
+        "price_at_spot": float(np.interp(spot, res.s, res.values[-1])),
+        "price_at_strike": float(np.interp(strike, res.s, res.values[-1])),
+        "delta_at_spot": float(np.interp(spot, res.s, res.delta[-1])),
+        "gamma_at_spot": float(np.interp(spot, res.s, res.gamma[-1])),
+        "theta_at_spot": float(np.interp(spot, res.s, res.theta[-1])),
+    }
+
+
+def _sampling(body: dict[str, Any]) -> dict[str, Any]:
+    assert body["schema_version"] == API_SCHEMA_VERSION
+    sampling = body["metadata"]["sampling"]
+    assert isinstance(sampling, dict)
+    return sampling
+
+
+@pytest.mark.parametrize("option_type", ["Call", "Put"])
+def test_price_and_greeks_sample_the_same_requested_spot_for_calls_and_puts(
+    option_type: str,
+) -> None:
+    payload = _payload(option_type=option_type, spot=137.5, strike=100.0)
+    client = TestClient(app)
+
+    price = client.post("/price", json=payload)
+    greeks = client.post("/greeks", json=payload)
+
+    assert price.status_code == 200
+    assert greeks.status_code == 200
+    expected = _expected_samples(payload)
+    price_body = price.json()
+    greeks_body = greeks.json()
+    assert price_body["price"] == pytest.approx(expected["price_at_spot"], abs=1e-12)
+    assert price_body["price"] != pytest.approx(expected["price_at_strike"], abs=1e-3)
+    assert greeks_body["delta"] == pytest.approx(expected["delta_at_spot"], abs=1e-12)
+    assert greeks_body["gamma"] == pytest.approx(expected["gamma_at_spot"], abs=1e-12)
+    assert greeks_body["theta"] == pytest.approx(expected["theta_at_spot"], abs=1e-12)
+    assert _sampling(price_body) == _sampling(greeks_body)
+
+
+def test_sampling_metadata_documents_linear_interpolation_location() -> None:
+    response = TestClient(app).post(
+        "/price", json=_payload(spot=137.5, s_max=250.0, s_steps=31)
+    )
+
+    assert response.status_code == 200
+    sampling = _sampling(response.json())
+    assert sampling["method"] == "linear_interpolation"
+    assert sampling["bounded_policy"] == "reject_outside_grid"
+    assert sampling["requested_spot"] == 137.5
+    assert sampling["lower_index"] == 16
+    assert sampling["upper_index"] == 17
+    assert sampling["lower_spot"] == pytest.approx(250.0 * 16 / 30)
+    assert sampling["upper_spot"] == pytest.approx(250.0 * 17 / 30)
+    assert sampling["interpolation_weight"] == pytest.approx(0.5)
+    assert sampling["extrapolated"] is False
+
+
+def test_sampling_metadata_documents_exact_grid_node_location() -> None:
+    response = TestClient(app).post(
+        "/price", json=_payload(spot=125.0, s_max=250.0, s_steps=11)
+    )
+
+    assert response.status_code == 200
+    sampling = _sampling(response.json())
+    assert sampling["method"] == "grid_node"
+    assert sampling["requested_spot"] == 125.0
+    assert sampling["lower_index"] == sampling["upper_index"] == 5
+    assert sampling["lower_spot"] == sampling["upper_spot"] == 125.0
+    assert sampling["interpolation_weight"] == 0.0
+    assert sampling["extrapolated"] is False
+
+
+def test_requested_spot_outside_grid_is_rejected_by_bounded_policy_before_solving() -> (
+    None
+):
+    response = TestClient(app).post("/price", json=_payload(spot=260.0, s_max=250.0))
+
+    assert response.status_code == 422
+    body = response.json()
+    assert body["error"]["code"] == "validation_error"
+    assert body["metadata"]["route_maturity"] == "experimental"
+    assert "spot must lie inside the spatial grid" in str(body["detail"])

--- a/tests/test_api_schema_contracts.py
+++ b/tests/test_api_schema_contracts.py
@@ -163,6 +163,7 @@ def test_openapi_schema_contains_reviewed_v1_response_error_components() -> None
         "ResponseMetadata",
         "SolverMetadata",
         "ConvergenceDiagnostics",
+        "SamplingDiagnostics",
         "UnitMetadata",
         "RouteWarning",
     }


### PR DESCRIPTION
## Summary
- Add shared requested-state sampling diagnostics for scalar `/price` and `/greeks` outputs.
- Replace route-local scalar interpolation with a single helper that records grid-node vs linear-interpolation metadata.
- Document bounded `reject_outside_grid` policy and keep unbounded grids disabled by default.
- Add interpolation diagnostics tests to the blocking CI stable suite and update README/CI policy docs.

Closes #99

## Evidence
- RED before implementation: `tests/test_api_interpolation_diagnostics.py` -> 4 failed, 1 passed because `metadata.sampling` was absent.
- `/tmp/qpe-fdo-venv/bin/python -m pytest -q tests/test_api_interpolation_diagnostics.py` -> 5 passed
- API/architecture focused suite -> 65 passed
- Local CI stable suite -> 171 passed, 14 existing matplotlib/pyparsing warnings
- `/tmp/qpe-fdo-venv/bin/python -m pytest -q` -> 233 passed, 14 existing matplotlib/pyparsing warnings
- `git diff --check` -> clean
- Added-line secret/injection scan -> no findings
- Independent pre-commit review -> no blocking issues

## Acceptance criteria mapping
- Price and Greeks share requested-state sampling semantics for Call and Put fixtures.
- `spot != strike` tests would fail under strike-based sampling.
- Out-of-grid requested spots are rejected by the bounded policy before solving.
- Scalar route metadata includes requested spot, grid bracket/node, interpolation method, and weight without returning unbounded grids by default.

## Closure topology mapping
- predecessor: #98
- successor: #100, #101 under parent #53
