### PR TITLE
fix(docs): add markdown link health gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
           ruff check . --select E9,F63,F7,F82
       - name: Architecture contract
         run: python scripts/check_architecture_contract.py
+      - name: Markdown link contract
+        run: python scripts/check_markdown_links.py
       - name: Architecture fitness gate
         run: pytest -q tests/architecture
       - name: Stable regression suite

--- a/docs/AI_MAINTENANCE.md
+++ b/docs/AI_MAINTENANCE.md
@@ -66,8 +66,8 @@ triggers:
 # Validate all code examples
 find docs/ -name "*.md" -exec python -m doctest {} \;
 
-# Check internal links
-grep -r "\[.*\](.*\.md)" docs/ | validate_links.py
+# Check internal Markdown links.
+python scripts/check_markdown_links.py
 
 # Verify template variables
 grep -r "TEMPLATE_" docs/ | check_populated.py

--- a/docs/CI_POLICY.md
+++ b/docs/CI_POLICY.md
@@ -15,9 +15,12 @@ The Python job uses Python 3.12 and reports failures by command group:
 2. static smoke gate:
    - `python -m compileall -q api src tests`;
    - `ruff check . --select E9,F63,F7,F82`;
-3. architecture fitness gate:
+3. architecture and documentation contracts:
+   - `python scripts/check_architecture_contract.py`;
+   - `python scripts/check_markdown_links.py`;
+4. architecture fitness gate:
    - `pytest -q tests/architecture`;
-4. stable regression suite:
+5. stable regression suite:
    - `PYTHONPATH=. pytest -q` with API request guards, schema contracts, route validation, interpolation diagnostics, resource controls, deployment hardening, and regulatory fail-closed envelopes;
    - boundary conditions;
    - callable bond;

--- a/docs/explanation/black_scholes_fdm.md
+++ b/docs/explanation/black_scholes_fdm.md
@@ -1,0 +1,82 @@
+# Black-Scholes finite-difference method
+
+This page is the durable theory companion for the repository's Black-Scholes finite-difference examples. The implementation target is not just "produce a price array"; it is to solve a precisely stated parabolic pricing PDE with explicit coordinates, boundary conditions, time orientation, and diagnostics.
+
+## Pricing equation
+
+For a non-dividend European claim with payoff `g(S)` at maturity `T`, the Black-Scholes value `V(S,t)` solves
+
+```text
+∂_t V + 0.5 σ² S² ∂²_SS V + r S ∂_S V - r V = 0,
+V(S,T) = g(S).
+```
+
+Finite-difference code usually evolves forward in time-to-maturity `τ = T - t`:
+
+```text
+∂_τ u = 0.5 σ² S² ∂²_SS u + r S ∂_S u - r u,
+u(S,0) = g(S).
+```
+
+The sign convention matters. In this repository, any route that advertises a value at valuation time must make the calendar-time/time-to-maturity orientation explicit in tests and result metadata.
+
+## Discretization contract
+
+A validated Black-Scholes FD route needs all of the following as inputs or declared policy:
+
+- spatial coordinate: spot `S`, log-spot `x = log(S)`, or another declared transform;
+- domain truncation: lower and upper spot/log-spot bounds;
+- grid family: uniform, nonuniform, or transformed, including node count and spacing policy;
+- boundary conditions: type, boundary side, formula, and time dependence;
+- time scheme: backward Euler, Crank-Nicolson, Rannacher-smoothed CN, or another documented θ-route;
+- linear solver and tolerances;
+- output convention: valuation-time point value, full grid, Greeks, or diagnostics.
+
+A route is not mathematically defined by option type alone. For example, a call's far-field boundary and a put's far-field boundary are product-adapter responsibilities; the FD core should receive them as explicit boundary records or fail closed.
+
+## Boundary examples
+
+For vanilla European options in spot coordinates on `[S_min, S_max]`, common benchmark boundaries are:
+
+```text
+call: V(0,t) = 0,
+      V(S_max,t) ≈ S_max - K exp(-r(T-t));
+
+put:  V(0,t) ≈ K exp(-r(T-t)),
+      V(S_max,t) = 0.
+```
+
+These are truncation approximations, not universal truths. Local volatility, dividends, stochastic rates, transformed coordinates, American exercise, or model-specific asymptotics require different contracts.
+
+## Stability and convergence expectations
+
+Blocking validation should separate:
+
+1. temporal convergence: vary time steps while holding spatial error small;
+2. spatial convergence: vary grid size while holding time error small;
+3. boundary sensitivity: move the truncated domain and verify stable target values;
+4. payoff-kink behavior: use Rannacher smoothing or document the observed degradation;
+5. Greek convergence: use grid-aware derivative formulas, especially on nonuniform grids.
+
+The repository's Project #5 architecture requires capability claims to be benchmark-backed. A single endpoint match to a closed-form price is useful smoke evidence, but it is not a complete numerical validation gate.
+
+## Relation to the architecture contract
+
+Black-Scholes is the simplest shared fixture for package, API, and solver-contract health:
+
+```text
+explicit Black-Scholes problem
+        ↓
+grid + boundary records
+        ↓
+θ time stepper
+        ↓
+price / Greeks / residual diagnostics
+```
+
+The same ownership rules apply here as for more complex models:
+
+- finite_difference_options owns FD grids, operators, boundary algebra, stepping, and diagnostics;
+- product adapters own financial payoff/boundary assumptions;
+- haircut-engine owns CASCADE/domain orchestration, not hidden FD semantics;
+- PDP owns data products, not pricing kernels.

