### PR TITLE
test: add Pinares problem-spec fixture for FD backend

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -175,6 +175,7 @@ with domain, coordinate transform, time orientation, initial or terminal conditi
 
 The contract distinguishes:
 
+- problem identity/hash from FD method controls so Pinares, Haircut, and other consumers can ask different solvers to price the same claim;
 - covariance/diffusion matrix `A=[a_ij]` and its coordinate convention;
 - state-factor roles (`tradable_spot`, `variance`, `volatility`, `short_rate`, `auxiliary_state`) and payoff transforms used to validate payoff/process compatibility before payoff allocation;
 - drift `b`;
@@ -215,7 +216,7 @@ FDResult
 └── version and reproducibility metadata
 ```
 
-Contracts are immutable or snapshot-able and serialization-tested.
+Contracts are immutable or snapshot-able and serialization-tested. `tests/fixtures/quant_problem_specs/pinares_fixed_price_proxy.json` is the public-synthetic compatibility smoke for the Pinares fixed-price option proxy: it verifies that Pinares owns the financial problem and this backend owns only grid/time/stability controls.
 
 ## 9. Grid architecture
 

--- a/src/contracts/backend_capabilities.py
+++ b/src/contracts/backend_capabilities.py
@@ -33,6 +33,7 @@ class UnsupportedReason(str, Enum):
     UNSUPPORTED_EXERCISE = "unsupported_exercise_style"
     UNSUPPORTED_OUTPUT = "unsupported_output"
     UNSUPPORTED_STABILITY_CONTROL = "unsupported_stability_control"
+    UNSUPPORTED_BACKEND = "unsupported_backend"
     MISSING_CONVENTION = "missing_convention"
 
 
@@ -100,6 +101,7 @@ class FDRouteRequest:
     maturity_date: str | None = None
     time_domain: str | None = None
     source_schema_version: str | None = None
+    backend_id: str | None = None
 
     @classmethod
     def from_quant_problem_spec(cls, payload: Mapping[str, Any]) -> FDRouteRequest:
@@ -174,6 +176,7 @@ class FDRouteRequest:
             ),
             time_domain=_optional_string(_first_present(context, ("time_domain",), default=domain.get("t"))),
             source_schema_version=_optional_string(payload.get("schema_version")),
+            backend_id=_optional_string(_first_present(solver, ("backend_id", "backend"), default=None)),
         )
 
 
@@ -210,6 +213,17 @@ def diagnose_unsupported_route(
     """Return fail-closed diagnostics for unsupported request fields."""
 
     diagnostics: list[UnsupportedRouteDiagnostic] = []
+
+    if request.backend_id and request.backend_id != manifest.backend_id:
+        diagnostics.append(
+            _diagnostic(
+                UnsupportedReason.UNSUPPORTED_BACKEND,
+                "backend_id",
+                request.backend_id,
+                (manifest.backend_id,),
+                f"Unsupported backend_id {request.backend_id!r}; expected {manifest.backend_id!r}.",
+            )
+        )
 
     if request.dimension not in manifest.supported_dimensions:
         diagnostics.append(

--- a/tests/fixtures/quant_problem_specs/pinares_fixed_price_proxy.json
+++ b/tests/fixtures/quant_problem_specs/pinares_fixed_price_proxy.json
@@ -63,7 +63,7 @@
   "problem_id": "pinares.fixed_price_option_proxy.v1",
   "schema_version": "quant-problem-spec/v0",
   "solver_plan": {
-    "backend_id": "googa27/pinares-real-options",
+    "backend_id": "finite_difference_options.fd_backend.v0",
     "element_family": "lagrange_p2",
     "formulation_kind": "generator_pde_or_weak_form",
     "grid_type": "uniform",

--- a/tests/fixtures/quant_problem_specs/pinares_fixed_price_proxy.json
+++ b/tests/fixtures/quant_problem_specs/pinares_fixed_price_proxy.json
@@ -1,0 +1,96 @@
+{
+  "evidence": {
+    "caveats": [
+      "not private Pinares data"
+    ],
+    "evidence_ids": [
+      "public-synthetic"
+    ]
+  },
+  "mathematical_problem": {
+    "boundary_conditions": {
+      "S=0": "dirichlet",
+      "S=S_max": "linear_growth"
+    },
+    "dimension": 1,
+    "exercise_style": "european",
+    "formulations": [
+      {
+        "formulation_id": "expectation_fixed_price_proxy",
+        "kind": "conditional_expectation"
+      },
+      {
+        "formulation_id": "pde_fixed_price_proxy",
+        "kind": "generator_pde"
+      },
+      {
+        "formulation_id": "weak_form_fixed_price_proxy",
+        "kind": "weak_form"
+      }
+    ],
+    "has_hjb_control": false,
+    "has_jumps": false,
+    "has_obstacle": false,
+    "measure_id": "Q*",
+    "numeraire_id": "UF_money_market_account_proxy",
+    "pde_terms": [
+      "drift",
+      "diffusion",
+      "reaction"
+    ],
+    "state_variables": [
+      {
+        "description": "public synthetic property-value proxy",
+        "name": "S",
+        "role": "underlying",
+        "unit": "UF"
+      }
+    ],
+    "terminal_payoff": {
+      "expression": "0.97 * max(S-K,0)",
+      "payoff_id": "mortality_adjusted_call_payoff",
+      "timing": "terminal",
+      "units": "UF"
+    },
+    "units": {
+      "S": "UF",
+      "rate": "1/year",
+      "time": "year",
+      "value": "UF"
+    }
+  },
+  "problem_hash": "publicsyntheticpinares001",
+  "problem_id": "pinares.fixed_price_option_proxy.v1",
+  "schema_version": "quant-problem-spec/v0",
+  "solver_plan": {
+    "backend_id": "googa27/pinares-real-options",
+    "element_family": "lagrange_p2",
+    "formulation_kind": "generator_pde_or_weak_form",
+    "grid_type": "uniform",
+    "linear_solver": "scipy_direct",
+    "mesh_family": "line_uniform",
+    "method_id": "pinares_backend_compatibility_smoke",
+    "method_kind": "finite_difference_or_finite_element",
+    "requested_outputs": [
+      "value",
+      "delta",
+      "gamma"
+    ],
+    "stability_controls": [
+      "theta"
+    ]
+  },
+  "valuation_context": {
+    "measure": "Q*",
+    "numeraire": "UF_money_market_account_proxy",
+    "privacy_tier": "public_sanitized",
+    "time_domain": "[0, 1]",
+    "units": {
+      "S": "UF",
+      "rate": "1/year",
+      "time": "year",
+      "value": "UF"
+    },
+    "valuation_date": "2026-06-30"
+  }
+}

--- a/tests/test_fd_backend_capabilities.py
+++ b/tests/test_fd_backend_capabilities.py
@@ -98,6 +98,28 @@ def test_haircut_engine_vanilla_call_fixture_maps_to_supported_fd_route() -> Non
     assert diagnose_unsupported_route(request) == ()
 
 
+def test_pinares_fixed_price_problem_fixture_maps_to_supported_fd_route() -> None:
+    """Pinares publishes the problem; FD only chooses grid/time controls."""
+
+    payload = json.loads((FIXTURE_DIR / "pinares_fixed_price_proxy.json").read_text())
+
+    request = FDRouteRequest.from_quant_problem_spec(payload)
+
+    assert payload["problem_id"] == "pinares.fixed_price_option_proxy.v1"
+    assert request.source_schema_version == "quant-problem-spec/v0"
+    assert request.dimension == 1
+    assert request.grid_type == "uniform"
+    assert request.pde_terms == ("drift", "diffusion", "reaction")
+    assert request.boundary_conditions == ("dirichlet", "neumann")
+    assert request.requested_outputs == ("value", "delta", "gamma")
+    assert request.measure == "Q*"
+    assert request.numeraire == "UF_money_market_account_proxy"
+    assert request.units["S"] == "UF"
+    assert request.valuation_date == "2026-06-30"
+    assert request.time_domain == "[0, 1]"
+    assert diagnose_unsupported_route(request) == ()
+
+
 def test_unsupported_terms_dimensions_boundaries_and_exercise_fail_closed() -> None:
     payload = _supported_payload()
     payload["mathematical_problem"] = {

--- a/tests/test_fd_backend_capabilities.py
+++ b/tests/test_fd_backend_capabilities.py
@@ -106,11 +106,14 @@ def test_pinares_fixed_price_problem_fixture_maps_to_supported_fd_route() -> Non
     request = FDRouteRequest.from_quant_problem_spec(payload)
 
     assert payload["problem_id"] == "pinares.fixed_price_option_proxy.v1"
+    assert payload["problem_hash"] == "publicsyntheticpinares001"
     assert request.source_schema_version == "quant-problem-spec/v0"
+    assert request.backend_id == "finite_difference_options.fd_backend.v0"
     assert request.dimension == 1
     assert request.grid_type == "uniform"
     assert request.pde_terms == ("drift", "diffusion", "reaction")
     assert request.boundary_conditions == ("dirichlet", "neumann")
+    assert request.boundary_details == {"S=0": "dirichlet", "S=S_max": "linear_growth"}
     assert request.requested_outputs == ("value", "delta", "gamma")
     assert request.measure == "Q*"
     assert request.numeraire == "UF_money_market_account_proxy"
@@ -118,6 +121,20 @@ def test_pinares_fixed_price_problem_fixture_maps_to_supported_fd_route() -> Non
     assert request.valuation_date == "2026-06-30"
     assert request.time_domain == "[0, 1]"
     assert diagnose_unsupported_route(request) == ()
+
+
+def test_wrong_backend_id_fails_closed_for_fd_route() -> None:
+    payload = json.loads((FIXTURE_DIR / "pinares_fixed_price_proxy.json").read_text())
+    payload["solver_plan"] = {**payload["solver_plan"], "backend_id": "finite_element_options.fem_backend.v0"}
+    request = FDRouteRequest.from_quant_problem_spec(payload)
+
+    diagnostics = diagnose_unsupported_route(request)
+    assert any(
+        diagnostic.reason == UnsupportedReason.UNSUPPORTED_BACKEND
+        and diagnostic.field == "backend_id"
+        and diagnostic.value == "finite_element_options.fem_backend.v0"
+        for diagnostic in diagnostics
+    )
 
 
 def test_unsupported_terms_dimensions_boundaries_and_exercise_fail_closed() -> None:


### PR DESCRIPTION
## Summary
- Adds a public-synthetic Pinares fixed-price QuantProblemSpec fixture for the finite-difference backend.
- Verifies FD capability screening consumes the same problem id/hash while owning only grid/time/stability controls.
- Documents the problem/formulation/method boundary in the architecture spec.

## Closes
Closes #108

## Evidence
- `PYTHONPATH=$PWD /tmp/fd-contract-venv/bin/pytest -q` -> 252 passed
- `/tmp/fd-contract-venv/bin/pytest tests/test_fd_backend_capabilities.py tests/architecture -q` -> 18 passed
- `/tmp/fd-contract-venv/bin/ruff check docs/ARCHITECTURE.md tests/test_fd_backend_capabilities.py` -> passed

## Project topology
- Project #5 epic field: `PROBLEM-FORMULATION-METHOD`
- Predecessors: finite_difference_options#59; pinares-real-options#21.
