### PR TITLE
Harden API deployment controls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
             tests/test_api_route_validation.py \
             tests/test_api_interpolation_diagnostics.py \
             tests/test_api_resource_controls.py \
+            tests/test_api_deployment_hardening.py \
             tests/test_regulatory_fail_closed.py \
             tests/test_boundary_conditions.py \
             tests/test_callable_bond.py \

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ python -m cli plot --option-type Call --strike 1 --maturity 1 --output plot.png
 ## FastAPI Service
 
 Start a REST API that exposes experimental pricing and Greek calculations.
-The service allows cross-origin requests from `http://localhost:5173`.
+This is a local-demo service contract, not a production deployment profile. By default, browser CORS origins are restrictive and no cross-origin browser caller is allowed; opt into the local demo client explicitly with `FDO_API_ENABLE_LOCAL_DEV_CORS=1` or set a comma-separated `FDO_API_CORS_ORIGINS` allow-list.
 
 ```bash
 uvicorn api.main:app --reload
@@ -183,6 +183,8 @@ All public responses use the stable `fd-api-v1` envelope. Successful scalar rout
 
 The default `local_demo` resource policy is process-local: one concurrent solve, one state dimension, up to 50,000 compute/output nodes, up to 8 MB estimated serialized numerical output, and a cooperative timeout capped at 5 seconds. The sync solver cannot be interrupted mid-kernel; the API checks deadlines before and after solve/sampling/assembly, releases the local concurrency slot on failure, and returns bounded HTTP 429/504 error envelopes when capacity or timeout limits are hit.
 
+Deployment hardening is intentionally conservative but still local-demo maturity. Default CORS allows no browser origins; `FDO_API_ENABLE_LOCAL_DEV_CORS=1` adds only `http://localhost:5173`, while `FDO_API_CORS_ORIGINS=https://example.com,https://admin.example.com` sets an explicit allow-list. Boolean deployment flags reject typos at startup instead of silently disabling controls. `FDO_API_AUTH_REQUIRED=1` enables fail-closed API-key authentication for pricing and reporting routes; if it is enabled without `FDO_API_KEY`, protected routes return a bounded 503 `auth_misconfigured` error rather than running unauthenticated. Valid credentials can be supplied as `Authorization: Bearer ...` or `X-API-Key`. The default process-local fixed-window limiter applies before authentication, counts failed auth attempts, allows 120 protected requests per 60 seconds, and can be tuned with `FDO_API_RATE_LIMIT_REQUESTS` and `FDO_API_RATE_LIMIT_WINDOW_SECONDS`; multi-worker or internet-facing deployments still require an external shared limiter and a real operations/security review.
+
 Endpoints:
 
 - `POST /price` → scalar requested-spot response with `{ "schema_version": "fd-api-v1", "request_id": str, "run_id": str, "metadata": {...}, "spot": float, "price": float, "grid": null }`
@@ -193,7 +195,7 @@ Endpoints:
 - `POST /reports/basel` → HTTP 501 `ErrorResponse` until a versioned Basel market-risk subset is implemented
 - `POST /reports/frtb` → HTTP 501 `ErrorResponse` until a versioned FRTB calculation subset is implemented
 
-Validation, resource-limit, concurrency-limit, timeout, bad-request, internal, and unsupported-route failures are concise machine-readable `ErrorResponse` objects with stable `error.code`, `error.http_status`, route, request/run IDs, and original diagnostic `detail`. The pricing, Greeks, and PDE routes currently execute only the explicit Black-Scholes / geometric-Brownian-motion / vanilla-European / tradable-spot contract; recognized but unsupported model, process, payoff, exercise-style, or factor-role combinations fail closed with HTTP 501 before numerical work. OpenAPI compatibility tests guard these public schema components from unreviewed drift.
+Validation, authentication, resource-limit, concurrency-limit, rate-limit, timeout, bad-request, internal, and unsupported-route failures are concise machine-readable `ErrorResponse` objects with stable `error.code`, `error.http_status`, route, request/run IDs, and original diagnostic `detail`. The pricing, Greeks, and PDE routes currently execute only the explicit Black-Scholes / geometric-Brownian-motion / vanilla-European / tradable-spot contract; recognized but unsupported model, process, payoff, exercise-style, or factor-role combinations fail closed with HTTP 501 before numerical work. OpenAPI compatibility tests guard these public schema components from unreviewed drift.
 
 ## Next.js Client
 
