### PR TITLE
fix: derive FD oracle time domain from maturity

### DIFF
--- a/src/validation/black_scholes_parity.py
+++ b/src/validation/black_scholes_parity.py
@@ -294,7 +294,7 @@ def _build_public_problem_spec(
             "numeraire": case.numeraire,
             "valuation_date": case.valuation_date,
             "maturity_date": case.maturity_date,
-            "time_domain": "[0, 1]",
+            "time_domain": f"[0, {case.maturity:g}]",
             "units": case.normalized_units(),
             "privacy_tier": "public_synthetic",
         },

--- a/tests/test_fd_black_scholes_parity_fixture.py
+++ b/tests/test_fd_black_scholes_parity_fixture.py
@@ -85,6 +85,14 @@ def test_public_black_scholes_fixture_emits_delta_gamma_reference_errors() -> No
     assert report.no_arbitrage["delta_upper_bound_ok"]
     assert report.no_arbitrage["gamma_non_negative_ok"]
 
+def test_public_black_scholes_fixture_spec_uses_case_maturity() -> None:
+    case = BlackScholesParityCase(maturity=2.0, maturity_date="2028-01-02")
+    report = run_public_black_scholes_parity_fixture(case=case, grid_levels=((20, 30),))
+    payload = report.as_dict()
+
+    assert payload["problem_spec"]["valuation_context"]["time_domain"] == "[0, 2]"
+    assert payload["result_export"]["domain"]["t_max"] == 2.0
+
 
 def test_arxiv_lab_payload_is_static_file_and_consumable() -> None:
     assert FIXTURE_PATH.exists(), "Fixture JSON expected under tests/fixtures."


### PR DESCRIPTION
## Summary
- follow up on post-merge review feedback from #113
- derive the exported QuantProblemSpec time domain from `BlackScholesParityCase.maturity`
- add a regression test for non-default maturities

## Verification
- `PYTHONPATH=. uv run python scripts/export_arxiv_lab_black_scholes_fixture.py`
- `uv run pytest -q tests/test_fd_black_scholes_parity_fixture.py tests/test_fd_backend_capabilities.py tests/architecture/test_architecture_contracts.py` -> 21 passed
- `uv run ruff check src/validation/black_scholes_parity.py tests/test_fd_black_scholes_parity_fixture.py scripts/export_arxiv_lab_black_scholes_fixture.py` -> All checks passed
- `git diff --check`


Closes #115
