### PR TITLE
Add API runtime resource controls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
             tests/test_api_schema_contracts.py \
             tests/test_api_route_validation.py \
             tests/test_api_interpolation_diagnostics.py \
+            tests/test_api_resource_controls.py \
             tests/test_regulatory_fail_closed.py \
             tests/test_boundary_conditions.py \
             tests/test_callable_bond.py \

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The service allows cross-origin requests from `http://localhost:5173`.
 uvicorn api.main:app --reload
 ```
 
-Pricing requests use a versioned schema with explicit model/payoff/process contracts, explicit `spot`, enum `option_type`, finite/range numeric validation, a pre-solve node budget, and full-grid output disabled by default:
+Pricing requests use a versioned schema with explicit model/payoff/process contracts, explicit `spot`, enum `option_type`, finite/range numeric validation, deployable compute/output/response-size budgets, a cooperative local timeout, and full-grid output disabled by default:
 
 ```json
 {
@@ -163,6 +163,7 @@ Pricing requests use a versioned schema with explicit model/payoff/process contr
   "payoff_family": "vanilla_european",
   "exercise_style": "european",
   "underlying_factor_role": "tradable_spot",
+  "state_dimensions": 1,
   "option_type": "Call",
   "spot": 100.0,
   "strike": 100.0,
@@ -171,11 +172,16 @@ Pricing requests use a versioned schema with explicit model/payoff/process contr
   "sigma": 0.2,
   "s_steps": 101,
   "t_steps": 51,
-  "include_full_grid": false
+  "include_full_grid": false,
+  "max_output_nodes": 50000,
+  "max_response_bytes": 8000000,
+  "timeout_seconds": 2.0
 }
 ```
 
-All public responses use the stable `fd-api-v1` envelope. Successful scalar routes include top-level `schema_version`, `request_id`, `run_id`, and `metadata`; callers may supply `X-Request-ID` for trace propagation. `metadata` records route maturity, warnings, units, solver/grid dimensions, requested-state sampling diagnostics, and explicit `not_assessed` convergence status. This is a service-contract shape, not a production validation claim.
+All public responses use the stable `fd-api-v1` envelope. Successful scalar routes include top-level `schema_version`, `request_id`, `run_id`, and `metadata`; callers may supply `X-Request-ID` for trace propagation. `metadata` records route maturity, warnings, units, solver/grid dimensions, requested-state sampling diagnostics, resource-budget diagnostics, and explicit `not_assessed` convergence status. This is a service-contract shape, not a production validation claim.
+
+The default `local_demo` resource policy is process-local: one concurrent solve, one state dimension, up to 50,000 compute/output nodes, up to 8 MB estimated serialized numerical output, and a cooperative timeout capped at 5 seconds. The sync solver cannot be interrupted mid-kernel; the API checks deadlines before and after solve/sampling/assembly, releases the local concurrency slot on failure, and returns bounded HTTP 429/504 error envelopes when capacity or timeout limits are hit.
 
 Endpoints:
 
@@ -187,7 +193,7 @@ Endpoints:
 - `POST /reports/basel` → HTTP 501 `ErrorResponse` until a versioned Basel market-risk subset is implemented
 - `POST /reports/frtb` → HTTP 501 `ErrorResponse` until a versioned FRTB calculation subset is implemented
 
-Validation, bad-request, internal, and unsupported-route failures are concise machine-readable `ErrorResponse` objects with stable `error.code`, `error.http_status`, route, request/run IDs, and original diagnostic `detail`. The pricing, Greeks, and PDE routes currently execute only the explicit Black-Scholes / geometric-Brownian-motion / vanilla-European / tradable-spot contract; recognized but unsupported model, process, payoff, exercise-style, or factor-role combinations fail closed with HTTP 501 before numerical work. OpenAPI compatibility tests guard these public schema components from unreviewed drift.
+Validation, resource-limit, concurrency-limit, timeout, bad-request, internal, and unsupported-route failures are concise machine-readable `ErrorResponse` objects with stable `error.code`, `error.http_status`, route, request/run IDs, and original diagnostic `detail`. The pricing, Greeks, and PDE routes currently execute only the explicit Black-Scholes / geometric-Brownian-motion / vanilla-European / tradable-spot contract; recognized but unsupported model, process, payoff, exercise-style, or factor-role combinations fail closed with HTTP 501 before numerical work. OpenAPI compatibility tests guard these public schema components from unreviewed drift.
 
 ## Next.js Client
 

--- a/api/main.py
+++ b/api/main.py
@@ -7,6 +7,8 @@ front-end integrations and smoke testing.
 from __future__ import annotations
 
 from enum import Enum
+from threading import BoundedSemaphore
+from time import monotonic as _monotonic
 from typing import Any, Literal, Optional
 from uuid import uuid4
 
@@ -90,6 +92,41 @@ class FactorRole(str, Enum):
     AUXILIARY_STATE = "auxiliary_state"
 
 
+class APIResourcePolicy(BaseModel):
+    """Deployable local/demo runtime safety policy for numerical API routes."""
+
+    policy_name: str = "local_demo"
+    max_state_dimensions: int = 1
+    max_s_steps: int = 5_000
+    max_t_steps: int = 5_000
+    max_compute_nodes: int = 50_000
+    max_output_nodes: int = 50_000
+    max_response_bytes: int = 8_000_000
+    bytes_per_float: int = 8
+    default_timeout_seconds: float = 2.0
+    max_timeout_seconds: float = 5.0
+    max_concurrent_solves: int = 1
+
+
+DEFAULT_API_RESOURCE_POLICY = APIResourcePolicy()
+_SOLVE_SEMAPHORE = BoundedSemaphore(DEFAULT_API_RESOURCE_POLICY.max_concurrent_solves)
+
+
+class ResourceBudgetMetadata(BaseModel):
+    """Budget metadata attached to API responses and pre-solve checks."""
+
+    policy_name: str
+    state_dimensions: int
+    compute_nodes: int
+    max_compute_nodes: int
+    output_nodes: int
+    max_output_nodes: int
+    estimated_response_bytes: int
+    max_response_bytes: int
+    timeout_seconds: float
+    max_concurrent_solves: int
+
+
 class OptionRequest(BaseModel):
     """Validated request payload for option pricing endpoints.
 
@@ -108,6 +145,7 @@ class OptionRequest(BaseModel):
     payoff_family: PayoffFamily = PayoffFamily.VANILLA_EUROPEAN
     exercise_style: ExerciseStyle = ExerciseStyle.EUROPEAN
     underlying_factor_role: FactorRole = FactorRole.TRADABLE_SPOT
+    state_dimensions: int = Field(default=1, ge=1, le=8)
     option_type: OptionType = OptionType.CALL
     spot: float = Field(..., gt=0.0, allow_inf_nan=False)
     strike: float = Field(..., gt=0.0, allow_inf_nan=False)
@@ -119,6 +157,8 @@ class OptionRequest(BaseModel):
     t_steps: int = Field(default=100, ge=3, le=5_000)
     include_full_grid: bool = False
     max_output_nodes: int = Field(default=50_000, ge=1, le=50_000)
+    max_response_bytes: int = Field(default=8_000_000, ge=1, le=8_000_000)
+    timeout_seconds: Optional[float] = Field(default=None, gt=0.0, le=5.0)
     correlation: Optional[float] = Field(
         default=None, ge=-1.0, le=1.0, allow_inf_nan=False
     )
@@ -133,15 +173,30 @@ class OptionRequest(BaseModel):
     def validate_api_budget_domain_and_model_fields(self) -> "OptionRequest":
         """Reject impossible, unbounded, or mismatched requests before numerical work."""
 
+        policy = DEFAULT_API_RESOURCE_POLICY
         s_max = self.resolved_s_max
         if self.spot > s_max:
             raise ValueError("spot must lie inside the spatial grid [0, s_max]")
         if self.strike > s_max:
             raise ValueError("strike must lie inside the spatial grid [0, s_max]")
-        node_count = self.s_steps * self.t_steps
-        if node_count > self.max_output_nodes:
+        if self.state_dimensions > policy.max_state_dimensions:
             raise ValueError(
-                f"request exceeds node budget: {node_count} > {self.max_output_nodes}"
+                "state dimension budget exceeded: "
+                f"{self.state_dimensions} > {policy.max_state_dimensions}"
+            )
+        if self.s_steps > policy.max_s_steps:
+            raise ValueError(
+                f"spatial step budget exceeded: {self.s_steps} > {policy.max_s_steps}"
+            )
+        if self.t_steps > policy.max_t_steps:
+            raise ValueError(
+                f"time step budget exceeded: {self.t_steps} > {policy.max_t_steps}"
+            )
+        node_count = self.state_dimensions * self.s_steps * self.t_steps
+        node_budget = policy.max_compute_nodes
+        if node_count > node_budget:
+            raise ValueError(
+                f"request exceeds node budget: {node_count} > {node_budget}"
             )
         if self.model == PricingModel.BLACK_SCHOLES:
             extra_model_fields = [
@@ -251,6 +306,7 @@ class ResponseMetadata(BaseModel):
     solver: SolverMetadata | None = None
     convergence: ConvergenceDiagnostics | None = None
     sampling: SamplingDiagnostics | None = None
+    resource_budget: ResourceBudgetMetadata | None = None
 
 
 class APIResponseBase(BaseModel):
@@ -322,8 +378,10 @@ class FullPDEResponse(APIResponseBase):
 API_ERROR_RESPONSES: dict[int | str, dict[str, Any]] = {
     400: {"model": ErrorResponse},
     422: {"model": ErrorResponse},
+    429: {"model": ErrorResponse},
     500: {"model": ErrorResponse},
     501: {"model": ErrorResponse},
+    504: {"model": ErrorResponse},
 }
 UNSUPPORTED_ROUTE_RESPONSES: dict[int | str, dict[str, Any]] = {
     501: {"model": ErrorResponse},
@@ -403,6 +461,7 @@ def _success_metadata(
     include_grid: bool,
     requested_outputs: list[str],
     sampling: SamplingDiagnostics | None = None,
+    resource_budget: ResourceBudgetMetadata | None = None,
 ) -> ResponseMetadata:
     """Build the success metadata envelope required by the v1 API schema."""
 
@@ -417,6 +476,7 @@ def _success_metadata(
         ),
         convergence=_convergence_metadata(),
         sampling=sampling,
+        resource_budget=resource_budget,
     )
 
 
@@ -446,6 +506,8 @@ def _response_identity(http_request: Request) -> dict[str, str]:
 def _error_code(status_code: int, detail: Any) -> str:
     """Classify HTTP failures into stable public error codes."""
 
+    if isinstance(detail, dict) and isinstance(detail.get("code"), str):
+        return str(detail["code"])
     if status_code == 501:
         return "unsupported_route"
     if isinstance(detail, dict) and detail.get("capability_status") in {
@@ -626,6 +688,165 @@ def _ensure_supported_contract(request: OptionRequest, *, route: str) -> None:
     )
 
 
+def _timeout_seconds(request: OptionRequest) -> float:
+    """Return request timeout clamped by the local API resource policy."""
+
+    policy = DEFAULT_API_RESOURCE_POLICY
+    requested = request.timeout_seconds or policy.default_timeout_seconds
+    return min(float(requested), policy.max_timeout_seconds)
+
+
+def _output_nodes(route: str, request: OptionRequest) -> int:
+    """Estimate serialized numerical output nodes for a route before solving."""
+
+    grid_nodes = request.s_steps * request.t_steps
+    if route == "/price":
+        return (
+            1 + request.s_steps + request.t_steps + grid_nodes
+            if request.include_full_grid
+            else 1
+        )
+    if route == "/greeks":
+        return 3
+    if route == "/pde_solution":
+        return (
+            request.s_steps + request.t_steps + 4 * grid_nodes
+            if request.include_full_grid
+            else 0
+        )
+    return 0
+
+
+def _resource_budget(route: str, request: OptionRequest) -> ResourceBudgetMetadata:
+    """Compute and enforce route resource budgets before numerical allocation."""
+
+    policy = DEFAULT_API_RESOURCE_POLICY
+    compute_nodes = request.state_dimensions * request.s_steps * request.t_steps
+    max_compute_nodes = policy.max_compute_nodes
+    output_nodes = _output_nodes(route, request)
+    max_output_nodes = min(policy.max_output_nodes, request.max_output_nodes)
+    estimated_response_bytes = output_nodes * policy.bytes_per_float
+    max_response_bytes = min(policy.max_response_bytes, request.max_response_bytes)
+    budget = ResourceBudgetMetadata(
+        policy_name=policy.policy_name,
+        state_dimensions=request.state_dimensions,
+        compute_nodes=compute_nodes,
+        max_compute_nodes=max_compute_nodes,
+        output_nodes=output_nodes,
+        max_output_nodes=max_output_nodes,
+        estimated_response_bytes=estimated_response_bytes,
+        max_response_bytes=max_response_bytes,
+        timeout_seconds=_timeout_seconds(request),
+        max_concurrent_solves=policy.max_concurrent_solves,
+    )
+    if compute_nodes > max_compute_nodes:
+        _raise_resource_limit(
+            route,
+            budget,
+            limit="max_compute_nodes",
+            observed=compute_nodes,
+            allowed=max_compute_nodes,
+        )
+    if output_nodes > max_output_nodes:
+        _raise_resource_limit(
+            route,
+            budget,
+            limit="max_output_nodes",
+            observed=output_nodes,
+            allowed=max_output_nodes,
+        )
+    if estimated_response_bytes > max_response_bytes:
+        _raise_resource_limit(
+            route,
+            budget,
+            limit="max_response_bytes",
+            observed=estimated_response_bytes,
+            allowed=max_response_bytes,
+        )
+    return budget
+
+
+def _raise_resource_limit(
+    route: str,
+    budget: ResourceBudgetMetadata,
+    *,
+    limit: str,
+    observed: int,
+    allowed: int,
+) -> None:
+    raise HTTPException(
+        status_code=422,
+        detail={
+            "code": "resource_limit_exceeded",
+            "message": f"request exceeds {limit}: {observed} > {allowed}",
+            "route": route,
+            "resource": {
+                "limit": limit,
+                "observed": observed,
+                "allowed": allowed,
+                **budget.model_dump(mode="json"),
+            },
+        },
+    )
+
+
+class _ResourceLease:
+    """Non-blocking local concurrency slot plus cooperative deadline checks."""
+
+    def __init__(self, route: str, budget: ResourceBudgetMetadata) -> None:
+        self.route = route
+        self.budget = budget
+        self.started_at = _monotonic()
+        self.deadline = self.started_at + budget.timeout_seconds
+        self.acquired = False
+
+    def __enter__(self) -> "_ResourceLease":
+        self.acquired = _SOLVE_SEMAPHORE.acquire(blocking=False)
+        if not self.acquired:
+            raise HTTPException(
+                status_code=429,
+                detail={
+                    "code": "concurrency_limit_exceeded",
+                    "message": "no local/demo API solve concurrency slot is available",
+                    "route": self.route,
+                    "resource": {
+                        "limit": "max_concurrent_solves",
+                        **self.budget.model_dump(mode="json"),
+                    },
+                },
+            )
+        try:
+            self.check_deadline(stage="before_solve")
+        except BaseException:
+            _SOLVE_SEMAPHORE.release()
+            self.acquired = False
+            raise
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        if self.acquired:
+            _SOLVE_SEMAPHORE.release()
+            self.acquired = False
+
+    def check_deadline(self, *, stage: str) -> None:
+        now = _monotonic()
+        if now < self.deadline:
+            return
+        elapsed = max(0.0, now - self.started_at)
+        raise HTTPException(
+            status_code=504,
+            detail={
+                "code": "request_timeout",
+                "message": f"request exceeded cooperative timeout at {stage}",
+                "route": self.route,
+                "stage": stage,
+                "timeout_seconds": self.budget.timeout_seconds,
+                "elapsed_seconds": elapsed,
+                "resource": self.budget.model_dump(mode="json"),
+            },
+        )
+
+
 def _compute_grid(request: OptionRequest, *, return_greeks: bool = False):
     model = GeometricBrownianMotion(mu=request.rate, sigma=request.sigma)
     instrument = _option_class(request.option_type)(
@@ -743,17 +964,23 @@ def _grid_payload(res) -> PriceGrid:
 def price(request: OptionRequest, http_request: Request) -> PriceResponse:
     """Return requested-spot price and optional bounded grid for an option."""
 
-    _ensure_supported_contract(request, route="/price")
-    res = _compute_grid(request)
-    price_sample = _sample_grid_at_spot(res.values[-1], res.s, request.spot)
+    route = "/price"
+    _ensure_supported_contract(request, route=route)
+    budget = _resource_budget(route, request)
+    with _ResourceLease(route, budget) as lease:
+        res = _compute_grid(request)
+        lease.check_deadline(stage="after_solve")
+        price_sample = _sample_grid_at_spot(res.values[-1], res.s, request.spot)
+        lease.check_deadline(stage="after_sampling")
     return PriceResponse(
         **_response_identity(http_request),
         metadata=_success_metadata(
-            "/price",
+            route,
             request,
             include_grid=request.include_full_grid,
             requested_outputs=["price"],
             sampling=price_sample.sampling,
+            resource_budget=budget,
         ),
         option_type=request.option_type,
         spot=request.spot,
@@ -766,23 +993,29 @@ def price(request: OptionRequest, http_request: Request) -> PriceResponse:
 def greeks(request: OptionRequest, http_request: Request) -> GreeksResponse:
     """Return scalar Greeks at the explicitly requested spot."""
 
-    _ensure_supported_contract(request, route="/greeks")
-    res = _compute_grid(request, return_greeks=True)
-    if (
-        res.delta is None or res.gamma is None or res.theta is None
-    ):  # pragma: no cover - defensive
-        raise HTTPException(status_code=500, detail="Greek grid was not computed")
-    delta_sample = _sample_grid_at_spot(res.delta[-1], res.s, request.spot)
-    gamma_sample = _sample_grid_at_spot(res.gamma[-1], res.s, request.spot)
-    theta_sample = _sample_grid_at_spot(res.theta[-1], res.s, request.spot)
+    route = "/greeks"
+    _ensure_supported_contract(request, route=route)
+    budget = _resource_budget(route, request)
+    with _ResourceLease(route, budget) as lease:
+        res = _compute_grid(request, return_greeks=True)
+        lease.check_deadline(stage="after_solve")
+        if (
+            res.delta is None or res.gamma is None or res.theta is None
+        ):  # pragma: no cover - defensive
+            raise HTTPException(status_code=500, detail="Greek grid was not computed")
+        delta_sample = _sample_grid_at_spot(res.delta[-1], res.s, request.spot)
+        gamma_sample = _sample_grid_at_spot(res.gamma[-1], res.s, request.spot)
+        theta_sample = _sample_grid_at_spot(res.theta[-1], res.s, request.spot)
+        lease.check_deadline(stage="after_sampling")
     return GreeksResponse(
         **_response_identity(http_request),
         metadata=_success_metadata(
-            "/greeks",
+            route,
             request,
             include_grid=False,
             requested_outputs=["delta", "gamma", "theta"],
             sampling=delta_sample.sampling,
+            resource_budget=budget,
         ),
         option_type=request.option_type,
         spot=request.spot,
@@ -798,24 +1031,30 @@ def greeks(request: OptionRequest, http_request: Request) -> GreeksResponse:
 def pde_solution(request: OptionRequest, http_request: Request) -> FullPDEResponse:
     """Return complete solution and Greeks grids only after explicit opt-in."""
 
-    _ensure_supported_contract(request, route="/pde_solution")
+    route = "/pde_solution"
+    _ensure_supported_contract(request, route=route)
     if not request.include_full_grid:
         raise HTTPException(
             status_code=400,
             detail="include_full_grid must be true to return the full PDE grid",
         )
-    res = _compute_grid(request, return_greeks=True)
-    if (
-        res.delta is None or res.gamma is None or res.theta is None
-    ):  # pragma: no cover - defensive
-        raise HTTPException(status_code=500, detail="Greek grid was not computed")
+    budget = _resource_budget(route, request)
+    with _ResourceLease(route, budget) as lease:
+        res = _compute_grid(request, return_greeks=True)
+        lease.check_deadline(stage="after_solve")
+        if (
+            res.delta is None or res.gamma is None or res.theta is None
+        ):  # pragma: no cover - defensive
+            raise HTTPException(status_code=500, detail="Greek grid was not computed")
+        lease.check_deadline(stage="after_grid_assembly")
     return FullPDEResponse(
         **_response_identity(http_request),
         metadata=_success_metadata(
-            "/pde_solution",
+            route,
             request,
             include_grid=True,
             requested_outputs=["price_grid", "delta_grid", "gamma_grid", "theta_grid"],
+            resource_budget=budget,
         ),
         option_type=request.option_type,
         spot=request.spot,

--- a/docs/CI_POLICY.md
+++ b/docs/CI_POLICY.md
@@ -18,7 +18,7 @@ The Python job uses Python 3.12 and reports failures by command group:
 3. architecture fitness gate:
    - `pytest -q tests/architecture`;
 4. stable regression suite:
-   - `PYTHONPATH=. pytest -q` with API request guards, schema contracts, route validation, interpolation diagnostics, and regulatory fail-closed envelopes;
+   - `PYTHONPATH=. pytest -q` with API request guards, schema contracts, route validation, interpolation diagnostics, resource controls, and regulatory fail-closed envelopes;
    - boundary conditions;
    - callable bond;
    - FD backend capability manifest;

--- a/tests/architecture/test_ci_policy_contracts.py
+++ b/tests/architecture/test_ci_policy_contracts.py
@@ -21,6 +21,7 @@ def test_blocking_ci_has_actionable_python_and_stable_suite_contract() -> None:
     assert "tests/test_api_schema_contracts.py" in workflow
     assert "tests/test_api_route_validation.py" in workflow
     assert "tests/test_api_interpolation_diagnostics.py" in workflow
+    assert "tests/test_api_resource_controls.py" in workflow
     assert "tests/test_unified_pricing_engine.py" in workflow
 
 

--- a/tests/test_api_resource_controls.py
+++ b/tests/test_api_resource_controls.py
@@ -1,0 +1,174 @@
+"""Runtime resource-control tests for API issue #100."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from fastapi.testclient import TestClient
+
+import api.main as api_main
+from api.main import API_SCHEMA_VERSION, app
+
+
+def _payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "model": "black_scholes",
+        "process": "geometric_brownian_motion",
+        "payoff_family": "vanilla_european",
+        "exercise_style": "european",
+        "underlying_factor_role": "tradable_spot",
+        "option_type": "Call",
+        "spot": 100.0,
+        "strike": 100.0,
+        "maturity": 0.5,
+        "rate": 0.03,
+        "sigma": 0.2,
+        "s_max": 250.0,
+        "s_steps": 21,
+        "t_steps": 21,
+    }
+    payload.update(overrides)
+    return payload
+
+
+@contextmanager
+def _acquire_all_solve_slots() -> Iterator[None]:
+    acquired = 0
+    try:
+        for _ in range(api_main.DEFAULT_API_RESOURCE_POLICY.max_concurrent_solves):
+            assert api_main._SOLVE_SEMAPHORE.acquire(blocking=False)
+            acquired += 1
+        yield
+    finally:
+        for _ in range(acquired):
+            api_main._SOLVE_SEMAPHORE.release()
+
+
+def test_success_metadata_includes_configured_resource_budget() -> None:
+    response = TestClient(app).post("/price", json=_payload(timeout_seconds=0.5))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["schema_version"] == API_SCHEMA_VERSION
+    budget = body["metadata"]["resource_budget"]
+    assert budget["policy_name"] == "local_demo"
+    assert budget["state_dimensions"] == 1
+    assert budget["compute_nodes"] == 21 * 21
+    assert budget["output_nodes"] == 1
+    assert budget["estimated_response_bytes"] == 8
+    assert budget["timeout_seconds"] == 0.5
+    assert (
+        budget["max_concurrent_solves"]
+        == api_main.DEFAULT_API_RESOURCE_POLICY.max_concurrent_solves
+    )
+
+
+def test_full_grid_price_budget_counts_scalar_price_output() -> None:
+    response = TestClient(app).post(
+        "/price",
+        json=_payload(include_full_grid=True, max_response_bytes=8_000_000),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    budget = body["metadata"]["resource_budget"]
+    assert budget["output_nodes"] == 1 + 21 + 21 + 21 * 21
+    assert budget["estimated_response_bytes"] == budget["output_nodes"] * 8
+
+
+def test_scalar_output_budget_does_not_constrain_compute_budget() -> None:
+    response = TestClient(app).post("/price", json=_payload(max_output_nodes=1))
+
+    assert response.status_code == 200
+    body = response.json()
+    budget = body["metadata"]["resource_budget"]
+    assert budget["compute_nodes"] == 21 * 21
+    assert budget["max_compute_nodes"] >= budget["compute_nodes"]
+    assert budget["max_output_nodes"] == 1
+    assert budget["output_nodes"] == 1
+
+
+def test_output_response_size_budget_rejects_full_grid_before_solver(
+    monkeypatch,
+) -> None:
+    def fail_if_called(*args: object, **kwargs: object) -> object:
+        raise AssertionError("solver should not run after output budget rejection")
+
+    monkeypatch.setattr(api_main, "_compute_grid", fail_if_called)
+
+    response = TestClient(app).post(
+        "/price",
+        json=_payload(include_full_grid=True, max_response_bytes=128),
+    )
+
+    assert response.status_code == 422
+    body = response.json()
+    assert body["error"]["code"] == "resource_limit_exceeded"
+    assert body["detail"]["resource"]["limit"] == "max_response_bytes"
+    assert body["detail"]["resource"]["estimated_response_bytes"] > 128
+
+
+def test_concurrency_limit_returns_bounded_error_without_running_solver(
+    monkeypatch,
+) -> None:
+    def fail_if_called(*args: object, **kwargs: object) -> object:
+        raise AssertionError("solver should not run without a concurrency slot")
+
+    monkeypatch.setattr(api_main, "_compute_grid", fail_if_called)
+    client = TestClient(app)
+
+    with _acquire_all_solve_slots():
+        response = client.post("/price", json=_payload())
+
+    assert response.status_code == 429
+    body = response.json()
+    assert body["error"]["code"] == "concurrency_limit_exceeded"
+    assert body["detail"]["resource"]["limit"] == "max_concurrent_solves"
+    assert body["metadata"]["route"] == "/price"
+
+
+def test_cooperative_timeout_path_is_deterministic_and_bounded(monkeypatch) -> None:
+    ticks = iter([0.0, 0.0, 10.0])
+    monkeypatch.setattr(api_main, "_monotonic", lambda: next(ticks, 10.0))
+
+    response = TestClient(app).post(
+        "/price",
+        json=_payload(timeout_seconds=0.001),
+    )
+
+    assert response.status_code == 504
+    body = response.json()
+    assert body["error"]["code"] == "request_timeout"
+    assert body["error"]["source"] == "http_exception"
+    assert body["detail"]["stage"] == "after_solve"
+    assert body["detail"]["timeout_seconds"] == 0.001
+
+
+def test_pre_solve_timeout_releases_concurrency_slot(monkeypatch) -> None:
+    ticks = iter([0.0, 10.0])
+    monkeypatch.setattr(api_main, "_monotonic", lambda: next(ticks, 10.0))
+
+    response = TestClient(app).post(
+        "/price",
+        json=_payload(timeout_seconds=0.001),
+    )
+
+    assert response.status_code == 504
+    body = response.json()
+    assert body["error"]["code"] == "request_timeout"
+    assert body["detail"]["stage"] == "before_solve"
+
+    assert api_main._SOLVE_SEMAPHORE.acquire(blocking=False)
+    api_main._SOLVE_SEMAPHORE.release()
+
+
+def test_dimension_compute_budget_rejects_unsupported_state_dimension_before_solver() -> (
+    None
+):
+    response = TestClient(app).post("/price", json=_payload(state_dimensions=2))
+
+    assert response.status_code == 422
+    body = response.json()
+    assert body["error"]["code"] == "validation_error"
+    assert "state dimension budget" in str(body["detail"])

--- a/tests/test_api_schema_contracts.py
+++ b/tests/test_api_schema_contracts.py
@@ -164,6 +164,7 @@ def test_openapi_schema_contains_reviewed_v1_response_error_components() -> None
         "SolverMetadata",
         "ConvergenceDiagnostics",
         "SamplingDiagnostics",
+        "ResourceBudgetMetadata",
         "UnitMetadata",
         "RouteWarning",
     }


### PR DESCRIPTION
## Summary
- Add a `local_demo` API resource policy with compute/output/response-size budgets.
- Add process-local non-blocking solve concurrency control for the default app instance.
- Add cooperative timeout checks around solve, sampling, and grid assembly with bounded HTTP 504 errors.
- Attach resource-budget diagnostics to success metadata and add bounded HTTP 429/422 resource errors.
- Promote resource-control tests into the blocking CI stable suite and document the local/demo limitation.

Closes #100

## Evidence
- RED before implementation: `tests/test_api_resource_controls.py` -> 5 failed
- Focused API/docs/architecture suite -> 75 passed
- Local CI stable suite -> 176 passed, 14 existing matplotlib/pyparsing warnings
- `/tmp/qpe-fdo-venv/bin/python -m pytest -q` -> 238 passed, 14 existing matplotlib/pyparsing warnings
- `git diff --check` -> clean
- Added-line secret/injection scan -> no findings
- Independent pre-commit review -> no blocking issues

## Acceptance criteria mapping
- Requests exceeding compute/output/response-size budgets are rejected before solver allocation where applicable.
- Long-running requests have deterministic cooperative timeout coverage without slow sleeps.
- Default app instance has a non-blocking process-local concurrency guard that returns bounded 429 responses.
- Tests cover oversized output, deterministic timeout, occupied concurrency slots, unsupported dimensions, and success metadata.

## Closure topology mapping
- predecessor: #99
- successor: #101 under parent #53