@@ -205,7 +207,7 @@ npm install
 npm run dev
 ```
 
-It expects the FastAPI server to run locally on port 8000.
+It expects the FastAPI server to run locally on port 8000 with local browser CORS explicitly enabled, for example `FDO_API_ENABLE_LOCAL_DEV_CORS=1 uvicorn api.main:app --reload`.
 
 ## Architecture
 

--- a/api/main.py
+++ b/api/main.py
@@ -6,8 +6,11 @@ front-end integrations and smoke testing.
 
 from __future__ import annotations
 
+import os
+import time
 from enum import Enum
-from threading import BoundedSemaphore
+from hmac import compare_digest
+from threading import BoundedSemaphore, Lock
 from time import monotonic as _monotonic
 from typing import Any, Literal, Optional
 from uuid import uuid4
@@ -34,13 +37,98 @@ API_SCHEMA_VERSION: Literal["fd-api-v1"] = "fd-api-v1"
 
 app = FastAPI(title="Finite Difference Option Pricing")
 
-# Allow browser applications from the specified domain to access the API.
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["http://localhost:5173"],
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+
+LOCAL_DEV_CORS_ORIGINS = ("http://localhost:5173",)
+
+
+def _env_bool(name: str, *, default: bool = False) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    normalized = raw.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(
+        f"{name} must be a boolean string: one of 1/0, true/false, yes/no, on/off"
+    )
+
+
+def _env_int(name: str, *, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    return int(raw)
+
+
+def _env_float(name: str, *, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    return float(raw)
+
+
+def _env_csv(name: str) -> tuple[str, ...]:
+    raw = os.environ.get(name, "")
+    return tuple(item.strip() for item in raw.split(",") if item.strip())
+
+
+class DeploymentSecurityPolicy(BaseModel):
+    """Restrictive default deployment posture for the experimental API service."""
+
+    model_config = ConfigDict(frozen=True)
+
+    policy_name: str = "local_demo_security"
+    allowed_origins: tuple[str, ...] = ()
+    local_dev_cors: bool = False
+    auth_required: bool = False
+    api_key: Optional[str] = Field(default=None, repr=False, exclude=True)
+    rate_limit_requests: int = Field(default=120, ge=0)
+    rate_limit_window_seconds: float = Field(default=60.0, gt=0.0)
+    protected_path_prefixes: tuple[str, ...] = (
+        "/price",
+        "/greeks",
+        "/pde_solution",
+        "/reports/",
+    )
+
+    @classmethod
+    def from_env(cls) -> "DeploymentSecurityPolicy":
+        """Build policy from environment without requiring secrets in tests."""
+
+        return cls(
+            allowed_origins=_env_csv("FDO_API_CORS_ORIGINS"),
+            local_dev_cors=_env_bool("FDO_API_ENABLE_LOCAL_DEV_CORS"),
+            auth_required=_env_bool("FDO_API_AUTH_REQUIRED"),
+            api_key=os.environ.get("FDO_API_KEY") or None,
+            rate_limit_requests=_env_int("FDO_API_RATE_LIMIT_REQUESTS", default=120),
+            rate_limit_window_seconds=_env_float(
+                "FDO_API_RATE_LIMIT_WINDOW_SECONDS", default=60.0
+            ),
+        )
+
+
+DEFAULT_API_SECURITY_POLICY = DeploymentSecurityPolicy.from_env()
+
+
+def _cors_origins(policy: DeploymentSecurityPolicy) -> list[str]:
+    origins = set(policy.allowed_origins)
+    if policy.local_dev_cors:
+        origins.update(LOCAL_DEV_CORS_ORIGINS)
+    return sorted(origins)
+
+
+def _configure_cors(fastapi_app: FastAPI, policy: DeploymentSecurityPolicy) -> None:
+    """Install CORS middleware with restrictive defaults and opt-in local dev."""
+
+    fastapi_app.add_middleware(
+        CORSMiddleware,
+        allow_origins=_cors_origins(policy),
+        allow_methods=["GET", "POST", "OPTIONS"],
+        allow_headers=["Authorization", "Content-Type", "X-API-Key", "X-Request-ID"],
+        expose_headers=["X-Request-ID"],
+    )
 
 
 class OptionType(str, Enum):
@@ -377,15 +465,22 @@ class FullPDEResponse(APIResponseBase):
 
 API_ERROR_RESPONSES: dict[int | str, dict[str, Any]] = {
     400: {"model": ErrorResponse},
+    401: {"model": ErrorResponse},
+    403: {"model": ErrorResponse},
     422: {"model": ErrorResponse},
     429: {"model": ErrorResponse},
     500: {"model": ErrorResponse},
     501: {"model": ErrorResponse},
+    503: {"model": ErrorResponse},
     504: {"model": ErrorResponse},
 }
 UNSUPPORTED_ROUTE_RESPONSES: dict[int | str, dict[str, Any]] = {
-    501: {"model": ErrorResponse},
+    401: {"model": ErrorResponse},
+    403: {"model": ErrorResponse},
     422: {"model": ErrorResponse},
+    429: {"model": ErrorResponse},
+    501: {"model": ErrorResponse},
+    503: {"model": ErrorResponse},
 }
 
 
@@ -607,6 +702,182 @@ def _http_exception_handler(http_request: Request, exc: HTTPException) -> JSONRe
         detail=exc.detail,
         source="http_exception",
     )
+
+
+class _ProcessLocalRateLimiter:
+    """Small in-process fixed-window limiter for local/demo API deployments."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._hits: dict[tuple[str, str], list[float]] = {}
+
+    def reset(self) -> None:
+        with self._lock:
+            self._hits.clear()
+
+    def check(
+        self,
+        key: tuple[str, str],
+        *,
+        max_requests: int,
+        window_seconds: float,
+    ) -> tuple[bool, int, float]:
+        if max_requests <= 0:
+            return True, 0, 0.0
+        now = time.monotonic()
+        cutoff = now - window_seconds
+        with self._lock:
+            hits = [hit for hit in self._hits.get(key, []) if hit > cutoff]
+            if len(hits) >= max_requests:
+                retry_after = max(0.0, window_seconds - (now - hits[0]))
+                self._hits[key] = hits
+                return False, len(hits), retry_after
+            hits.append(now)
+            self._hits[key] = hits
+            return True, len(hits), 0.0
+
+
+_RATE_LIMITER = _ProcessLocalRateLimiter()
+
+
+def _is_protected_path(path: str, policy: DeploymentSecurityPolicy) -> bool:
+    for prefix in policy.protected_path_prefixes:
+        if prefix.endswith("/"):
+            if path.startswith(prefix):
+                return True
+        elif path == prefix or path.startswith(f"{prefix}/"):
+            return True
+    return False
+
+
+def _extract_api_key(http_request: Request) -> str | None:
+    authorization = http_request.headers.get("authorization")
+    if authorization:
+        scheme, _, token = authorization.partition(" ")
+        if scheme.lower() == "bearer" and token.strip():
+            return token.strip()
+    api_key = http_request.headers.get("x-api-key")
+    return api_key.strip() if api_key and api_key.strip() else None
+
+
+def _constant_time_key_equal(presented_key: str, configured_key: str) -> bool:
+    """Compare API keys without leaking timing and without ASCII-only TypeError."""
+
+    return compare_digest(
+        presented_key.encode("utf-8"),
+        configured_key.encode("utf-8"),
+    )
+
+
+def _auth_failure(
+    http_request: Request,
+    *,
+    status_code: int,
+    code: str,
+    message: str,
+) -> JSONResponse:
+    return _error_response(
+        http_request,
+        status_code=status_code,
+        detail={
+            "code": code,
+            "message": message,
+            "capability_status": "deployment_hardening",
+        },
+        source="deployment_security",
+    )
+
+
+def _enforce_authentication(
+    http_request: Request, policy: DeploymentSecurityPolicy
+) -> JSONResponse | None:
+    if not policy.auth_required:
+        return None
+    if not policy.api_key:
+        return _auth_failure(
+            http_request,
+            status_code=503,
+            code="auth_misconfigured",
+            message="API authentication is required but no API key is configured",
+        )
+    presented_key = _extract_api_key(http_request)
+    if presented_key is None:
+        return _auth_failure(
+            http_request,
+            status_code=401,
+            code="auth_required",
+            message="API authentication is required for this route",
+        )
+    if not _constant_time_key_equal(presented_key, policy.api_key):
+        return _auth_failure(
+            http_request,
+            status_code=403,
+            code="auth_invalid",
+            message="API authentication credentials were rejected",
+        )
+    return None
+
+
+def _rate_limit_key(http_request: Request) -> tuple[str, str]:
+    client_host = http_request.client.host if http_request.client else "unknown"
+    return (http_request.url.path, client_host)
+
+
+def _enforce_rate_limit(
+    http_request: Request, policy: DeploymentSecurityPolicy
+) -> JSONResponse | None:
+    allowed, observed, retry_after = _RATE_LIMITER.check(
+        _rate_limit_key(http_request),
+        max_requests=policy.rate_limit_requests,
+        window_seconds=policy.rate_limit_window_seconds,
+    )
+    if allowed:
+        return None
+    return _error_response(
+        http_request,
+        status_code=429,
+        detail={
+            "code": "rate_limit_exceeded",
+            "message": "process-local API rate limit exceeded",
+            "route": http_request.url.path,
+            "resource": {
+                "limit": "rate_limit_requests",
+                "observed": observed,
+                "allowed": policy.rate_limit_requests,
+                "window_seconds": policy.rate_limit_window_seconds,
+                "retry_after_seconds": retry_after,
+                "scope": "process_local_demo",
+            },
+        },
+        source="deployment_security",
+    )
+
+
+async def _apply_deployment_security(http_request: Request, call_next):
+    """Apply fail-closed auth and process-local rate limits to API routes."""
+
+    if http_request.method.upper() == "OPTIONS":
+        return await call_next(http_request)
+    policy = DEFAULT_API_SECURITY_POLICY
+    if not _is_protected_path(http_request.url.path, policy):
+        return await call_next(http_request)
+    rate_response = _enforce_rate_limit(http_request, policy)
+    if rate_response is not None:
+        return rate_response
+    auth_response = _enforce_authentication(http_request, policy)
+    if auth_response is not None:
+        return auth_response
+    return await call_next(http_request)
+
+
+@app.middleware("http")
+async def _deployment_security_middleware(http_request: Request, call_next):
+    return await _apply_deployment_security(http_request, call_next)
+
+
+# Register CORS after the security middleware so it remains outermost and adds
+# browser-readable headers to auth/rate-limit error envelopes for allowed origins.
+_configure_cors(app, DEFAULT_API_SECURITY_POLICY)
 
 
 @app.exception_handler(Exception)

--- a/docs/CI_POLICY.md
+++ b/docs/CI_POLICY.md
@@ -18,7 +18,7 @@ The Python job uses Python 3.12 and reports failures by command group:
 3. architecture fitness gate:
    - `pytest -q tests/architecture`;
 4. stable regression suite:
-   - `PYTHONPATH=. pytest -q` with API request guards, schema contracts, route validation, interpolation diagnostics, resource controls, and regulatory fail-closed envelopes;
+   - `PYTHONPATH=. pytest -q` with API request guards, schema contracts, route validation, interpolation diagnostics, resource controls, deployment hardening, and regulatory fail-closed envelopes;
    - boundary conditions;
    - callable bond;
    - FD backend capability manifest;

--- a/tests/architecture/test_ci_policy_contracts.py
+++ b/tests/architecture/test_ci_policy_contracts.py
@@ -22,6 +22,7 @@ def test_blocking_ci_has_actionable_python_and_stable_suite_contract() -> None:
     assert "tests/test_api_route_validation.py" in workflow
     assert "tests/test_api_interpolation_diagnostics.py" in workflow
     assert "tests/test_api_resource_controls.py" in workflow
+    assert "tests/test_api_deployment_hardening.py" in workflow
     assert "tests/test_unified_pricing_engine.py" in workflow
 
 

--- a/tests/test_api_deployment_hardening.py
+++ b/tests/test_api_deployment_hardening.py
@@ -1,0 +1,269 @@
+"""Deployment hardening black-box tests for API issue #101."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import api.main as api_main
+from api.main import API_SCHEMA_VERSION, DeploymentSecurityPolicy, app
+
+
+def _payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "model": "black_scholes",
+        "process": "geometric_brownian_motion",
+        "payoff_family": "vanilla_european",
+        "exercise_style": "european",
+        "underlying_factor_role": "tradable_spot",
+        "option_type": "Call",
+        "spot": 100.0,
+        "strike": 100.0,
+        "maturity": 0.25,
+        "rate": 0.03,
+        "sigma": 0.2,
+        "s_max": 250.0,
+        "s_steps": 31,
+        "t_steps": 21,
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.fixture(autouse=True)
+def _isolated_security_policy(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setattr(
+        api_main,
+        "DEFAULT_API_SECURITY_POLICY",
+        DeploymentSecurityPolicy(rate_limit_requests=0),
+    )
+    api_main._RATE_LIMITER.reset()
+    yield
+    api_main._RATE_LIMITER.reset()
+
+
+def _assert_error(body: dict[str, Any], *, code: str, route: str, status: int) -> None:
+    assert body["schema_version"] == API_SCHEMA_VERSION
+    assert body["error"]["code"] == code
+    assert body["error"]["route"] == route
+    assert body["error"]["http_status"] == status
+    assert body["metadata"]["route"] == route
+
+
+def _cors_security_test_app() -> FastAPI:
+    test_app = FastAPI()
+
+    @test_app.middleware("http")
+    async def _security(http_request, call_next):
+        return await api_main._apply_deployment_security(http_request, call_next)
+
+    api_main._configure_cors(test_app, DeploymentSecurityPolicy(local_dev_cors=True))
+
+    @test_app.post("/price")
+    def _synthetic_price() -> dict[str, str]:
+        return {"status": "ok"}
+
+    return test_app
+
+
+def test_invalid_auth_required_env_value_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FDO_API_AUTH_REQUIRED", "treu")
+
+    with pytest.raises(ValueError, match="FDO_API_AUTH_REQUIRED"):
+        DeploymentSecurityPolicy.from_env()
+
+
+def test_default_cors_policy_rejects_unlisted_browser_origins() -> None:
+    response = TestClient(app).options(
+        "/price",
+        headers={
+            "Origin": "https://untrusted.example",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_local_development_cors_is_explicit_opt_in() -> None:
+    test_app = FastAPI()
+    api_main._configure_cors(test_app, DeploymentSecurityPolicy(local_dev_cors=True))
+
+    @test_app.post("/price")
+    def _synthetic_price() -> dict[str, str]:
+        return {"status": "ok"}
+
+    response = TestClient(test_app).options(
+        "/price",
+        headers={
+            "Origin": "http://localhost:5173",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "http://localhost:5173"
+
+
+def test_allowed_browser_origin_can_read_auth_error_envelopes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        api_main,
+        "DEFAULT_API_SECURITY_POLICY",
+        DeploymentSecurityPolicy(
+            local_dev_cors=True,
+            auth_required=True,
+            api_key="test-secret",
+            rate_limit_requests=0,
+        ),
+    )
+
+    response = TestClient(_cors_security_test_app()).post(
+        "/price",
+        json=_payload(),
+        headers={"Origin": "http://localhost:5173"},
+    )
+
+    assert response.status_code == 401
+    assert response.headers["access-control-allow-origin"] == "http://localhost:5173"
+    _assert_error(response.json(), code="auth_required", route="/price", status=401)
+
+
+def test_authentication_configuration_fails_closed_without_a_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        api_main,
+        "DEFAULT_API_SECURITY_POLICY",
+        DeploymentSecurityPolicy(
+            auth_required=True, api_key=None, rate_limit_requests=0
+        ),
+    )
+
+    response = TestClient(app).post("/price", json=_payload())
+
+    assert response.status_code == 503
+    body = response.json()
+    _assert_error(body, code="auth_misconfigured", route="/price", status=503)
+    assert "test-secret" not in str(body)
+
+
+def test_authentication_rejects_missing_and_bad_credentials_then_allows_bearer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        api_main,
+        "DEFAULT_API_SECURITY_POLICY",
+        DeploymentSecurityPolicy(
+            auth_required=True,
+            api_key="test-secret",
+            rate_limit_requests=0,
+        ),
+    )
+    client = TestClient(app)
+
+    missing = client.post("/price", json=_payload())
+    bad = client.post(
+        "/price", json=_payload(), headers={"Authorization": "Bearer wrong"}
+    )
+    good = client.post(
+        "/price", json=_payload(), headers={"Authorization": "Bearer test-secret"}
+    )
+
+    assert missing.status_code == 401
+    _assert_error(missing.json(), code="auth_required", route="/price", status=401)
+    assert bad.status_code == 403
+    _assert_error(bad.json(), code="auth_invalid", route="/price", status=403)
+    assert good.status_code == 200
+    assert "test-secret" not in str(missing.json())
+    assert "test-secret" not in str(bad.json())
+    assert "test-secret" not in str(good.json())
+
+
+def test_constant_time_key_compare_handles_non_ascii_values() -> None:
+    assert api_main._constant_time_key_equal("clave-ñ", "clave-ñ")
+    assert not api_main._constant_time_key_equal("inválido", "test-secret")
+
+
+def test_process_local_rate_limit_returns_bounded_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        api_main,
+        "DEFAULT_API_SECURITY_POLICY",
+        DeploymentSecurityPolicy(rate_limit_requests=1, rate_limit_window_seconds=60.0),
+    )
+    api_main._RATE_LIMITER.reset()
+    client = TestClient(app)
+
+    first = client.post("/price", json=_payload())
+    second = client.post("/price", json=_payload())
+
+    assert first.status_code == 200
+    assert second.status_code == 429
+    body = second.json()
+    _assert_error(body, code="rate_limit_exceeded", route="/price", status=429)
+    assert body["detail"]["resource"]["limit"] == "rate_limit_requests"
+    assert body["detail"]["resource"]["scope"] == "process_local_demo"
+
+
+def test_failed_authentication_attempts_consume_rate_limit_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        api_main,
+        "DEFAULT_API_SECURITY_POLICY",
+        DeploymentSecurityPolicy(
+            auth_required=True,
+            api_key="test-secret",
+            rate_limit_requests=1,
+            rate_limit_window_seconds=60.0,
+        ),
+    )
+    api_main._RATE_LIMITER.reset()
+    client = TestClient(app)
+
+    first = client.post("/price", json=_payload())
+    second = client.post("/price", json=_payload())
+
+    assert first.status_code == 401
+    _assert_error(first.json(), code="auth_required", route="/price", status=401)
+    assert second.status_code == 429
+    _assert_error(second.json(), code="rate_limit_exceeded", route="/price", status=429)
+
+
+def test_black_box_lifecycle_failures_use_stable_error_envelopes() -> None:
+    client = TestClient(app)
+
+    malformed = client.post(
+        "/price",
+        content="{not-json",
+        headers={"content-type": "application/json"},
+    )
+    oversized = client.post(
+        "/pde_solution",
+        json=_payload(include_full_grid=True, max_output_nodes=1),
+    )
+    unsupported = client.post("/reports/crif", json=[])
+
+    assert malformed.status_code == 422
+    _assert_error(malformed.json(), code="validation_error", route="/price", status=422)
+    assert oversized.status_code == 422
+    _assert_error(
+        oversized.json(),
+        code="resource_limit_exceeded",
+        route="/pde_solution",
+        status=422,
+    )
+    assert unsupported.status_code == 501
+    _assert_error(
+        unsupported.json(), code="unsupported_route", route="/reports/crif", status=501
+    )

--- a/tests/test_api_schema_contracts.py
+++ b/tests/test_api_schema_contracts.py
@@ -207,10 +207,11 @@ def test_openapi_schema_contains_reviewed_v1_response_error_components() -> None
         "/reports/frtb",
     ]:
         operation = schema["paths"][path]["post"]
-        assert "422" in operation["responses"]
-        assert operation["responses"]["422"]["content"]["application/json"]["schema"][
-            "$ref"
-        ].endswith("/ErrorResponse")
+        for status in ["401", "403", "422", "429", "503"]:
+            assert status in operation["responses"]
+            assert operation["responses"][status]["content"]["application/json"][
+                "schema"
+            ]["$ref"].endswith("/ErrorResponse")
 
     for path in ["/reports/crif", "/reports/cuso", "/reports/basel", "/reports/frtb"]:
         assert schema["paths"][path]["post"]["responses"]["501"]["content"][


### PR DESCRIPTION
Closes googa27/finite_difference_options#101.

## Summary
- Add restrictive deployment security policy with default-deny browser CORS and explicit local-dev/allow-list environment overrides.
- Add fail-closed optional API-key auth for protected pricing/reporting routes plus process-local fixed-window rate limiting.
- Add black-box tests for CORS, auth misconfiguration, missing/bad/good credentials, rate limits, malformed payloads, oversized requests, and unsupported routes.
- Document local-demo deployment maturity, required safeguards, and CI stable-suite coverage.

## Verification
- `/tmp/qpe-fdo-venv/bin/python -m compileall -q api src tests`
- `/tmp/qpe-fdo-venv/bin/ruff check . --select E9,F63,F7,F82`
- `/tmp/qpe-fdo-venv/bin/python scripts/check_architecture_contract.py`
- `/tmp/qpe-fdo-venv/bin/python -m pytest -q tests/architecture`
- `/tmp/qpe-fdo-venv/bin/python -m pytest -q` → 247 passed, 14 external matplotlib/pyparsing deprecation warnings
- Env smoke: auth/CORS/rate env parsing works and `api_key` is excluded from `model_dump()`/repr.

## Review notes
- A delegated local pre-commit review was attempted but timed out without findings; this PR is intentionally left to the normal GitHub CI + automated review gates before merge.