--- a/docs/explanation/pde_models.md
+++ b/docs/explanation/pde_models.md
@@ -1,0 +1,92 @@
+# PDE model contracts
+
+This page explains the model-theory boundary behind the repository architecture. A finite-difference solver route is valid only when the mathematical PDE, coordinate convention, boundary conditions, and numerical policy are explicit. Model names and process dimensions are not enough.
+
+## Generic parabolic pricing form
+
+The canonical backward pricing problem can be written as
+
+```text
+∂_t V + L_t V - c(x,t) V + f(x,t) = 0,
+V(x,T) = g(x),
+```
+
+where the generator is
+
+```text
+L_t V = 0.5 Σ_ij a_ij(x,t) ∂²_ij V + Σ_i b_i(x,t) ∂_i V.
+```
+
+In time-to-maturity `τ = T - t`, the same problem is evolved with a consistent sign convention and an initial condition at `τ = 0`. Every implementation must state which orientation it uses.
+
+## Required problem fields
+
+A model-correct FD problem contract includes:
+
+- state variables and coordinate transforms;
+- domain and truncation policy;
+- drift vector `b(x,t)`;
+- covariance/diffusion matrix `A(x,t)` with symmetry and positive-semidefinite checks where required;
+- reaction/discount `c(x,t)`;
+- source term `f(x,t)`;
+- initial or terminal payoff/condition;
+- typed boundary conditions for every boundary set;
+- optional obstacle/free-boundary, jump, or coupled-system terms;
+- requested outputs: value, grid, Greeks, residuals, exercise boundary, or diagnostics;
+- discretization controls and resource limits.
+
+No route should replace missing data with dummy drift, hard-coded covariance, generic zero discounting, or product-string boundary guesses.
+
+## Model families
+
+### Black-Scholes / local volatility
+
+Black-Scholes has one tradable state and an analytic reference. Local-volatility variants keep the parabolic structure but make diffusion state/time dependent. They are good validation fixtures for boundary handling, time stepping, and Greek convergence.
+
+### Short-rate models
+
+Vasicek/Ornstein-Uhlenbeck and CIR-style models may price claims in a rate coordinate. Boundary behavior and discounting are model-specific. Positivity constraints, transformed coordinates, and degeneracy near zero must be explicit.
+
+### Stochastic volatility
+
+Heston-style contracts require at least spot/log-spot and variance state variables. The executable convention in this repository's target architecture is log-spot plus variance when used by native problem contracts. The covariance tensor, mixed derivative, variance lower boundary, Feller/numerical policy, and payoff transform must be explicit.
+
+The Feller condition is not a universal validity switch for every numerical route; it is one input into a declared boundary/numerical policy.
+
+### Correlated multidimensional models and ADI
+
+Alternating-direction implicit methods require a real operator split. Correctness depends on drift, covariance, reaction, mixed derivative signs, boundary application, and time dependence. Selecting ADI because a process has dimension greater than one is not sufficient.
+
+### American and callable claims
+
+Early exercise is an obstacle or complementarity problem:
+
+```text
+V ≥ payoff,
+∂_t V + L_t V - cV + f ≤ 0,
+(V - payoff)(∂_t V + L_t V - cV + f) = 0.
+```
+
+Post-step payoff clipping is not, by itself, a diagnosed LCP solver. Valid routes report complementarity residuals, iteration counts, stopping criteria, and exercise-boundary diagnostics.
+
+## Validation expectations
+
+A model enters the supported capability matrix only after evidence exists for the advertised route:
+
+- analytical or manufactured reference where available;
+- convergence/stability tests at fixed mathematical problem;
+- boundary residuals and truncation sensitivity;
+- covariance/mixed-derivative validation for multidimensional routes;
+- explicit failure tests for unsupported inputs;
+- complete result diagnostics and reproducibility metadata.
+
+## Cross-repository meaning
+
+Within the Quant PDE Platform:
+
+- finite_difference_options owns finite-difference model mechanics and diagnostics;
+- finite_element_options owns finite-element mechanics and diagnostics;
+- haircut-engine owns graph/CASCADE orchestration and solver routing;
+- PDP owns data products and point-in-time data contracts.
+
+Integration happens through explicit problem specs, capability manifests, shared fixtures, and compatibility matrices, not through hidden source-tree imports or model-name conventions.

