### PR TITLE
feat(validation): add benchmark evidence registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
             tests/test_api_route_validation.py \
             tests/test_api_interpolation_diagnostics.py \
             tests/test_api_resource_controls.py \
+            tests/test_benchmark_registry.py \
             tests/test_api_deployment_hardening.py \
             tests/test_adi_solver_operator_split.py \
             tests/test_regulatory_fail_closed.py \

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -326,7 +326,7 @@ Adapter lifecycle:
 4. Select only explicit validated native policies.
 5. Reject absent coefficients, unsupported BCs or invalid covariance before operator work.
 6. Solve and normalize values, Greeks and diagnostics.
-7. Record package, contract, benchmark and environment identity.
+7. Record package, contract, benchmark-registry and environment identity.
 
 The adapter imports no Haircut domain/application, PDP or delivery modules and advertises only tested capabilities.
 

--- a/docs/BENCHMARK_REGISTRY.md
+++ b/docs/BENCHMARK_REGISTRY.md
@@ -1,0 +1,67 @@
+# Finite-difference benchmark registry
+
+Issue: [googa27/finite_difference_options#49](https://github.com/googa27/finite_difference_options/issues/49)
+Schema: `finite-difference-benchmark-registry/v0`
+Executable source: `src.validation.benchmark_registry`
+Static fixture: `tests/fixtures/fd_benchmark_registry_v1.json`
+
+The registry is the evidence index behind `docs/CAPABILITY_MATRIX.md`. A capability row is not a production claim just because a route can run; it needs a versioned benchmark/evidence ID with explicit model, route, oracle, tolerance, invariants, fixture paths and resource policy.
+
+## Evidence layers
+
+| Layer | Purpose | Example |
+|---|---|---|
+| Analytical oracle | Compare the FD route to a closed-form or independent semi-analytical result. | `BS-CALL-PARITY-V0`, `HESTON-ORACLE-V0` |
+| Manufactured/fixture evidence | Pin expected behavior for a route-specific contract before broader production claims. | `RANNACHER-GAMMA-V0`, `BOUNDARY-MODEL-AWARE-V0` |
+| No-arbitrage invariants | Guard positivity, bounds, Delta/Gamma signs and parity-style properties. | `BS-CALL-PARITY-V0` |
+| Route parity | Assert that a generic/cross-repo contract and a specialized local route agree on semantics. | `QPS-VANILLA-CALL-V0`, `HESTON-BS-LIMIT-V0` |
+| Capability gate | Fail closed for unsupported products, regulatory reports, factors or solver features. | `FACTOR-ROLE-COMPAT-V0`, `REG-FAIL-CLOSED-V0` |
+| Smoke evidence | Prove shape/orientation/finite values only; this is not convergence maturity. | `ADI-SMOKE-V0`, `HESTON-SMOKE-DOCSTRING-V0` |
+
+## Validation policy
+
+`validate_benchmark_registry()` enforces:
+
+- unique versioned benchmark IDs ending in `-Vn`;
+- route/model/instrument/state/grid/time metadata on every case;
+- validated and experimental rows must cite an oracle or fixture;
+- validated rows require tolerance policies;
+- no-arbitrage and route-parity rows must name invariants;
+- all capability-matrix evidence IDs must be represented by registry rows in tests.
+
+Only rows with an explicit runner can execute numerical code through `run_registered_benchmark(...)`. Metadata-only rows fail closed if called directly so no consumer mistakes registry coverage for executed evidence.
+
+## Current executable runner
+
+`BS-CALL-PARITY-V0` executes the public-synthetic Black-Scholes call fixture and verifies:
+
+- convergence against the analytical Black-Scholes oracle;
+- price, Delta and Gamma tolerances;
+- value bound, upper bound, Delta bounds and nonnegative Gamma invariants;
+- deterministic solver evidence with route/backend/config/fixture IDs.
+
+## Registry rows
+
+The static registry fixture currently contains these versioned evidence IDs:
+
+| Benchmark ID | Evidence role |
+|---|---|
+| `BS-CALL-PARITY-V0` | executable Black-Scholes analytical parity, Greeks, convergence and no-arbitrage runner |
+| `QPS-VANILLA-CALL-V0` | executable QuantProblemSpec/static-fixture route-parity runner |
+| `BOUNDARY-MODEL-AWARE-V0` | typed model-aware boundary/reaction gate |
+| `REACTION-INDEPENDENT-V0` | reaction/discount coefficient independence gate |
+| `RANNACHER-GAMMA-V0` | Rannacher startup and kinked-payoff Gamma evidence |
+| `HESTON-SMOKE-DOCSTRING-V0` | Heston ADI smoke/shape/finite-value evidence |
+| `HESTON-ORACLE-V0` | semi-analytical Heston oracle evidence |
+| `HESTON-BS-LIMIT-V0` | executable Heston-to-Black-Scholes limit runner |
+| `HESTON-VARIANCE-BOUNDARY-V0` | Heston variance-boundary diagnostic evidence |
+| `ADI-SMOKE-V0` | ADI finite-value/orientation smoke evidence |
+| `ADI-OPERATOR-SPLIT-V0` | ADI operator split coefficient evidence |
+| `FACTOR-ROLE-COMPAT-V0` | factor-role payoff compatibility fail-closed gate |
+| `DOCS-README-SMOKE-V0` | README/docs smoke and maturity-disclosure evidence |
+| `API-REQUEST-GUARDS-V0` | API request guards and convergence non-claim metadata |
+| `REG-FAIL-CLOSED-V0` | regulatory/reporting endpoint fail-closed gate |
+
+## Successor work
+
+The registry deliberately records several experimental/smoke rows. Closing issue #49 does not graduate ADI/Heston/basket/regulatory routes to production; it makes their evidence status explicit and machine-checkable. Subsequent issues should add executable runners for convergence, stability, American/LCP, Heston ADI parity, and cross-backend route parity before changing maturity in `docs/CAPABILITY_MATRIX.md`.

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -30,6 +30,7 @@ Maintained documentation set:
 - Product requirements: `docs/PRD.md`
 - Architecture and migration map: `docs/ARCHITECTURE.md`
 - Capability matrix: this file
+- Benchmark evidence registry: `docs/BENCHMARK_REGISTRY.md`
 - CI policy: `docs/CI_POLICY.md`
 
 Archived planning material under `docs/planning/` and `docs/archive/` is not a current capability source of truth.

--- a/src/validation/__init__.py
+++ b/src/validation/__init__.py
@@ -2,6 +2,21 @@
 
 This package contains validation functions for the unified pricing framework.
 """
+
+from .benchmark_registry import (
+    BenchmarkCase,
+    BenchmarkRegistryError,
+    BenchmarkRunResult,
+    OracleSpec,
+    TolerancePolicy,
+    default_benchmark_registry,
+    registry_as_dict,
+    registry_by_id,
+    run_registered_benchmark,
+    validate_benchmark_registry,
+    write_benchmark_result_json,
+    write_registry_json,
+)
 from .validators import (
     validate_positive,
     validate_non_negative,
@@ -14,6 +29,18 @@ from .validators import (
 )
 
 __all__ = [
+    "BenchmarkCase",
+    "BenchmarkRegistryError",
+    "BenchmarkRunResult",
+    "OracleSpec",
+    "TolerancePolicy",
+    "default_benchmark_registry",
+    "registry_as_dict",
+    "registry_by_id",
+    "run_registered_benchmark",
+    "validate_benchmark_registry",
+    "write_benchmark_result_json",
+    "write_registry_json",
     "validate_positive",
     "validate_non_negative",
     "validate_probability",

--- a/src/validation/benchmark_registry.py
+++ b/src/validation/benchmark_registry.py
@@ -1,0 +1,924 @@
+"""Executable benchmark registry for finite-difference validation evidence.
+
+The registry is intentionally metadata-first: every public capability claim points to
+versioned evidence with explicit oracle, invariant, tolerance, route and resource
+policy metadata. A small subset of entries also has deterministic runners so CI can
+verify that the registry is not just documentation.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+BenchmarkStatus = Literal["validated", "experimental", "scaffold", "unsupported"]
+BenchmarkFamily = Literal[
+    "analytical_oracle",
+    "manufactured_solution",
+    "no_arbitrage",
+    "route_parity",
+    "capability_gate",
+    "smoke",
+    "regulatory_fail_closed",
+]
+OracleKind = Literal[
+    "analytical", "manufactured", "fixture", "regression", "capability", "none"
+]
+MetricKind = Literal[
+    "price_abs",
+    "price_rel",
+    "delta_abs",
+    "gamma_abs",
+    "convergence_order",
+    "boolean_invariant",
+    "route_parity_abs",
+    "residual_norm",
+]
+
+_VERSIONED_ID_PATTERN = re.compile(r"^[A-Z0-9][A-Z0-9-]+-V\d+$")
+
+
+class BenchmarkRegistryError(ValueError):
+    """Raised when benchmark registry metadata is internally inconsistent."""
+
+    def __init__(self, errors: list[str]) -> None:
+        self.errors = tuple(errors)
+        super().__init__("; ".join(errors))
+
+
+@dataclass(frozen=True)
+class TolerancePolicy:
+    """Named tolerance policy for one benchmark metric."""
+
+    metric: MetricKind
+    threshold: float | bool
+    norm: str
+    notes: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class OracleSpec:
+    """Independent or reference oracle metadata for a benchmark case."""
+
+    kind: OracleKind
+    source: str
+    independence: str
+    notes: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class BenchmarkCase:
+    """One benchmark/evidence registry row."""
+
+    benchmark_id: str
+    title: str
+    family: BenchmarkFamily
+    status: BenchmarkStatus
+    route_id: str
+    model: str
+    instrument: str
+    state_convention: str
+    grid_family: str
+    time_schedule: str
+    oracle: OracleSpec
+    tolerances: tuple[TolerancePolicy, ...]
+    invariants: tuple[str, ...] = ()
+    capability_rows: tuple[str, ...] = ()
+    fixture_paths: tuple[str, ...] = ()
+    issue_refs: tuple[str, ...] = ()
+    resource_policy: dict[str, int | float | str] = field(default_factory=dict)
+    runner: str | None = None
+    notes: str = ""
+
+    def validate(self) -> list[str]:
+        errors: list[str] = []
+        if not _VERSIONED_ID_PATTERN.fullmatch(self.benchmark_id):
+            errors.append(
+                f"benchmark_id is not versioned kebab id: {self.benchmark_id}"
+            )
+        if not self.title.strip():
+            errors.append(f"title required for {self.benchmark_id}")
+        if not self.route_id.strip():
+            errors.append(f"route_id required for {self.benchmark_id}")
+        if not self.model.strip():
+            errors.append(f"model required for {self.benchmark_id}")
+        if not self.instrument.strip():
+            errors.append(f"instrument required for {self.benchmark_id}")
+        if self.status in {"validated", "experimental"} and self.oracle.kind == "none":
+            errors.append(
+                f"{self.benchmark_id} claims {self.status} without an oracle/fixture"
+            )
+        if self.status == "validated" and not self.tolerances:
+            errors.append(
+                f"validated benchmark {self.benchmark_id} requires tolerances"
+            )
+        if self.family in {"no_arbitrage", "route_parity"} and not self.invariants:
+            errors.append(
+                f"{self.family} benchmark {self.benchmark_id} requires invariants"
+            )
+        if (
+            self.status == "validated"
+            and self.family == "route_parity"
+            and self.runner is None
+        ):
+            errors.append(
+                f"validated route-parity benchmark {self.benchmark_id} requires an executable runner"
+            )
+        return errors
+
+    def as_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["oracle"] = self.oracle.as_dict()
+        payload["tolerances"] = [tol.as_dict() for tol in self.tolerances]
+        return payload
+
+
+@dataclass(frozen=True)
+class BenchmarkRunResult:
+    """Normalized result returned by executable benchmark runners."""
+
+    benchmark_id: str
+    passed: bool
+    metrics: dict[str, float | bool | int | str]
+    evidence: dict[str, Any]
+    invariants: dict[str, bool]
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def default_benchmark_registry() -> tuple[BenchmarkCase, ...]:
+    """Return the default versioned FD benchmark registry."""
+
+    bs_oracle = OracleSpec(
+        kind="analytical",
+        source="closed-form Black-Scholes European call",
+        independence="analytic formula independent of the FD grid/operator implementation",
+        notes="Public-synthetic spot=strike=1 case with deterministic convergence table.",
+    )
+    heston_oracle = OracleSpec(
+        kind="regression",
+        source="semi-analytical Heston characteristic-function oracle",
+        independence="separate Fourier integration route under src.validation.heston_oracle",
+        notes="Used for oracle and Black-Scholes-limit smoke evidence; not a calibration maturity claim.",
+    )
+    capability_oracle = OracleSpec(
+        kind="capability",
+        source="DEFAULT_FD_CAPABILITY_MANIFEST fail-closed feature screening",
+        independence="contract-level rejection before solver construction",
+        notes="Unsupported features must be explicit capability rejections, not silent approximation.",
+    )
+    return (
+        BenchmarkCase(
+            benchmark_id="BS-CALL-PARITY-V0",
+            title="Black-Scholes European call analytical parity and no-arbitrage evidence",
+            family="analytical_oracle",
+            status="validated",
+            route_id="fd.black_scholes_1d.crank_nicolson",
+            model="Black-Scholes / GBM",
+            instrument="European call",
+            state_convention="spot S, calendar-time output, forward tau internal march",
+            grid_family="uniform spot grid; uniform time grid",
+            time_schedule="three refinement levels with Crank-Nicolson theta=0.5",
+            oracle=bs_oracle,
+            tolerances=(
+                TolerancePolicy(
+                    "price_abs",
+                    5.0e-4,
+                    "absolute price error",
+                    "finest grid against analytic oracle",
+                ),
+                TolerancePolicy(
+                    "delta_abs",
+                    5.0e-2,
+                    "absolute Delta error",
+                    "central finite-difference Greek",
+                ),
+                TolerancePolicy(
+                    "gamma_abs",
+                    2.0e-2,
+                    "absolute Gamma error",
+                    "central finite-difference Greek",
+                ),
+            ),
+            invariants=(
+                "value_bound_ok",
+                "upper_bound_ok",
+                "delta_lower_bound_ok",
+                "delta_upper_bound_ok",
+                "gamma_non_negative_ok",
+            ),
+            capability_rows=(
+                "1D Black-Scholes European call value on uniform/log-uniform grids",
+                "1D Black-Scholes Delta/Gamma from finite-difference price grids",
+            ),
+            fixture_paths=("tests/fixtures/arxiv_lab_bs_oracle_v1.json",),
+            issue_refs=("googa27/finite_difference_options#49",),
+            resource_policy={
+                "max_s_steps": 120,
+                "max_t_steps": 200,
+                "grid_levels": 3,
+                "deterministic": "true",
+            },
+            runner="black_scholes_parity",
+            notes="Executable CI runner exercises convergence table, Greeks, no-arbitrage checks and evidence payload.",
+        ),
+        BenchmarkCase(
+            benchmark_id="QPS-VANILLA-CALL-V0",
+            title="QuantProblemSpec vanilla call fixture compatibility",
+            family="route_parity",
+            status="validated",
+            route_id="fd.quant_problem_spec.black_scholes_call",
+            model="Black-Scholes / QuantProblemSpec v0",
+            instrument="European call problem contract",
+            state_convention="explicit measure, numeraire, time orientation and typed boundary metadata",
+            grid_family="fixture-declared FD grid",
+            time_schedule="fixture-declared theta controls",
+            oracle=OracleSpec(
+                kind="fixture",
+                source="arXiv-Lab FD oracle fixture export",
+                independence="serialized public-synthetic problem/result contract consumed without private data",
+                notes="Guards cross-repo compatibility rather than a new numerical method.",
+            ),
+            tolerances=(
+                TolerancePolicy(
+                    "price_abs",
+                    5.0e-4,
+                    "absolute price error",
+                    "shared with BS-CALL-PARITY-V0",
+                ),
+            ),
+            invariants=(
+                "schema_version",
+                "problem_hash",
+                "typed_boundary",
+                "calendar_time_orientation",
+            ),
+            capability_rows=(
+                "1D Black-Scholes European call value on uniform/log-uniform grids",
+            ),
+            fixture_paths=("tests/fixtures/arxiv_lab_bs_oracle_v1.json",),
+            issue_refs=(
+                "googa27/finite_difference_options#49",
+                "googa27/finite_difference_options#59",
+            ),
+            resource_policy={"public_synthetic": "true"},
+            runner="black_scholes_qps_contract",
+            notes=(
+                "Metadata registry row for cross-repo fixture parity; execution is covered by "
+                "BS-CALL-PARITY-V0 tests."
+            ),
+        ),
+        BenchmarkCase(
+            benchmark_id="BOUNDARY-MODEL-AWARE-V0",
+            title="Model-aware vanilla boundary and reaction semantics",
+            family="capability_gate",
+            status="validated",
+            route_id="fd.boundary_conditions.model_aware_vanilla",
+            model="Black-Scholes / GBM boundary algebra",
+            instrument="European call/put boundary facets",
+            state_convention="spot boundary facets with explicit strike, rate/carry and time-to-maturity",
+            grid_family="boundary-facet contract independent of grid density",
+            time_schedule="time-to-maturity-aware boundary values",
+            oracle=OracleSpec(
+                kind="fixture",
+                source="boundary condition and model-aware reaction regression tests",
+                independence="boundary builder tests assert explicit typed facets before solver use",
+                notes="Prevents route maturity claims from relying on option_type guessing.",
+            ),
+            tolerances=(
+                TolerancePolicy(
+                    "boolean_invariant",
+                    True,
+                    "all invariants",
+                    "typed boundary/reaction checks pass",
+                ),
+            ),
+            invariants=(
+                "dirichlet_call_zero",
+                "far_call_asymptotic",
+                "explicit_zero_discount_preserved",
+            ),
+            capability_rows=("1D vanilla boundary/reaction semantics",),
+            fixture_paths=(
+                "tests/test_boundary_conditions.py",
+                "tests/test_model_aware_reaction_terms.py",
+            ),
+            issue_refs=(
+                "googa27/finite_difference_options#48",
+                "googa27/finite_difference_options#49",
+            ),
+            resource_policy={"deterministic": "true"},
+        ),
+        BenchmarkCase(
+            benchmark_id="REACTION-INDEPENDENT-V0",
+            title="Reaction/discount coefficient can be supplied independently from drift",
+            family="capability_gate",
+            status="validated",
+            route_id="fd.coefficients.model_aware_reaction",
+            model="GBM / affine process coefficient extraction",
+            instrument="generic model-aware PDE coefficients",
+            state_convention="drift, covariance and reaction are separate coefficient fields",
+            grid_family="grid-independent coefficient extraction",
+            time_schedule="terminal-time process coefficient calls",
+            oracle=OracleSpec(
+                kind="fixture",
+                source="model-aware reaction regression tests",
+                independence="direct coefficient-path tests independent of pricing output",
+                notes="Avoids conflating real-world drift with risk-neutral discount reaction.",
+            ),
+            tolerances=(
+                TolerancePolicy(
+                    "boolean_invariant",
+                    True,
+                    "all invariants",
+                    "reaction pass-through checks pass",
+                ),
+            ),
+            invariants=(
+                "reaction_not_inferred_from_mu",
+                "explicit_zero_discount_preserved",
+            ),
+            capability_rows=("1D vanilla boundary/reaction semantics",),
+            fixture_paths=("tests/test_model_aware_reaction_terms.py",),
+            issue_refs=(
+                "googa27/finite_difference_options#48",
+                "googa27/finite_difference_options#49",
+            ),
+            resource_policy={"deterministic": "true"},
+        ),
+        BenchmarkCase(
+            benchmark_id="RANNACHER-GAMMA-V0",
+            title="Rannacher startup protects kinked-payoff Gamma evidence",
+            family="manufactured_solution",
+            status="validated",
+            route_id="fd.black_scholes_1d.rannacher_crank_nicolson",
+            model="Black-Scholes / GBM",
+            instrument="European vanilla payoff with strike kink",
+            state_convention="spot grid around strike with explicit startup schedule",
+            grid_family="1D finite-difference grid",
+            time_schedule="two/four Backward-Euler half-step startup before Crank-Nicolson",
+            oracle=OracleSpec(
+                kind="regression",
+                source="Rannacher Gamma regression tests",
+                independence="compares declared startup schedules against unsmoothed route behavior",
+                notes="Regression evidence for smoothing policy, not a universal Greek guarantee.",
+            ),
+            tolerances=(
+                TolerancePolicy(
+                    "boolean_invariant",
+                    True,
+                    "all invariants",
+                    "startup schedule and Gamma sanity checks pass",
+                ),
+            ),
+            invariants=("startup_schedule_recorded", "gamma_kink_sanity"),
+            capability_rows=(
+                "Rannacher startup before Crank-Nicolson for kinked payoffs",
+            ),
+            fixture_paths=("tests/test_rannacher_startup.py",),
+            issue_refs=("googa27/finite_difference_options#49",),
+            resource_policy={"deterministic": "true"},
+        ),
+        BenchmarkCase(
+            benchmark_id="HESTON-SMOKE-DOCSTRING-V0",
+            title="Heston vanilla-call smoke route shape and finite-value evidence",
+            family="smoke",
+            status="experimental",
+            route_id="fd.heston.adi_smoke",
+            model="Heston stochastic volatility",
+            instrument="European call smoke fixture",
+            state_convention="log-spot and variance state convention with declared exp factor transform",
+            grid_family="2D tensor grid smoke fixture",
+            time_schedule="ADI/Douglas smoke route calendar-output orientation",
+            oracle=OracleSpec(
+                kind="fixture",
+                source="Heston state/oracle smoke tests and capability matrix docstring evidence",
+                independence="shape/finite-value route test separate from semi-analytical oracle maturity claim",
+                notes="Experimental smoke evidence only; convergence and production calibration remain unsupported.",
+            ),
+            tolerances=(
+                TolerancePolicy(
+                    "boolean_invariant",
+                    True,
+                    "all invariants",
+                    "finite shape/no-NaN Heston smoke checks pass",
+                ),
+            ),
+            invariants=(
+                "finite_values",
+                "log_spot_factor_transform",
+                "variance_state_not_payoff_asset",
+            ),
+            capability_rows=("Heston stochastic volatility vanilla call smoke route",),
+            fixture_paths=("tests/test_heston_state_oracle.py",),
+            issue_refs=("googa27/finite_difference_options#49",),
+            resource_policy={"deterministic": "true"},
+        ),
+        BenchmarkCase(
+            benchmark_id="HESTON-ORACLE-V0",
+            title="Heston semi-analytical European call oracle",
+            family="analytical_oracle",
+            status="validated",
+            route_id="fd.validation.heston_oracle",
+            model="Heston stochastic volatility",
+            instrument="European call",
+            state_convention="log-spot and variance state convention",
+            grid_family="not an FD grid; Fourier oracle reference",
+            time_schedule="single maturity reference integration",
+            oracle=heston_oracle,
+            tolerances=(
+                TolerancePolicy(
+                    "price_abs",
+                    2.0e-3,
+                    "absolute price error",
+                    "oracle regression tolerance",
+                ),
+            ),
+            invariants=(
+                "positive_price",
+                "finite_integral",
+                "variance_boundary_diagnostics",
+            ),
+            capability_rows=(
+                "Heston semi-analytical European call oracle",
+                "Heston stochastic volatility vanilla call smoke route",
+            ),
+            fixture_paths=("src/validation/heston_oracle.py",),
+            issue_refs=("googa27/finite_difference_options#49",),
+            resource_policy={"deterministic": "true"},
+        ),
+        BenchmarkCase(
+            benchmark_id="HESTON-BS-LIMIT-V0",
+            title="Heston zero vol-of-vol Black-Scholes limiting case",
+            family="route_parity",
+            status="validated",
+            route_id="fd.validation.heston_black_scholes_limit",
+            model="Heston -> Black-Scholes limit",
+            instrument="European call",
+            state_convention="variance fixed at sigma^2 when vol-of-vol tends to zero",
+            grid_family="oracle parity, not production FD route",
+            time_schedule="single maturity reference comparison",
+            oracle=heston_oracle,
+            tolerances=(
+                TolerancePolicy(
+                    "price_abs",
+                    2.0e-3,
+                    "absolute price error",
+                    "against Black-Scholes oracle",
+                ),
+            ),
+            invariants=("limit_price_matches_black_scholes",),
+            capability_rows=("Heston semi-analytical European call oracle",),
+            fixture_paths=("src/validation/heston_oracle.py",),
+            issue_refs=("googa27/finite_difference_options#49",),
+            resource_policy={"deterministic": "true"},
+            runner="heston_black_scholes_limit",
+        ),
+        BenchmarkCase(
+            benchmark_id="HESTON-VARIANCE-BOUNDARY-V0",
+            title="Heston variance-boundary diagnostics",
+            family="capability_gate",
+            status="validated",
+            route_id="fd.heston.variance_boundary_diagnostics",
+            model="Heston stochastic volatility",
+            instrument="European call smoke route",
+            state_convention="variance boundary has explicit lower/upper diagnostics",
+            grid_family="variance grid diagnostics",
+            time_schedule="single smoke solve diagnostics",
+            oracle=heston_oracle,
+            tolerances=(
+                TolerancePolicy(
+                    "boolean_invariant",
+                    True,
+                    "all invariants",
+                    "variance boundary diagnostics present",
+                ),
+            ),
+            invariants=("variance_nonnegative", "boundary_diagnostics_recorded"),
+            capability_rows=("Heston semi-analytical European call oracle",),
+            fixture_paths=("src/validation/heston_oracle.py",),
+            issue_refs=("googa27/finite_difference_options#49",),
+            resource_policy={"deterministic": "true"},
+        ),
+        BenchmarkCase(
+            benchmark_id="ADI-SMOKE-V0",
+            title="ADI multidimensional finite-value smoke route",
+            family="smoke",
+            status="experimental",
+            route_id="fd.adi.douglas_smoke",
+            model="generic multidimensional parabolic PDE",
+            instrument="vanilla/basket smoke fixtures",
+            state_convention="tensor-product state grid with explicit covariance convention",
+            grid_family="2D/3D tensor grids",
+            time_schedule="Douglas ADI calendar-output orientation",
+            oracle=OracleSpec(
+                kind="fixture",
+                source="ADI smoke and operator split regression tests",
+                independence="regression tests cover operator splitting components before production claim",
+                notes="Smoke evidence only; convergence issue remains open.",
+            ),
+            tolerances=(
+                TolerancePolicy(
+                    "boolean_invariant",
+                    True,
+                    "all invariants",
+                    "finite shape/no-NaN smoke checks pass",
+                ),
+            ),
+            invariants=(
+                "finite_values",
+                "calendar_output_orientation",
+                "shape_consistency",
+            ),
+            capability_rows=("ADI multidimensional routes",),
+            fixture_paths=("tests/test_adi_solver_operator_split.py",),
+            issue_refs=(
+                "googa27/finite_difference_options#49",
+                "googa27/finite_difference_options#58",
+            ),
+            resource_policy={"deterministic": "true"},
+        ),
+        BenchmarkCase(
+            benchmark_id="ADI-OPERATOR-SPLIT-V0",
+            title="ADI operator split coefficient/regression evidence",
+            family="route_parity",
+            status="experimental",
+            route_id="fd.adi.operator_split_contract",
+            model="generic multidimensional parabolic PDE",
+            instrument="operator-level fixture",
+            state_convention="diagonal diffusion, off-diagonal mixed derivative, reaction and source terms explicit",
+            grid_family="2D/3D tensor grids",
+            time_schedule="operator construction before time march",
+            oracle=OracleSpec(
+                kind="fixture",
+                source="ADI operator split regression tests",
+                independence="operator assembly tested separately from high-level pricing route",
+                notes="Supports route maturity disclosure; not yet convergence evidence.",
+            ),
+            tolerances=(
+                TolerancePolicy(
+                    "boolean_invariant",
+                    True,
+                    "all invariants",
+                    "split terms match expected coefficients",
+                ),
+            ),
+            invariants=(
+                "mixed_derivative_sign",
+                "reaction_preserved",
+                "source_preserved",
+            ),
+            capability_rows=("ADI multidimensional routes",),
+            fixture_paths=("tests/test_adi_solver_operator_split.py",),
+            issue_refs=(
+                "googa27/finite_difference_options#49",
+                "googa27/finite_difference_options#58",
+            ),
+            resource_policy={"deterministic": "true"},
+        ),
+        BenchmarkCase(
+            benchmark_id="FACTOR-ROLE-COMPAT-V0",
+            title="Factor-role payoff compatibility fail-closed gate",
+            family="capability_gate",
+            status="validated",
+            route_id="fd.payoff.factor_role_compatibility",
+            model="basket/spread payoff role screening",
+            instrument="basket, spread and factor payoffs",
+            state_convention="tradable spot factors must be explicitly distinguished from variance/vol/rate factors",
+            grid_family="route-screening metadata, not a numerical grid",
+            time_schedule="pre-solve compatibility gate",
+            oracle=capability_oracle,
+            tolerances=(
+                TolerancePolicy(
+                    "boolean_invariant",
+                    True,
+                    "all invariants",
+                    "unsupported factor/payoff pairs fail closed",
+                ),
+            ),
+            invariants=(
+                "heston_variance_not_basket_asset",
+                "sabr_vol_not_basket_asset",
+                "asset_id_mapping_required",
+            ),
+            capability_rows=("basket option payoff on true multi-asset factors",),
+            fixture_paths=("tests/test_factor_role_payoff_compatibility.py",),
+            issue_refs=("googa27/finite_difference_options#49",),
+            resource_policy={"deterministic": "true"},
+        ),
+        BenchmarkCase(
+            benchmark_id="DOCS-README-SMOKE-V0",
+            title="README and documentation smoke examples stay aligned with supported routes",
+            family="smoke",
+            status="experimental",
+            route_id="fd.docs.readme_smoke",
+            model="documentation/examples",
+            instrument="public README/API examples",
+            state_convention="examples must disclose capability maturity and synthetic inputs",
+            grid_family="example-declared grids only",
+            time_schedule="example-declared time controls only",
+            oracle=OracleSpec(
+                kind="fixture",
+                source="documentation smoke tests and capability matrix gating",
+                independence="docs examples are exercised separately from numerical core validation",
+                notes="Convenience-surface evidence; numerical truth remains in core benchmark rows.",
+            ),
+            tolerances=(
+                TolerancePolicy(
+                    "boolean_invariant",
+                    True,
+                    "all invariants",
+                    "README/docs examples execute without unsupported maturity claims",
+                ),
+            ),
+            invariants=(
+                "examples_execute",
+                "maturity_disclosed",
+                "public_synthetic_inputs",
+            ),
+            capability_rows=("FastAPI/CLI/UI service contracts",),
+            fixture_paths=("tests/test_documentation_capabilities.py",),
+            issue_refs=("googa27/finite_difference_options#49",),
+            resource_policy={"deterministic": "true"},
+        ),
+        BenchmarkCase(
+            benchmark_id="API-REQUEST-GUARDS-V0",
+            title="API request guards and explicit non-claim convergence metadata",
+            family="capability_gate",
+            status="experimental",
+            route_id="fd.api.request_guards",
+            model="FastAPI/CLI adapter schemas",
+            instrument="pricing request/response contracts",
+            state_convention="outer adapters over numerical core with explicit route maturity",
+            grid_family="bounded request grids only",
+            time_schedule="request-declared maturity/time controls",
+            oracle=OracleSpec(
+                kind="fixture",
+                source="API schema and request-guard tests",
+                independence="adapter contract tests exercise bounded inputs before solver dispatch",
+                notes="API evidence does not promote experimental numerical routes to validated status.",
+            ),
+            tolerances=(
+                TolerancePolicy(
+                    "boolean_invariant",
+                    True,
+                    "all invariants",
+                    "invalid requests fail closed and responses disclose convergence status",
+                ),
+            ),
+            invariants=(
+                "bounded_grid_nodes",
+                "invalid_payoff_rejected",
+                "convergence_not_assessed_disclosed",
+            ),
+            capability_rows=("FastAPI/CLI/UI service contracts",),
+            fixture_paths=("tests/test_api_schema_contracts.py",),
+            issue_refs=("googa27/finite_difference_options#49",),
+            resource_policy={"deterministic": "true"},
+        ),
+        BenchmarkCase(
+            benchmark_id="REG-FAIL-CLOSED-V0",
+            title="Regulatory endpoint fail-closed standard/version gate",
+            family="regulatory_fail_closed",
+            status="scaffold",
+            route_id="fd.regulatory.fail_closed",
+            model="regulatory reporting scaffold",
+            instrument="CRIF/CUSO/Basel/FRTB endpoints",
+            state_convention="standard/profile/version/effective-date/jurisdiction required before implementation",
+            grid_family="not applicable",
+            time_schedule="not applicable",
+            oracle=capability_oracle,
+            tolerances=(),
+            invariants=(
+                "http_501_for_unsupported_standard",
+                "no_placeholder_report_values",
+            ),
+            capability_rows=("CRIF/CUSO/Basel/FRTB regulatory report endpoints",),
+            fixture_paths=("tests/test_regulatory_fail_closed.py",),
+            issue_refs=("googa27/finite_difference_options#49",),
+            resource_policy={"deterministic": "true"},
+        ),
+    )
+
+
+def registry_by_id(
+    registry: tuple[BenchmarkCase, ...] | None = None
+) -> dict[str, BenchmarkCase]:
+    """Return registry rows keyed by benchmark id."""
+
+    rows = registry if registry is not None else default_benchmark_registry()
+    return {case.benchmark_id: case for case in rows}
+
+
+def validate_benchmark_registry(
+    registry: tuple[BenchmarkCase, ...] | None = None
+) -> tuple[BenchmarkCase, ...]:
+    """Validate registry invariants and return the rows if valid."""
+
+    rows = registry if registry is not None else default_benchmark_registry()
+    errors: list[str] = []
+    seen: set[str] = set()
+    for case in rows:
+        if case.benchmark_id in seen:
+            errors.append(f"duplicate benchmark_id: {case.benchmark_id}")
+        seen.add(case.benchmark_id)
+        errors.extend(case.validate())
+    if errors:
+        raise BenchmarkRegistryError(errors)
+    return rows
+
+
+def registry_as_dict(
+    registry: tuple[BenchmarkCase, ...] | None = None
+) -> dict[str, Any]:
+    """Return a JSON-friendly registry payload."""
+
+    rows = validate_benchmark_registry(registry)
+    return {
+        "schema_version": "finite-difference-benchmark-registry/v0",
+        "registry_id": "finite_difference_options.benchmark_registry.v0",
+        "issue_ref": "googa27/finite_difference_options#49",
+        "case_count": len(rows),
+        "cases": [case.as_dict() for case in rows],
+    }
+
+
+def write_registry_json(
+    path: str | Path, registry: tuple[BenchmarkCase, ...] | None = None
+) -> None:
+    """Write the registry JSON payload with stable ordering and indentation."""
+
+    import json
+
+    payload = registry_as_dict(registry)
+    Path(path).write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def write_benchmark_result_json(path: str | Path, result: BenchmarkRunResult) -> None:
+    """Persist one benchmark run result for CI/artifact triage."""
+
+    import json
+
+    Path(path).write_text(
+        json.dumps(result.as_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def _black_scholes_parity_result(case: BenchmarkCase) -> BenchmarkRunResult:
+    from src.validation.black_scholes_parity import (
+        run_public_black_scholes_parity_fixture,
+    )
+
+    report = run_public_black_scholes_parity_fixture()
+    invariants = {
+        name: bool(report.no_arbitrage[name])
+        for name in case.invariants
+        if name in report.no_arbitrage
+    }
+    passed = report.converged and all(invariants.values())
+    return BenchmarkRunResult(
+        benchmark_id=case.benchmark_id,
+        passed=passed,
+        metrics={
+            "price": report.price,
+            "oracle_price": report.oracle_price,
+            "price_abs": report.final_abs_error,
+            "delta_abs": report.errors["delta_abs"],
+            "gamma_abs": report.errors["gamma_abs"],
+            "grid_levels": len(report.convergence_table()),
+        },
+        evidence=report.evidence.as_dict(),
+        invariants=invariants,
+    )
+
+
+def _black_scholes_qps_contract_result(case: BenchmarkCase) -> BenchmarkRunResult:
+    from src.validation.black_scholes_parity import (
+        run_public_black_scholes_parity_fixture,
+    )
+
+    report = run_public_black_scholes_parity_fixture()
+    payload = report.as_dict()
+    problem = payload["problem_spec"]
+    result = payload["result_export"]
+    typed_boundary = result["boundary"]["typed"]
+    invariants = {
+        "schema_version": problem["schema_version"] == "quant-problem-spec/v0",
+        "problem_hash": bool(problem["problem_hash"]),
+        "typed_boundary": all("boundary_type" in item for item in typed_boundary),
+        "calendar_time_orientation": result["time_axis"]["direction"] == "decreasing",
+    }
+    passed = report.converged and all(invariants.values())
+    return BenchmarkRunResult(
+        benchmark_id=case.benchmark_id,
+        passed=passed,
+        metrics={
+            "price_abs": report.final_abs_error,
+            "grid_levels": len(report.convergence_table()),
+            "typed_boundary_count": len(typed_boundary),
+        },
+        evidence=report.evidence.as_dict(),
+        invariants=invariants,
+    )
+
+
+def _heston_black_scholes_limit_result(case: BenchmarkCase) -> BenchmarkRunResult:
+    from math import sqrt
+
+    from src.validation.black_scholes_parity import black_scholes_call_oracle
+    from src.validation.heston_oracle import HestonOracleCase, heston_call_oracle
+
+    heston_case = HestonOracleCase(
+        spot=100.0,
+        strike=100.0,
+        rate=0.03,
+        dividend_yield=0.0,
+        maturity=1.0,
+        variance=0.04,
+        kappa=3.0,
+        theta=0.04,
+        vol_of_vol=1e-4,
+        rho=-0.4,
+    )
+    heston_price = heston_call_oracle(heston_case)
+    black_scholes_price = black_scholes_call_oracle(
+        spot=heston_case.spot,
+        strike=heston_case.strike,
+        rate=heston_case.rate,
+        sigma=sqrt(heston_case.theta),
+        maturity=heston_case.maturity,
+    )
+    price_abs = abs(heston_price - black_scholes_price)
+    threshold = float(case.tolerances[0].threshold)
+    invariants = {"limit_price_matches_black_scholes": price_abs <= threshold}
+    return BenchmarkRunResult(
+        benchmark_id=case.benchmark_id,
+        passed=all(invariants.values()),
+        metrics={
+            "heston_price": heston_price,
+            "black_scholes_price": black_scholes_price,
+            "price_abs": price_abs,
+            "threshold": threshold,
+        },
+        evidence={
+            "route_id": case.route_id,
+            "oracle": case.oracle.source,
+            "deterministic": True,
+        },
+        invariants=invariants,
+    )
+
+
+def run_registered_benchmark(
+    benchmark_id: str, *, artifact_path: str | Path | None = None
+) -> BenchmarkRunResult:
+    """Run an executable benchmark by id.
+
+    Only benchmark rows with a registered deterministic runner execute numerical
+    code. Metadata-only rows fail closed so callers cannot mistake registry
+    coverage for executed evidence. When ``artifact_path`` is supplied, the
+    normalized result is persisted even when ``passed`` is false.
+    """
+
+    case = registry_by_id()[benchmark_id]
+    if case.runner == "black_scholes_parity":
+        result = _black_scholes_parity_result(case)
+    elif case.runner == "black_scholes_qps_contract":
+        result = _black_scholes_qps_contract_result(case)
+    elif case.runner == "heston_black_scholes_limit":
+        result = _heston_black_scholes_limit_result(case)
+    else:
+        raise BenchmarkRegistryError(
+            [f"benchmark {benchmark_id} has no executable runner"]
+        )
+
+    if artifact_path is not None:
+        write_benchmark_result_json(artifact_path, result)
+    return result
+
+
+__all__ = [
+    "BenchmarkCase",
+    "BenchmarkRegistryError",
+    "BenchmarkRunResult",
+    "OracleSpec",
+    "TolerancePolicy",
+    "default_benchmark_registry",
+    "registry_as_dict",
+    "registry_by_id",
+    "run_registered_benchmark",
+    "validate_benchmark_registry",
+    "write_benchmark_result_json",
+    "write_registry_json",
+]

--- a/src/validation/benchmark_registry.py
+++ b/src/validation/benchmark_registry.py
@@ -775,6 +775,14 @@ def write_benchmark_result_json(path: str | Path, result: BenchmarkRunResult) ->
     )
 
 
+def _reported_invariants(
+    names: tuple[str, ...], reported: dict[str, Any]
+) -> dict[str, bool]:
+    """Evaluate declared invariants fail-closed against a reported payload."""
+
+    return {name: bool(reported.get(name, False)) for name in names}
+
+
 def _tolerance_invariants(
     case: BenchmarkCase, metrics: dict[str, float | bool | int | str]
 ) -> dict[str, bool]:
@@ -805,11 +813,7 @@ def _black_scholes_parity_result(case: BenchmarkCase) -> BenchmarkRunResult:
         "gamma_abs": report.errors["gamma_abs"],
         "grid_levels": len(report.convergence_table()),
     }
-    invariants = {
-        name: bool(report.no_arbitrage[name])
-        for name in case.invariants
-        if name in report.no_arbitrage
-    }
+    invariants = _reported_invariants(case.invariants, report.no_arbitrage)
     invariants.update(_tolerance_invariants(case, metrics))
     passed = all(invariants.values())
     return BenchmarkRunResult(
@@ -831,21 +835,23 @@ def _black_scholes_qps_contract_result(case: BenchmarkCase) -> BenchmarkRunResul
     problem = payload["problem_spec"]
     result = payload["result_export"]
     typed_boundary = result["boundary"]["typed"]
+    metrics: dict[str, float | bool | int | str] = {
+        "price_abs": report.final_abs_error,
+        "grid_levels": len(report.convergence_table()),
+        "typed_boundary_count": len(typed_boundary),
+    }
     invariants = {
         "schema_version": problem["schema_version"] == "quant-problem-spec/v0",
         "problem_hash": bool(problem["problem_hash"]),
         "typed_boundary": all("boundary_type" in item for item in typed_boundary),
         "calendar_time_orientation": result["time_axis"]["direction"] == "decreasing",
     }
-    passed = report.converged and all(invariants.values())
+    invariants.update(_tolerance_invariants(case, metrics))
+    passed = all(invariants.values())
     return BenchmarkRunResult(
         benchmark_id=case.benchmark_id,
         passed=passed,
-        metrics={
-            "price_abs": report.final_abs_error,
-            "grid_levels": len(report.convergence_table()),
-            "typed_boundary_count": len(typed_boundary),
-        },
+        metrics=metrics,
         evidence=report.evidence.as_dict(),
         invariants=invariants,
     )

--- a/src/validation/benchmark_registry.py
+++ b/src/validation/benchmark_registry.py
@@ -775,29 +775,47 @@ def write_benchmark_result_json(path: str | Path, result: BenchmarkRunResult) ->
     )
 
 
+def _tolerance_invariants(
+    case: BenchmarkCase, metrics: dict[str, float | bool | int | str]
+) -> dict[str, bool]:
+    """Evaluate every declared benchmark tolerance against produced metrics."""
+
+    results: dict[str, bool] = {}
+    for tolerance in case.tolerances:
+        key = f"{tolerance.metric}_tolerance_ok"
+        observed = metrics.get(tolerance.metric)
+        if not isinstance(observed, int | float):
+            results[key] = False
+            continue
+        results[key] = float(observed) <= tolerance.threshold
+    return results
+
+
 def _black_scholes_parity_result(case: BenchmarkCase) -> BenchmarkRunResult:
     from src.validation.black_scholes_parity import (
         run_public_black_scholes_parity_fixture,
     )
 
     report = run_public_black_scholes_parity_fixture()
+    metrics: dict[str, float | bool | int | str] = {
+        "price": report.price,
+        "oracle_price": report.oracle_price,
+        "price_abs": report.final_abs_error,
+        "delta_abs": report.errors["delta_abs"],
+        "gamma_abs": report.errors["gamma_abs"],
+        "grid_levels": len(report.convergence_table()),
+    }
     invariants = {
         name: bool(report.no_arbitrage[name])
         for name in case.invariants
         if name in report.no_arbitrage
     }
-    passed = report.converged and all(invariants.values())
+    invariants.update(_tolerance_invariants(case, metrics))
+    passed = all(invariants.values())
     return BenchmarkRunResult(
         benchmark_id=case.benchmark_id,
         passed=passed,
-        metrics={
-            "price": report.price,
-            "oracle_price": report.oracle_price,
-            "price_abs": report.final_abs_error,
-            "delta_abs": report.errors["delta_abs"],
-            "gamma_abs": report.errors["gamma_abs"],
-            "grid_levels": len(report.convergence_table()),
-        },
+        metrics=metrics,
         evidence=report.evidence.as_dict(),
         invariants=invariants,
     )

--- a/tests/fixtures/fd_benchmark_registry_v1.json
+++ b/tests/fixtures/fd_benchmark_registry_v1.json
@@ -1,0 +1,696 @@
+{
+  "case_count": 15,
+  "cases": [
+    {
+      "benchmark_id": "BS-CALL-PARITY-V0",
+      "capability_rows": [
+        "1D Black-Scholes European call value on uniform/log-uniform grids",
+        "1D Black-Scholes Delta/Gamma from finite-difference price grids"
+      ],
+      "family": "analytical_oracle",
+      "fixture_paths": [
+        "tests/fixtures/arxiv_lab_bs_oracle_v1.json"
+      ],
+      "grid_family": "uniform spot grid; uniform time grid",
+      "instrument": "European call",
+      "invariants": [
+        "value_bound_ok",
+        "upper_bound_ok",
+        "delta_lower_bound_ok",
+        "delta_upper_bound_ok",
+        "gamma_non_negative_ok"
+      ],
+      "issue_refs": [
+        "googa27/finite_difference_options#49"
+      ],
+      "model": "Black-Scholes / GBM",
+      "notes": "Executable CI runner exercises convergence table, Greeks, no-arbitrage checks and evidence payload.",
+      "oracle": {
+        "independence": "analytic formula independent of the FD grid/operator implementation",
+        "kind": "analytical",
+        "notes": "Public-synthetic spot=strike=1 case with deterministic convergence table.",
+        "source": "closed-form Black-Scholes European call"
+      },
+      "resource_policy": {
+        "deterministic": "true",
+        "grid_levels": 3,
+        "max_s_steps": 120,
+        "max_t_steps": 200
+      },
+      "route_id": "fd.black_scholes_1d.crank_nicolson",
+      "runner": "black_scholes_parity",
+      "state_convention": "spot S, calendar-time output, forward tau internal march",
+      "status": "validated",
+      "time_schedule": "three refinement levels with Crank-Nicolson theta=0.5",
+      "title": "Black-Scholes European call analytical parity and no-arbitrage evidence",
+      "tolerances": [
+        {
+          "metric": "price_abs",
+          "norm": "absolute price error",
+          "notes": "finest grid against analytic oracle",
+          "threshold": 0.0005
+        },
+        {
+          "metric": "delta_abs",
+          "norm": "absolute Delta error",
+          "notes": "central finite-difference Greek",
+          "threshold": 0.05
+        },
+        {
+          "metric": "gamma_abs",
+          "norm": "absolute Gamma error",
+          "notes": "central finite-difference Greek",
+          "threshold": 0.02
+        }
+      ]
+    },
+    {
+      "benchmark_id": "QPS-VANILLA-CALL-V0",
+      "capability_rows": [
+        "1D Black-Scholes European call value on uniform/log-uniform grids"
+      ],
+      "family": "route_parity",
+      "fixture_paths": [
+        "tests/fixtures/arxiv_lab_bs_oracle_v1.json"
+      ],
+      "grid_family": "fixture-declared FD grid",
+      "instrument": "European call problem contract",
+      "invariants": [
+        "schema_version",
+        "problem_hash",
+        "typed_boundary",
+        "calendar_time_orientation"
+      ],
+      "issue_refs": [
+        "googa27/finite_difference_options#49",
+        "googa27/finite_difference_options#59"
+      ],
+      "model": "Black-Scholes / QuantProblemSpec v0",
+      "notes": "Metadata registry row for cross-repo fixture parity; execution is covered by BS-CALL-PARITY-V0 tests.",
+      "oracle": {
+        "independence": "serialized public-synthetic problem/result contract consumed without private data",
+        "kind": "fixture",
+        "notes": "Guards cross-repo compatibility rather than a new numerical method.",
+        "source": "arXiv-Lab FD oracle fixture export"
+      },
+      "resource_policy": {
+        "public_synthetic": "true"
+      },
+      "route_id": "fd.quant_problem_spec.black_scholes_call",
+      "runner": "black_scholes_qps_contract",
+      "state_convention": "explicit measure, numeraire, time orientation and typed boundary metadata",
+      "status": "validated",
+      "time_schedule": "fixture-declared theta controls",
+      "title": "QuantProblemSpec vanilla call fixture compatibility",
+      "tolerances": [
+        {
+          "metric": "price_abs",
+          "norm": "absolute price error",
+          "notes": "shared with BS-CALL-PARITY-V0",
+          "threshold": 0.0005
+        }
+      ]
+    },
+    {
+      "benchmark_id": "BOUNDARY-MODEL-AWARE-V0",
+      "capability_rows": [
+        "1D vanilla boundary/reaction semantics"
+      ],
+      "family": "capability_gate",
+      "fixture_paths": [
+        "tests/test_boundary_conditions.py",
+        "tests/test_model_aware_reaction_terms.py"
+      ],
+      "grid_family": "boundary-facet contract independent of grid density",
+      "instrument": "European call/put boundary facets",
+      "invariants": [
+        "dirichlet_call_zero",
+        "far_call_asymptotic",
+        "explicit_zero_discount_preserved"
+      ],
+      "issue_refs": [
+        "googa27/finite_difference_options#48",
+        "googa27/finite_difference_options#49"
+      ],
+      "model": "Black-Scholes / GBM boundary algebra",
+      "notes": "",
+      "oracle": {
+        "independence": "boundary builder tests assert explicit typed facets before solver use",
+        "kind": "fixture",
+        "notes": "Prevents route maturity claims from relying on option_type guessing.",
+        "source": "boundary condition and model-aware reaction regression tests"
+      },
+      "resource_policy": {
+        "deterministic": "true"
+      },
+      "route_id": "fd.boundary_conditions.model_aware_vanilla",
+      "runner": null,
+      "state_convention": "spot boundary facets with explicit strike, rate/carry and time-to-maturity",
+      "status": "validated",
+      "time_schedule": "time-to-maturity-aware boundary values",
+      "title": "Model-aware vanilla boundary and reaction semantics",
+      "tolerances": [
+        {
+          "metric": "boolean_invariant",
+          "norm": "all invariants",
+          "notes": "typed boundary/reaction checks pass",
+          "threshold": true
+        }
+      ]
+    },
+    {
+      "benchmark_id": "REACTION-INDEPENDENT-V0",
+      "capability_rows": [
+        "1D vanilla boundary/reaction semantics"
+      ],
+      "family": "capability_gate",
+      "fixture_paths": [
+        "tests/test_model_aware_reaction_terms.py"
+      ],
+      "grid_family": "grid-independent coefficient extraction",
+      "instrument": "generic model-aware PDE coefficients",
+      "invariants": [
+        "reaction_not_inferred_from_mu",
+        "explicit_zero_discount_preserved"
+      ],
+      "issue_refs": [
+        "googa27/finite_difference_options#48",
+        "googa27/finite_difference_options#49"
+      ],
+      "model": "GBM / affine process coefficient extraction",
+      "notes": "",
+      "oracle": {
+        "independence": "direct coefficient-path tests independent of pricing output",
+        "kind": "fixture",
+        "notes": "Avoids conflating real-world drift with risk-neutral discount reaction.",
+        "source": "model-aware reaction regression tests"
+      },
+      "resource_policy": {
+        "deterministic": "true"
+      },
+      "route_id": "fd.coefficients.model_aware_reaction",
+      "runner": null,
+      "state_convention": "drift, covariance and reaction are separate coefficient fields",
+      "status": "validated",
+      "time_schedule": "terminal-time process coefficient calls",
+      "title": "Reaction/discount coefficient can be supplied independently from drift",
+      "tolerances": [
+        {
+          "metric": "boolean_invariant",
+          "norm": "all invariants",
+          "notes": "reaction pass-through checks pass",
+          "threshold": true
+        }
+      ]
+    },
+    {
+      "benchmark_id": "RANNACHER-GAMMA-V0",
+      "capability_rows": [
+        "Rannacher startup before Crank-Nicolson for kinked payoffs"
+      ],
+      "family": "manufactured_solution",
+      "fixture_paths": [
+        "tests/test_rannacher_startup.py"
+      ],
+      "grid_family": "1D finite-difference grid",
+      "instrument": "European vanilla payoff with strike kink",
+      "invariants": [
+        "startup_schedule_recorded",
+        "gamma_kink_sanity"
+      ],
+      "issue_refs": [
+        "googa27/finite_difference_options#49"
+      ],
+      "model": "Black-Scholes / GBM",
+      "notes": "",
+      "oracle": {
+        "independence": "compares declared startup schedules against unsmoothed route behavior",
+        "kind": "regression",
+        "notes": "Regression evidence for smoothing policy, not a universal Greek guarantee.",
+        "source": "Rannacher Gamma regression tests"
+      },
+      "resource_policy": {
+        "deterministic": "true"
+      },
+      "route_id": "fd.black_scholes_1d.rannacher_crank_nicolson",
+      "runner": null,
+      "state_convention": "spot grid around strike with explicit startup schedule",
+      "status": "validated",
+      "time_schedule": "two/four Backward-Euler half-step startup before Crank-Nicolson",
+      "title": "Rannacher startup protects kinked-payoff Gamma evidence",
+      "tolerances": [
+        {
+          "metric": "boolean_invariant",
+          "norm": "all invariants",
+          "notes": "startup schedule and Gamma sanity checks pass",
+          "threshold": true
+        }
+      ]
+    },
+    {
+      "benchmark_id": "HESTON-SMOKE-DOCSTRING-V0",
+      "capability_rows": [
+        "Heston stochastic volatility vanilla call smoke route"
+      ],
+      "family": "smoke",
+      "fixture_paths": [
+        "tests/test_heston_state_oracle.py"
+      ],
+      "grid_family": "2D tensor grid smoke fixture",
+      "instrument": "European call smoke fixture",
+      "invariants": [
+        "finite_values",
+        "log_spot_factor_transform",
+        "variance_state_not_payoff_asset"
+      ],
+      "issue_refs": [
+        "googa27/finite_difference_options#49"
+      ],
+      "model": "Heston stochastic volatility",
+      "notes": "",
+      "oracle": {
+        "independence": "shape/finite-value route test separate from semi-analytical oracle maturity claim",
+        "kind": "fixture",
+        "notes": "Experimental smoke evidence only; convergence and production calibration remain unsupported.",
+        "source": "Heston state/oracle smoke tests and capability matrix docstring evidence"
+      },
+      "resource_policy": {
+        "deterministic": "true"
+      },
+      "route_id": "fd.heston.adi_smoke",
+      "runner": null,
+      "state_convention": "log-spot and variance state convention with declared exp factor transform",
+      "status": "experimental",
+      "time_schedule": "ADI/Douglas smoke route calendar-output orientation",
+      "title": "Heston vanilla-call smoke route shape and finite-value evidence",
+      "tolerances": [
+        {
+          "metric": "boolean_invariant",
+          "norm": "all invariants",
+          "notes": "finite shape/no-NaN Heston smoke checks pass",
+          "threshold": true
+        }
+      ]
+    },
+    {
+      "benchmark_id": "HESTON-ORACLE-V0",
+      "capability_rows": [
+        "Heston semi-analytical European call oracle",
+        "Heston stochastic volatility vanilla call smoke route"
+      ],
+      "family": "analytical_oracle",
+      "fixture_paths": [
+        "src/validation/heston_oracle.py"
+      ],
+      "grid_family": "not an FD grid; Fourier oracle reference",
+      "instrument": "European call",
+      "invariants": [
+        "positive_price",
+        "finite_integral",
+        "variance_boundary_diagnostics"
+      ],
+      "issue_refs": [
+        "googa27/finite_difference_options#49"
+      ],
+      "model": "Heston stochastic volatility",
+      "notes": "",
+      "oracle": {
+        "independence": "separate Fourier integration route under src.validation.heston_oracle",
+        "kind": "regression",
+        "notes": "Used for oracle and Black-Scholes-limit smoke evidence; not a calibration maturity claim.",
+        "source": "semi-analytical Heston characteristic-function oracle"
+      },
+      "resource_policy": {
+        "deterministic": "true"
+      },
+      "route_id": "fd.validation.heston_oracle",
+      "runner": null,
+      "state_convention": "log-spot and variance state convention",
+      "status": "validated",
+      "time_schedule": "single maturity reference integration",
+      "title": "Heston semi-analytical European call oracle",
+      "tolerances": [
+        {
+          "metric": "price_abs",
+          "norm": "absolute price error",
+          "notes": "oracle regression tolerance",
+          "threshold": 0.002
+        }
+      ]
+    },
+    {
+      "benchmark_id": "HESTON-BS-LIMIT-V0",
+      "capability_rows": [
+        "Heston semi-analytical European call oracle"
+      ],
+      "family": "route_parity",
+      "fixture_paths": [
+        "src/validation/heston_oracle.py"
+      ],
+      "grid_family": "oracle parity, not production FD route",
+      "instrument": "European call",
+      "invariants": [
+        "limit_price_matches_black_scholes"
+      ],
+      "issue_refs": [
+        "googa27/finite_difference_options#49"
+      ],
+      "model": "Heston -> Black-Scholes limit",
+      "notes": "",
+      "oracle": {
+        "independence": "separate Fourier integration route under src.validation.heston_oracle",
+        "kind": "regression",
+        "notes": "Used for oracle and Black-Scholes-limit smoke evidence; not a calibration maturity claim.",
+        "source": "semi-analytical Heston characteristic-function oracle"
+      },
+      "resource_policy": {
+        "deterministic": "true"
+      },
+      "route_id": "fd.validation.heston_black_scholes_limit",
+      "runner": "heston_black_scholes_limit",
+      "state_convention": "variance fixed at sigma^2 when vol-of-vol tends to zero",
+      "status": "validated",
+      "time_schedule": "single maturity reference comparison",
+      "title": "Heston zero vol-of-vol Black-Scholes limiting case",
+      "tolerances": [
+        {
+          "metric": "price_abs",
+          "norm": "absolute price error",
+          "notes": "against Black-Scholes oracle",
+          "threshold": 0.002
+        }
+      ]
+    },
+    {
+      "benchmark_id": "HESTON-VARIANCE-BOUNDARY-V0",
+      "capability_rows": [
+        "Heston semi-analytical European call oracle"
+      ],
+      "family": "capability_gate",
+      "fixture_paths": [
+        "src/validation/heston_oracle.py"
+      ],
+      "grid_family": "variance grid diagnostics",
+      "instrument": "European call smoke route",
+      "invariants": [
+        "variance_nonnegative",
+        "boundary_diagnostics_recorded"
+      ],
+      "issue_refs": [
+        "googa27/finite_difference_options#49"
+      ],
+      "model": "Heston stochastic volatility",
+      "notes": "",
+      "oracle": {
+        "independence": "separate Fourier integration route under src.validation.heston_oracle",
+        "kind": "regression",
+        "notes": "Used for oracle and Black-Scholes-limit smoke evidence; not a calibration maturity claim.",
+        "source": "semi-analytical Heston characteristic-function oracle"
+      },
+      "resource_policy": {
+        "deterministic": "true"
+      },
+      "route_id": "fd.heston.variance_boundary_diagnostics",
+      "runner": null,
+      "state_convention": "variance boundary has explicit lower/upper diagnostics",
+      "status": "validated",
+      "time_schedule": "single smoke solve diagnostics",
+      "title": "Heston variance-boundary diagnostics",
+      "tolerances": [
+        {
+          "metric": "boolean_invariant",
+          "norm": "all invariants",
+          "notes": "variance boundary diagnostics present",
+          "threshold": true
+        }
+      ]
+    },
+    {
+      "benchmark_id": "ADI-SMOKE-V0",
+      "capability_rows": [
+        "ADI multidimensional routes"
+      ],
+      "family": "smoke",
+      "fixture_paths": [
+        "tests/test_adi_solver_operator_split.py"
+      ],
+      "grid_family": "2D/3D tensor grids",
+      "instrument": "vanilla/basket smoke fixtures",
+      "invariants": [
+        "finite_values",
+        "calendar_output_orientation",
+        "shape_consistency"
+      ],
+      "issue_refs": [
+        "googa27/finite_difference_options#49",
+        "googa27/finite_difference_options#58"
+      ],
+      "model": "generic multidimensional parabolic PDE",
+      "notes": "",
+      "oracle": {
+        "independence": "regression tests cover operator splitting components before production claim",
+        "kind": "fixture",
+        "notes": "Smoke evidence only; convergence issue remains open.",
+        "source": "ADI smoke and operator split regression tests"
+      },
+      "resource_policy": {
+        "deterministic": "true"
+      },
+      "route_id": "fd.adi.douglas_smoke",
+      "runner": null,
+      "state_convention": "tensor-product state grid with explicit covariance convention",
+      "status": "experimental",
+      "time_schedule": "Douglas ADI calendar-output orientation",
+      "title": "ADI multidimensional finite-value smoke route",
+      "tolerances": [
+        {
+          "metric": "boolean_invariant",
+          "norm": "all invariants",
+          "notes": "finite shape/no-NaN smoke checks pass",
+          "threshold": true
+        }
+      ]
+    },
+    {
+      "benchmark_id": "ADI-OPERATOR-SPLIT-V0",
+      "capability_rows": [
+        "ADI multidimensional routes"
+      ],
+      "family": "route_parity",
+      "fixture_paths": [
+        "tests/test_adi_solver_operator_split.py"
+      ],
+      "grid_family": "2D/3D tensor grids",
+      "instrument": "operator-level fixture",
+      "invariants": [
+        "mixed_derivative_sign",
+        "reaction_preserved",
+        "source_preserved"
+      ],
+      "issue_refs": [
+        "googa27/finite_difference_options#49",
+        "googa27/finite_difference_options#58"
+      ],
+      "model": "generic multidimensional parabolic PDE",
+      "notes": "",
+      "oracle": {
+        "independence": "operator assembly tested separately from high-level pricing route",
+        "kind": "fixture",
+        "notes": "Supports route maturity disclosure; not yet convergence evidence.",
+        "source": "ADI operator split regression tests"
+      },
+      "resource_policy": {
+        "deterministic": "true"
+      },
+      "route_id": "fd.adi.operator_split_contract",
+      "runner": null,
+      "state_convention": "diagonal diffusion, off-diagonal mixed derivative, reaction and source terms explicit",
+      "status": "experimental",
+      "time_schedule": "operator construction before time march",
+      "title": "ADI operator split coefficient/regression evidence",
+      "tolerances": [
+        {
+          "metric": "boolean_invariant",
+          "norm": "all invariants",
+          "notes": "split terms match expected coefficients",
+          "threshold": true
+        }
+      ]
+    },
+    {
+      "benchmark_id": "FACTOR-ROLE-COMPAT-V0",
+      "capability_rows": [
+        "basket option payoff on true multi-asset factors"
+      ],
+      "family": "capability_gate",
+      "fixture_paths": [
+        "tests/test_factor_role_payoff_compatibility.py"
+      ],
+      "grid_family": "route-screening metadata, not a numerical grid",
+      "instrument": "basket, spread and factor payoffs",
+      "invariants": [
+        "heston_variance_not_basket_asset",
+        "sabr_vol_not_basket_asset",
+        "asset_id_mapping_required"
+      ],
+      "issue_refs": [
+        "googa27/finite_difference_options#49"
+      ],
+      "model": "basket/spread payoff role screening",
+      "notes": "",
+      "oracle": {
+        "independence": "contract-level rejection before solver construction",
+        "kind": "capability",
+        "notes": "Unsupported features must be explicit capability rejections, not silent approximation.",
+        "source": "DEFAULT_FD_CAPABILITY_MANIFEST fail-closed feature screening"
+      },
+      "resource_policy": {
+        "deterministic": "true"
+      },
+      "route_id": "fd.payoff.factor_role_compatibility",
+      "runner": null,
+      "state_convention": "tradable spot factors must be explicitly distinguished from variance/vol/rate factors",
+      "status": "validated",
+      "time_schedule": "pre-solve compatibility gate",
+      "title": "Factor-role payoff compatibility fail-closed gate",
+      "tolerances": [
+        {
+          "metric": "boolean_invariant",
+          "norm": "all invariants",
+          "notes": "unsupported factor/payoff pairs fail closed",
+          "threshold": true
+        }
+      ]
+    },
+    {
+      "benchmark_id": "DOCS-README-SMOKE-V0",
+      "capability_rows": [
+        "FastAPI/CLI/UI service contracts"
+      ],
+      "family": "smoke",
+      "fixture_paths": [
+        "tests/test_documentation_capabilities.py"
+      ],
+      "grid_family": "example-declared grids only",
+      "instrument": "public README/API examples",
+      "invariants": [
+        "examples_execute",
+        "maturity_disclosed",
+        "public_synthetic_inputs"
+      ],
+      "issue_refs": [
+        "googa27/finite_difference_options#49"
+      ],
+      "model": "documentation/examples",
+      "notes": "",
+      "oracle": {
+        "independence": "docs examples are exercised separately from numerical core validation",
+        "kind": "fixture",
+        "notes": "Convenience-surface evidence; numerical truth remains in core benchmark rows.",
+        "source": "documentation smoke tests and capability matrix gating"
+      },
+      "resource_policy": {
+        "deterministic": "true"
+      },
+      "route_id": "fd.docs.readme_smoke",
+      "runner": null,
+      "state_convention": "examples must disclose capability maturity and synthetic inputs",
+      "status": "experimental",
+      "time_schedule": "example-declared time controls only",
+      "title": "README and documentation smoke examples stay aligned with supported routes",
+      "tolerances": [
+        {
+          "metric": "boolean_invariant",
+          "norm": "all invariants",
+          "notes": "README/docs examples execute without unsupported maturity claims",
+          "threshold": true
+        }
+      ]
+    },
+    {
+      "benchmark_id": "API-REQUEST-GUARDS-V0",
+      "capability_rows": [
+        "FastAPI/CLI/UI service contracts"
+      ],
+      "family": "capability_gate",
+      "fixture_paths": [
+        "tests/test_api_schema_contracts.py"
+      ],
+      "grid_family": "bounded request grids only",
+      "instrument": "pricing request/response contracts",
+      "invariants": [
+        "bounded_grid_nodes",
+        "invalid_payoff_rejected",
+        "convergence_not_assessed_disclosed"
+      ],
+      "issue_refs": [
+        "googa27/finite_difference_options#49"
+      ],
+      "model": "FastAPI/CLI adapter schemas",
+      "notes": "",
+      "oracle": {
+        "independence": "adapter contract tests exercise bounded inputs before solver dispatch",
+        "kind": "fixture",
+        "notes": "API evidence does not promote experimental numerical routes to validated status.",
+        "source": "API schema and request-guard tests"
+      },
+      "resource_policy": {
+        "deterministic": "true"
+      },
+      "route_id": "fd.api.request_guards",
+      "runner": null,
+      "state_convention": "outer adapters over numerical core with explicit route maturity",
+      "status": "experimental",
+      "time_schedule": "request-declared maturity/time controls",
+      "title": "API request guards and explicit non-claim convergence metadata",
+      "tolerances": [
+        {
+          "metric": "boolean_invariant",
+          "norm": "all invariants",
+          "notes": "invalid requests fail closed and responses disclose convergence status",
+          "threshold": true
+        }
+      ]
+    },
+    {
+      "benchmark_id": "REG-FAIL-CLOSED-V0",
+      "capability_rows": [
+        "CRIF/CUSO/Basel/FRTB regulatory report endpoints"
+      ],
+      "family": "regulatory_fail_closed",
+      "fixture_paths": [
+        "tests/test_regulatory_fail_closed.py"
+      ],
+      "grid_family": "not applicable",
+      "instrument": "CRIF/CUSO/Basel/FRTB endpoints",
+      "invariants": [
+        "http_501_for_unsupported_standard",
+        "no_placeholder_report_values"
+      ],
+      "issue_refs": [
+        "googa27/finite_difference_options#49"
+      ],
+      "model": "regulatory reporting scaffold",
+      "notes": "",
+      "oracle": {
+        "independence": "contract-level rejection before solver construction",
+        "kind": "capability",
+        "notes": "Unsupported features must be explicit capability rejections, not silent approximation.",
+        "source": "DEFAULT_FD_CAPABILITY_MANIFEST fail-closed feature screening"
+      },
+      "resource_policy": {
+        "deterministic": "true"
+      },
+      "route_id": "fd.regulatory.fail_closed",
+      "runner": null,
+      "state_convention": "standard/profile/version/effective-date/jurisdiction required before implementation",
+      "status": "scaffold",
+      "time_schedule": "not applicable",
+      "title": "Regulatory endpoint fail-closed standard/version gate",
+      "tolerances": []
+    }
+  ],
+  "issue_ref": "googa27/finite_difference_options#49",
+  "registry_id": "finite_difference_options.benchmark_registry.v0",
+  "schema_version": "finite-difference-benchmark-registry/v0"
+}

--- a/tests/test_benchmark_registry.py
+++ b/tests/test_benchmark_registry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import pathlib
 import re
+from dataclasses import replace
 
 import pytest
 
@@ -85,6 +86,9 @@ def test_black_scholes_registered_benchmark_executes_real_runner(
     assert result.metrics["price_abs"] <= 5.0e-4
     assert result.metrics["delta_abs"] <= 5.0e-2
     assert result.metrics["gamma_abs"] <= 2.0e-2
+    assert result.invariants["price_abs_tolerance_ok"]
+    assert result.invariants["delta_abs_tolerance_ok"]
+    assert result.invariants["gamma_abs_tolerance_ok"]
     assert result.evidence["fixture_id"] == "public-synthetic.black-scholes-call.v0"
     assert result.evidence["route_id"] == "fd.black_scholes_1d.crank_nicolson"
     assert all(result.invariants.values())
@@ -97,6 +101,34 @@ def test_black_scholes_registered_benchmark_executes_real_runner(
     assert json.loads(explicit_artifact.read_text(encoding="utf-8")) == json.loads(
         json.dumps(result.as_dict())
     )
+
+
+def test_black_scholes_runner_fails_when_declared_greek_tolerance_is_violated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.validation import black_scholes_parity
+
+    report = black_scholes_parity.run_public_black_scholes_parity_fixture()
+    bad_report = replace(
+        report,
+        errors={
+            **report.errors,
+            "delta_abs": 10.0
+            * registry_by_id()["BS-CALL-PARITY-V0"].tolerances[1].threshold,
+        },
+    )
+    monkeypatch.setattr(
+        black_scholes_parity,
+        "run_public_black_scholes_parity_fixture",
+        lambda: bad_report,
+    )
+
+    result = run_registered_benchmark("BS-CALL-PARITY-V0")
+
+    assert not result.passed
+    assert result.invariants["price_abs_tolerance_ok"]
+    assert result.invariants["delta_abs_tolerance_ok"] is False
+    assert result.invariants["gamma_abs_tolerance_ok"]
 
 
 def test_validated_route_parity_benchmarks_execute_real_runners() -> None:

--- a/tests/test_benchmark_registry.py
+++ b/tests/test_benchmark_registry.py
@@ -131,6 +131,56 @@ def test_black_scholes_runner_fails_when_declared_greek_tolerance_is_violated(
     assert result.invariants["gamma_abs_tolerance_ok"]
 
 
+def test_black_scholes_runner_fails_when_declared_invariant_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.validation import black_scholes_parity
+
+    report = black_scholes_parity.run_public_black_scholes_parity_fixture()
+    incomplete_report = replace(
+        report,
+        no_arbitrage={
+            key: value
+            for key, value in report.no_arbitrage.items()
+            if key != "gamma_non_negative_ok"
+        },
+    )
+    monkeypatch.setattr(
+        black_scholes_parity,
+        "run_public_black_scholes_parity_fixture",
+        lambda: incomplete_report,
+    )
+
+    result = run_registered_benchmark("BS-CALL-PARITY-V0")
+
+    assert not result.passed
+    assert result.invariants["gamma_non_negative_ok"] is False
+
+
+def test_qps_runner_fails_when_declared_price_tolerance_is_violated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.validation import black_scholes_parity
+
+    report = black_scholes_parity.run_public_black_scholes_parity_fixture()
+    bad_final_row = replace(report.observations[-1], abs_error=1.0)
+    bad_report = replace(
+        report,
+        observations=(*report.observations[:-1], bad_final_row),
+        errors={**report.errors, "price_abs": 1.0},
+    )
+    monkeypatch.setattr(
+        black_scholes_parity,
+        "run_public_black_scholes_parity_fixture",
+        lambda: bad_report,
+    )
+
+    result = run_registered_benchmark("QPS-VANILLA-CALL-V0")
+
+    assert not result.passed
+    assert result.invariants["price_abs_tolerance_ok"] is False
+
+
 def test_validated_route_parity_benchmarks_execute_real_runners() -> None:
     qps = run_registered_benchmark("QPS-VANILLA-CALL-V0")
     heston_limit = run_registered_benchmark("HESTON-BS-LIMIT-V0")
@@ -141,6 +191,7 @@ def test_validated_route_parity_benchmarks_execute_real_runners() -> None:
         "problem_hash": True,
         "typed_boundary": True,
         "calendar_time_orientation": True,
+        "price_abs_tolerance_ok": True,
     }
     assert qps.metrics["typed_boundary_count"] == 2
 

--- a/tests/test_benchmark_registry.py
+++ b/tests/test_benchmark_registry.py
@@ -1,0 +1,155 @@
+"""Executable tests for the FD benchmark registry (#49)."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+
+import pytest
+
+from src.validation.benchmark_registry import (
+    BenchmarkCase,
+    BenchmarkRegistryError,
+    registry_as_dict,
+    registry_by_id,
+    run_registered_benchmark,
+    validate_benchmark_registry,
+    write_benchmark_result_json,
+    write_registry_json,
+)
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+CAPABILITY_MATRIX = ROOT / "docs" / "CAPABILITY_MATRIX.md"
+STATIC_REGISTRY = ROOT / "tests" / "fixtures" / "fd_benchmark_registry_v1.json"
+EVIDENCE_ID_RE = re.compile(r"`([A-Z0-9][A-Z0-9-]+-V\d+)`")
+
+
+def _capability_matrix_evidence_ids() -> set[str]:
+    text = CAPABILITY_MATRIX.read_text(encoding="utf-8")
+    ids: set[str] = set()
+    for line in text.splitlines():
+        if not line.startswith("| ") or "Evidence / benchmark ID" in line:
+            continue
+        ids.update(EVIDENCE_ID_RE.findall(line))
+    return ids
+
+
+def test_default_benchmark_registry_is_valid_and_versioned() -> None:
+    registry = validate_benchmark_registry()
+    ids = [case.benchmark_id for case in registry]
+
+    assert len(ids) == len(set(ids))
+    assert "BS-CALL-PARITY-V0" in ids
+    assert "ADI-OPERATOR-SPLIT-V0" in ids
+    assert all(case.benchmark_id.endswith("-V0") for case in registry)
+    assert all(case.issue_refs for case in registry)
+
+
+def test_capability_matrix_evidence_ids_are_registry_rows() -> None:
+    matrix_ids = _capability_matrix_evidence_ids()
+    registry_ids = set(registry_by_id())
+
+    assert matrix_ids
+    assert matrix_ids <= registry_ids
+
+
+def test_registry_rows_reference_existing_fixture_paths() -> None:
+    for case in validate_benchmark_registry():
+        for fixture_path in case.fixture_paths:
+            assert (
+                ROOT / fixture_path
+            ).exists(), f"{case.benchmark_id} references missing fixture {fixture_path}"
+
+
+def test_static_registry_fixture_matches_generated_payload(
+    tmp_path: pathlib.Path,
+) -> None:
+    generated = json.loads(json.dumps(registry_as_dict()))
+    cached = json.loads(STATIC_REGISTRY.read_text(encoding="utf-8"))
+
+    assert cached == generated
+
+    written = tmp_path / "registry.json"
+    write_registry_json(written)
+    assert json.loads(written.read_text(encoding="utf-8")) == generated
+
+
+def test_black_scholes_registered_benchmark_executes_real_runner(
+    tmp_path: pathlib.Path,
+) -> None:
+    artifact = tmp_path / "bs_result.json"
+    result = run_registered_benchmark("BS-CALL-PARITY-V0", artifact_path=artifact)
+
+    assert result.passed
+    assert result.metrics["price_abs"] <= 5.0e-4
+    assert result.metrics["delta_abs"] <= 5.0e-2
+    assert result.metrics["gamma_abs"] <= 2.0e-2
+    assert result.evidence["fixture_id"] == "public-synthetic.black-scholes-call.v0"
+    assert result.evidence["route_id"] == "fd.black_scholes_1d.crank_nicolson"
+    assert all(result.invariants.values())
+    assert json.loads(artifact.read_text(encoding="utf-8")) == json.loads(
+        json.dumps(result.as_dict())
+    )
+
+    explicit_artifact = tmp_path / "explicit_result.json"
+    write_benchmark_result_json(explicit_artifact, result)
+    assert json.loads(explicit_artifact.read_text(encoding="utf-8")) == json.loads(
+        json.dumps(result.as_dict())
+    )
+
+
+def test_validated_route_parity_benchmarks_execute_real_runners() -> None:
+    qps = run_registered_benchmark("QPS-VANILLA-CALL-V0")
+    heston_limit = run_registered_benchmark("HESTON-BS-LIMIT-V0")
+
+    assert qps.passed
+    assert qps.invariants == {
+        "schema_version": True,
+        "problem_hash": True,
+        "typed_boundary": True,
+        "calendar_time_orientation": True,
+    }
+    assert qps.metrics["typed_boundary_count"] == 2
+
+    assert heston_limit.passed
+    assert heston_limit.invariants["limit_price_matches_black_scholes"]
+    assert float(heston_limit.metrics["price_abs"]) <= float(
+        heston_limit.metrics["threshold"]
+    )
+
+
+def test_metadata_only_benchmarks_fail_closed_when_run_directly() -> None:
+    with pytest.raises(BenchmarkRegistryError) as excinfo:
+        run_registered_benchmark("ADI-OPERATOR-SPLIT-V0")
+
+    assert "has no executable runner" in str(excinfo.value)
+
+
+def test_registry_validation_rejects_duplicate_oracleless_validated_case() -> None:
+    valid = registry_by_id()["BS-CALL-PARITY-V0"]
+    invalid = BenchmarkCase(
+        benchmark_id=valid.benchmark_id,
+        title="invalid duplicate",
+        family="route_parity",
+        status="validated",
+        route_id="fd.invalid",
+        model="invalid",
+        instrument="invalid",
+        state_convention="invalid",
+        grid_family="invalid",
+        time_schedule="invalid",
+        oracle=valid.oracle.__class__(
+            kind="none", source="none", independence="none", notes="none"
+        ),
+        tolerances=(),
+        invariants=("unexecuted_parity",),
+    )
+
+    with pytest.raises(BenchmarkRegistryError) as excinfo:
+        validate_benchmark_registry((valid, invalid))
+
+    errors = "\n".join(excinfo.value.errors)
+    assert "duplicate benchmark_id" in errors
+    assert "claims validated without an oracle" in errors
+    assert "validated route-parity benchmark" in errors


### PR DESCRIPTION
## Summary

Closes #49.

Adds an executable benchmark evidence registry for finite-difference validation claims:

- introduces `src.validation.benchmark_registry` with versioned evidence rows for every current `docs/CAPABILITY_MATRIX.md` benchmark ID;
- adds deterministic runners for `BS-CALL-PARITY-V0`, `QPS-VANILLA-CALL-V0`, and `HESTON-BS-LIMIT-V0`;
- makes metadata-only benchmarks fail closed when executed directly;
- requires validated route-parity rows to have executable runners;
- adds result artifact persistence via `artifact_path=` and `write_benchmark_result_json(...)`;
- publishes `tests/fixtures/fd_benchmark_registry_v1.json` and `docs/BENCHMARK_REGISTRY.md`;
- adds `tests/test_benchmark_registry.py` to the CI stable regression suite.

## Verification

Local gates run on `/tmp/qpe-fdo-49-benchmark-registry`:

```bash
PYTHONPATH=$PWD python -m compileall -q api src tests
PYTHONPATH=$PWD python -m ruff check . --select E9,F63,F7,F82
PYTHONPATH=$PWD python scripts/check_architecture_contract.py
PYTHONPATH=$PWD python scripts/check_markdown_links.py
PYTHONPATH=$PWD python -m pytest -q tests/architecture tests/test_benchmark_registry.py
PYTHONPATH=$PWD python -m pytest -q
PYTHONPATH=$PWD python -m ruff check src/validation/benchmark_registry.py src/validation/__init__.py tests/test_benchmark_registry.py
git diff --check
```

Observed:

- `compileall` -> 0
- static CI ruff selector -> 0
- architecture contract -> 0
- markdown link check -> 0
- architecture + benchmark-registry tests -> 24 passed
- full pytest -> 280 passed, 14 third-party deprecation warnings
- changed-file ruff -> 0
- `git diff --check` -> 0
- adversarial re-review -> no blocking defects

## Notes

This registry does not graduate ADI/Heston/basket/regulatory routes to production. It makes their evidence status explicit and machine-checkable, with successor work expected to add additional executable runners before changing maturity claims.