--- a/scripts/check_markdown_links.py
+++ b/scripts/check_markdown_links.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Check repository-local Markdown links.
+
+The checker is intentionally small and dependency-free so documentation health can
+stay in blocking CI without adding a docs toolchain. It validates relative links
+in Markdown files and ignores external URLs, anchors-only links, e-mail links,
+images, and fenced code blocks.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+EXTERNAL_SCHEMES = {"http", "https", "mailto", "tel", "ftp", "data"}
+DEFAULT_EXCLUDES = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    "__pycache__",
+    "node_modules",
+}
+
+
+def _iter_markdown_files(root: Path) -> list[Path]:
+    files: list[Path] = []
+    for path in root.rglob("*.md"):
+        if any(part in DEFAULT_EXCLUDES for part in path.parts):
+            continue
+        files.append(path)
+    return sorted(files)
+
+
+def _strip_fenced_code(text: str) -> str:
+    lines = text.splitlines(keepends=True)
+    output: list[str] = []
+    in_fence = False
+    fence_marker = ""
+    for line in lines:
+        stripped = line.lstrip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            marker = stripped[:3]
+            if not in_fence:
+                in_fence = True
+                fence_marker = marker
+            elif marker == fence_marker:
+                in_fence = False
+                fence_marker = ""
+            output.append("\n")
+            continue
+        output.append("\n" if in_fence else line)
+    return "".join(output)
+
+
+def _find_label_end(line: str, start: int) -> int | None:
+    depth = 0
+    escaped = False
+    for cursor in range(start + 1, len(line)):
+        char = line[cursor]
+        if escaped:
+            escaped = False
+        elif char == "\\":
+            escaped = True
+        elif char == "[":
+            depth += 1
+        elif char == "]":
+            if depth == 0:
+                return cursor
+            depth -= 1
+    return None
+
+
+def _iter_link_targets(line: str):
+    index = 0
+    while index < len(line):
+        start = line.find("[", index)
+        if start == -1:
+            return
+        if start > 0 and line[start - 1] == "!":
+            index = start + 1
+            continue
+        label_end = _find_label_end(line, start)
+        if label_end is None:
+            return
+        if label_end + 1 >= len(line) or line[label_end + 1] != "(":
+            index = label_end + 1
+            continue
+
+        cursor = label_end + 2
+        depth = 0
+        in_angle = False
+        quote: str | None = None
+        escaped = False
+        target: list[str] = []
+        while cursor < len(line):
+            char = line[cursor]
+            if escaped:
+                target.append(char)
+                escaped = False
+            elif char == "\\":
+                target.append(char)
+                escaped = True
+            elif quote is not None:
+                target.append(char)
+                if char == quote:
+                    quote = None
+            elif char in {"'", '"'}:
+                target.append(char)
+                quote = char
+            elif in_angle:
+                target.append(char)
+                if char == ">":
+                    in_angle = False
+            elif char == "<":
+                target.append(char)
+                in_angle = True
+            elif char == "(":
+                target.append(char)
+                depth += 1
+            elif char == ")":
+                if depth == 0:
+                    yield "".join(target)
+                    index = cursor + 1
+                    break
+                target.append(char)
+                depth -= 1
+            else:
+                target.append(char)
+            cursor += 1
+        else:
+            return
+
+
+def _link_destination(raw_target: str) -> str:
+    target = raw_target.strip()
+    if target.startswith("<"):
+        closing = target.find(">")
+        if closing != -1:
+            return target[1:closing].strip()
+    return target.split(maxsplit=1)[0]
+
+
+def _normalise_target(raw_target: str) -> str | None:
+    target = _link_destination(raw_target)
+    if not target:
+        return None
+    parsed = urlparse(target)
+    if parsed.scheme.lower() in EXTERNAL_SCHEMES or parsed.netloc:
+        return None
+    if target.startswith("#"):
+        return None
+    path_part = target.split("#", 1)[0].split("?", 1)[0]
+    if not path_part:
+        return None
+    return unquote(path_part)
+
+
+def validate_links(repo_root: Path) -> list[str]:
+    failures: list[str] = []
+    for markdown_file in _iter_markdown_files(repo_root):
+        rel_file = markdown_file.relative_to(repo_root)
+        text = _strip_fenced_code(markdown_file.read_text(encoding="utf-8"))
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            for raw_target in _iter_link_targets(line):
+                target = _normalise_target(raw_target)
+                if target is None:
+                    continue
+                if target.startswith("/"):
+                    candidate = repo_root / target.lstrip("/")
+                else:
+                    candidate = markdown_file.parent / target
+                candidate = candidate.resolve()
+                try:
+                    candidate.relative_to(repo_root.resolve())
+                except ValueError:
+                    failures.append(f"{rel_file}:{line_number}: link escapes repository: {target}")
+                    continue
+                if not candidate.exists():
+                    failures.append(f"{rel_file}:{line_number}: missing relative link target: {target}")
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd(), help="repository root (default: current directory)")
+    args = parser.parse_args()
+    repo_root = args.root.resolve()
+    failures = validate_links(repo_root)
+    if failures:
+        print("Markdown link check failed:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+    print("Markdown link check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/architecture/test_markdown_link_contract.py
+++ b/tests/architecture/test_markdown_link_contract.py
@@ -1,0 +1,79 @@
+import importlib.util
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_markdown_links.py"
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location("check_markdown_links", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_markdown_link_checker_accepts_existing_relative_targets_with_titles(tmp_path) -> None:
+    checker = _load_checker()
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "target.md").write_text("# Target\n", encoding="utf-8")
+    (tmp_path / "docs" / "target(with-parens).md").write_text("# Target with parens\n", encoding="utf-8")
+    (tmp_path / "docs" / "index.md").write_text(
+        '[plain](target.md)\n'
+        '[titled](target.md "Target doc")\n'
+        '[angle](<target.md> "Target doc")\n'
+        '[parens](target(with-parens).md)\n'
+        '[angle-parens](<target(with-parens).md> "Target doc")\n',
+        encoding="utf-8",
+    )
+
+    assert checker.validate_links(tmp_path) == []
+
+
+def test_markdown_link_checker_reports_missing_relative_targets(tmp_path) -> None:
+    checker = _load_checker()
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "index.md").write_text("[missing](absent.md)\n", encoding="utf-8")
+
+    assert checker.validate_links(tmp_path) == ["docs/index.md:1: missing relative link target: absent.md"]
+
+
+def test_markdown_link_checker_validates_outer_target_for_linked_images(tmp_path) -> None:
+    checker = _load_checker()
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "img.png").write_bytes(b"synthetic")
+    (tmp_path / "docs" / "index.md").write_text(
+        "[![diagram](img.png)](missing-diagram-page.md)\n",
+        encoding="utf-8",
+    )
+
+    assert checker.validate_links(tmp_path) == [
+        "docs/index.md:1: missing relative link target: missing-diagram-page.md"
+    ]
+
+
+def test_markdown_link_checker_resolves_root_relative_repo_links(tmp_path) -> None:
+    checker = _load_checker()
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "CI_POLICY.md").write_text("# CI Policy\n", encoding="utf-8")
+    (tmp_path / "docs" / "index.md").write_text("[policy](/docs/CI_POLICY.md)\n", encoding="utf-8")
+
+    assert checker.validate_links(tmp_path) == []
+
+
+def test_markdown_link_checker_ignores_fenced_code_external_and_anchor_links(tmp_path) -> None:
+    checker = _load_checker()
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "index.md").write_text(
+        "[external](https://example.com/x.md)\n"
+        "[protocol-relative](//example.com/file.md)\n"
+        "[anchor](#local)\n"
+        "```bash\n"
+        "grep -r \"\\[.*\\](.*\\.md)\" docs/\n"
+        "```\n",
+        encoding="utf-8",
+    )
+
+    assert checker.validate_links(tmp_path) == []


### PR DESCRIPTION
## Summary

Closes #111.

Repairs the Project #5 documentation-health failures reported by the cross-repo audit:

- adds durable theory/explanation pages for the README's Black-Scholes FDM and PDE-model links
- replaces the regex-like malformed Markdown-link recipe in `docs/AI_MAINTENANCE.md`
- adds a dependency-free `scripts/check_markdown_links.py` relative-link checker
- wires the new link checker into blocking CI and documents it in `docs/CI_POLICY.md`

## Verification

Local gates:

```text
git diff --check: pass
.venv/bin/python -m compileall -q api src tests scripts: pass
.venv/bin/python -m ruff check . --select E9,F63,F7,F82: pass
.venv/bin/python scripts/check_architecture_contract.py: pass
.venv/bin/python scripts/check_markdown_links.py: pass
PYTHONPATH=. .venv/bin/python -m pytest -q tests/architecture: 11 passed
CI stable suite: 191 passed, 14 third-party matplotlib/pyparsing deprecation warnings
cross_repo_governance_audit finite_difference_options markdown_link_findings: 0
```

Adversarial review:

```text
APPROVE — no blockers found before PR.
```

## Risk

Low. This is docs + a stdlib-only documentation fitness gate. The new checker validates repository-local Markdown link targets and intentionally does not attempt external URL or anchor validation.
