### PR TITLE
Harden CI supply-chain and release evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,7 @@ jobs:
       - name: Generate frontend SBOM
         if: steps.nextjs.outputs.present == 'true' && steps.nextjs.outputs.lockfile == 'true'
         working-directory: nextjs-client
-        run: npm sbom --json > npm-sbom.json
+        run: npm sbom --sbom-format cyclonedx --json > npm-sbom.json
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: steps.nextjs.outputs.present == 'true' && steps.nextjs.outputs.lockfile == 'true'
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
   package:
     name: Package / Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -50,15 +51,19 @@ jobs:
           ]:
               importlib.import_module(name)
           PY
+      - name: Generate release manifest
+        run: python scripts/write_release_manifest.py --dist dist --output dist/release-manifest.json
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: finite-difference-options-dist-py${{ matrix.python-version }}
           path: dist/*
           if-no-files-found: error
+          retention-days: 14
 
   test:
     name: Test / Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -93,10 +98,12 @@ jobs:
             coverage.xml
             junit.xml
           if-no-files-found: warn
+          retention-days: 14
 
   optional-profiles:
     name: Optional profile / ${{ matrix.profile }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: package
     strategy:
       fail-fast: false
@@ -140,6 +147,7 @@ jobs:
   audit:
     name: Audit and SBOM
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -159,10 +167,12 @@ jobs:
           name: finite-difference-options-sbom
           path: sbom.json
           if-no-files-found: error
+          retention-days: 14
 
   node:
     name: Optional Node client
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Detect Next.js client
@@ -180,7 +190,7 @@ jobs:
           else
             echo "present=false" >> "$GITHUB_OUTPUT"
             echo "lockfile=false" >> "$GITHUB_OUTPUT"
-            echo "nextjs-client is absent; skipping Node install/test/lint."
+            echo "nextjs-client is absent; skipping Node install/test/lint/build/audit."
           fi
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         if: steps.nextjs.outputs.present == 'true'
@@ -202,3 +212,22 @@ jobs:
         if: steps.nextjs.outputs.present == 'true'
         working-directory: nextjs-client
         run: npm run lint
+      - name: Run production build
+        if: steps.nextjs.outputs.present == 'true'
+        working-directory: nextjs-client
+        run: npm run build
+      - name: Run npm audit
+        if: steps.nextjs.outputs.present == 'true' && steps.nextjs.outputs.lockfile == 'true'
+        working-directory: nextjs-client
+        run: npm audit --audit-level=high
+      - name: Generate frontend SBOM
+        if: steps.nextjs.outputs.present == 'true' && steps.nextjs.outputs.lockfile == 'true'
+        working-directory: nextjs-client
+        run: npm sbom --json > npm-sbom.json
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: steps.nextjs.outputs.present == 'true' && steps.nextjs.outputs.lockfile == 'true'
+        with:
+          name: finite-difference-options-node-sbom
+          path: nextjs-client/npm-sbom.json
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/gemini-cli.yml
+++ b/.github/workflows/gemini-cli.yml
@@ -198,7 +198,7 @@ jobs:
 
       - name: 'Run Gemini'
         id: 'run_gemini'
-        uses: 'google-github-actions/run-gemini-cli@v0'
+        uses: 'google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489' # v0.1.22, patched for GHSA-wpqr-6v78-jr5g
         env:
           GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
           REPOSITORY: '${{ github.repository }}'

--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -153,7 +153,7 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
 
       - name: 'Run Gemini PR Review'
-        uses: 'google-github-actions/run-gemini-cli@v0'
+        uses: 'google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489' # v0.1.22, patched for GHSA-wpqr-6v78-jr5g
         id: 'gemini_pr_review'
         continue-on-error: true
         env:

--- a/docs/CI_POLICY.md
+++ b/docs/CI_POLICY.md
@@ -1,7 +1,7 @@
 # CI policy
 
-Audit baseline: 2026-06-26
-Owning issues: [#69](https://github.com/googa27/finite_difference_options/issues/69), [#51](https://github.com/googa27/finite_difference_options/issues/51)
+Audit baseline: 2026-07-03
+Owning issues: [#69](https://github.com/googa27/finite_difference_options/issues/69), [#51](https://github.com/googa27/finite_difference_options/issues/51), [#67](https://github.com/googa27/finite_difference_options/issues/67)
 
 ## Blocking signals
 
@@ -14,7 +14,8 @@ The package job builds the release artifacts from PEP 621 metadata on Python 3.1
 1. `python -m build --sdist --wheel`;
 2. `python -m twine check dist/*`;
 3. clean-wheel import smoke outside the repository checkout;
-4. upload of the sdist/wheel artifacts.
+4. release manifest generation with artifact, lockfile, capability-matrix and benchmark-registry hashes;
+5. upload of the sdist/wheel/manifest artifacts with bounded retention.
 
 The clean-wheel smoke imports only core/contract/validation/backend modules, proving that the wheel does not depend on repository-relative `src.*` imports.
 
@@ -25,7 +26,7 @@ The test job installs the development profile with `python -m pip install -e '.[
 1. static smoke gate:
    - `python -m compileall -q src tests scripts`;
    - `ruff check . --select E9,F63,F7,F82`;
-   - `mypy --ignore-missing-imports --follow-imports=silent` on contract-critical modules;
+   - mypy on contract-critical modules with ignore-missing-imports and follow-imports=silent;
 2. architecture, documentation, and packaging contracts:
    - `python scripts/check_architecture_contract.py`;
    - `python scripts/check_markdown_links.py`;
@@ -57,11 +58,18 @@ The audit job installs the development profile, applies `requirements-dev.lock.t
 
 The Node job is a presence-gated application-profile smoke:
 
-- if `nextjs-client/package.json` is absent, the job records that the Next.js client is absent and skips install/test/lint;
+- if `nextjs-client/package.json` is absent, the job records that the Next.js client is absent and skips install/test/lint/build/audit;
 - if `nextjs-client/package-lock.json` is present, it uses `npm ci`;
-- if the package exists without a lockfile, it uses `npm install --no-audit --no-fund` and emits an explicit log message.
+- if the package exists without a lockfile, it uses `npm install --no-audit --no-fund` and emits an explicit log message;
+- when a maintained frontend exists, the job runs tests, lint, production build, npm audit, and emits an npm SBOM artifact from the committed lockfile.
 
-If the frontend becomes a maintained deliverable, a successor issue must add a committed lockfile, explicit `test` and `lint` scripts, and separate dependency/audit evidence. Until then, frontend checks are scoped to the optional application profile, not the numerical core package.
+If the frontend becomes a maintained deliverable, a successor issue must add a committed lockfile, explicit `test`, `lint`, and `build` scripts, and separate dependency/audit evidence. Until then, frontend checks are scoped to the optional application profile, not the numerical core package.
+
+## Supply-chain/runtime controls
+
+All third-party GitHub Actions are pinned to reviewed full commit SHAs. Mutable tags such as `@v4` or `@v0` may appear only in explanatory comments, not as executable refs. The CI workflow declares top-level read-only contents permission, workflow concurrency/cancellation, per-job timeouts, and explicit artifact retention.
+
+Release-manifest generation is intentionally lightweight and deterministic: `scripts/write_release_manifest.py` hashes built distributions plus governance inputs (`pyproject.toml`, requirements/lock files, capability matrix, and benchmark-registry fixture). This links source commit, artifact hashes, CI run metadata, and production route evidence without reading secrets.
 
 ## Advisory automated-review signals
 

--- a/scripts/write_release_manifest.py
+++ b/scripts/write_release_manifest.py
@@ -28,6 +28,8 @@ DEFAULT_LOCKFILES = (
     "tests/fixtures/fd_benchmark_registry_v1.json",
 )
 
+PYTHON_DISTRIBUTION_SUFFIXES = (".whl", ".tar.gz")
+
 
 def _sha256(path: Path) -> str:
     digest = hashlib.sha256()
@@ -47,7 +49,11 @@ def _file_record(path: Path, *, relative_to: Path | None = None) -> dict[str, An
 
 
 def build_manifest(dist: Path, lockfiles: tuple[str, ...] = DEFAULT_LOCKFILES) -> dict[str, Any]:
-    artifact_paths = sorted(path for path in dist.glob("*") if path.is_file())
+    artifact_paths = sorted(
+        path
+        for path in dist.glob("*")
+        if path.is_file() and path.name.endswith(PYTHON_DISTRIBUTION_SUFFIXES)
+    )
     if not artifact_paths:
         raise SystemExit(f"No distribution artifacts found under {dist}")
 

--- a/scripts/write_release_manifest.py
+++ b/scripts/write_release_manifest.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Write a reproducible release-manifest skeleton for built artifacts.
+
+The manifest intentionally records only public repository metadata and hashes of
+checked-in/build artifacts. It does not read secrets or environment variables
+that could contain credentials.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import platform
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+
+DEFAULT_LOCKFILES = (
+    "pyproject.toml",
+    "requirements.txt",
+    "requirements-dev.txt",
+    "requirements-dev.lock.txt",
+    "docs/CAPABILITY_MATRIX.md",
+    "tests/fixtures/fd_benchmark_registry_v1.json",
+)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _file_record(path: Path, *, relative_to: Path | None = None) -> dict[str, Any]:
+    base = relative_to or ROOT
+    return {
+        "path": path.relative_to(base).as_posix() if path.is_relative_to(base) else path.as_posix(),
+        "size_bytes": path.stat().st_size,
+        "sha256": _sha256(path),
+    }
+
+
+def build_manifest(dist: Path, lockfiles: tuple[str, ...] = DEFAULT_LOCKFILES) -> dict[str, Any]:
+    artifact_paths = sorted(path for path in dist.glob("*") if path.is_file())
+    if not artifact_paths:
+        raise SystemExit(f"No distribution artifacts found under {dist}")
+
+    lockfile_records = []
+    for relative in lockfiles:
+        path = ROOT / relative
+        if path.exists():
+            lockfile_records.append(_file_record(path))
+
+    return {
+        "schema_version": "finite-difference-options.release-manifest.v0",
+        "generated_at_utc": dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat(),
+        "source": {
+            "repository": os.environ.get("GITHUB_REPOSITORY", "googa27/finite_difference_options"),
+            "sha": os.environ.get("GITHUB_SHA", "local"),
+            "ref": os.environ.get("GITHUB_REF_NAME", "local"),
+            "workflow": os.environ.get("GITHUB_WORKFLOW", "local"),
+            "run_id": os.environ.get("GITHUB_RUN_ID", "local"),
+        },
+        "environment": {
+            "python_version": platform.python_version(),
+            "platform": platform.platform(),
+        },
+        "artifacts": [_file_record(path, relative_to=dist.parent) for path in artifact_paths],
+        "governance_inputs": lockfile_records,
+        "capability_evidence": {
+            "capability_matrix": "docs/CAPABILITY_MATRIX.md",
+            "benchmark_registry_fixture": "tests/fixtures/fd_benchmark_registry_v1.json",
+            "ci_policy": "docs/CI_POLICY.md",
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dist", type=Path, default=ROOT / "dist")
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    manifest = build_manifest(args.dist)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/architecture/test_ci_policy_contracts.py
+++ b/tests/architecture/test_ci_policy_contracts.py
@@ -1,10 +1,37 @@
 from pathlib import Path
+import re
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _read(relative_path: str) -> str:
     return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_third_party_actions_are_pinned_to_full_commit_shas() -> None:
+    workflows = sorted((REPO_ROOT / ".github" / "workflows").glob("*.yml"))
+    assert workflows
+
+    unpinned: list[str] = []
+    uses_re = re.compile(r"^\s*(?:-\s*)?uses:\s*['\"]?([^'\"\s]+)")
+    for workflow_path in workflows:
+        for line_number, line in enumerate(
+            workflow_path.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            match = uses_re.search(line)
+            if not match:
+                continue
+            target = match.group(1)
+            if target.startswith(("./", "docker://")):
+                continue
+            if "@" not in target:
+                unpinned.append(f"{workflow_path.relative_to(REPO_ROOT)}:{line_number}:{target}")
+                continue
+            ref = target.rsplit("@", maxsplit=1)[1]
+            if not re.fullmatch(r"[0-9a-f]{40}", ref):
+                unpinned.append(f"{workflow_path.relative_to(REPO_ROOT)}:{line_number}:{target}")
+
+    assert unpinned == []
 
 
 def test_blocking_ci_has_actionable_python_and_stable_suite_contract() -> None:
@@ -27,6 +54,21 @@ def test_blocking_ci_has_actionable_python_and_stable_suite_contract() -> None:
     assert "python -m pip check" in workflow
     assert "python -m pip_audit --progress-spinner=off --skip-editable" in workflow
     assert "cyclonedx-py environment --of JSON -o sbom.json" in workflow
+    assert "Generate release manifest" in workflow
+    assert "scripts/write_release_manifest.py --dist dist --output dist/release-manifest.json" in workflow
+    assert "retention-days: 14" in workflow
+
+
+def test_ci_jobs_declare_bounded_runtime_and_artifact_retention() -> None:
+    workflow = _read(".github/workflows/ci.yml")
+
+    for job in ("package", "test", "optional-profiles", "audit", "node"):
+        section = workflow.split(f"  {job}:\n", maxsplit=1)[1]
+        next_job = re.search(r"\n  [a-zA-Z0-9_-]+:\n", section)
+        job_section = section[: next_job.start()] if next_job else section
+        assert "timeout-minutes:" in job_section, job
+
+    assert workflow.count("retention-days: 14") >= 4
 
 
 def test_node_profile_never_references_a_missing_lockfile_cache_path() -> None:
@@ -36,6 +78,10 @@ def test_node_profile_never_references_a_missing_lockfile_cache_path() -> None:
     assert "Install dependencies with lockfile" in workflow
     assert "Install dependencies without lockfile" in workflow
     assert "cache-dependency-path: nextjs-client/package-lock.json" not in workflow
+    assert "Run production build" in workflow
+    assert "npm run build" in workflow
+    assert "npm audit --audit-level=high" in workflow
+    assert "npm sbom --json > npm-sbom.json" in workflow
 
 
 def test_gemini_review_and_issue_triage_failures_are_advisory() -> None:
@@ -74,6 +120,15 @@ def test_issue_triage_ai_output_is_schema_validated_before_additive_label_writes
         assert "Raw labels JSON" not in workflow
         assert "protected labels that require deterministic handling" in workflow
         assert "status/needs-triage" in workflow
+
+
+def test_review_and_cli_gemini_actions_are_pinned_to_reviewed_sha() -> None:
+    pr_review = _read(".github/workflows/gemini-pr-review.yml")
+    cli = _read(".github/workflows/gemini-cli.yml")
+
+    for workflow in (pr_review, cli):
+        assert "google-github-actions/run-gemini-cli@v0" not in workflow
+        assert "google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489" in workflow
 
 
 def test_scheduled_issue_triage_rotates_candidate_batches() -> None:

--- a/tests/architecture/test_ci_policy_contracts.py
+++ b/tests/architecture/test_ci_policy_contracts.py
@@ -81,7 +81,7 @@ def test_node_profile_never_references_a_missing_lockfile_cache_path() -> None:
     assert "Run production build" in workflow
     assert "npm run build" in workflow
     assert "npm audit --audit-level=high" in workflow
-    assert "npm sbom --json > npm-sbom.json" in workflow
+    assert "npm sbom --sbom-format cyclonedx --json > npm-sbom.json" in workflow
 
 
 def test_gemini_review_and_issue_triage_failures_are_advisory() -> None:

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+import tarfile
+import zipfile
+from pathlib import Path
+
+from scripts.write_release_manifest import build_manifest
+
+
+def test_release_manifest_records_artifact_and_governance_hashes(tmp_path: Path) -> None:
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    wheel = dist / "finite_difference_options-0.1.0-py3-none-any.whl"
+    sdist = dist / "finite_difference_options-0.1.0.tar.gz"
+
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr("finite_difference_options/__init__.py", "")
+    with tarfile.open(sdist, "w:gz") as archive:
+        payload = tmp_path / "PKG-INFO"
+        payload.write_text("Name: finite-difference-options\n", encoding="utf-8")
+        archive.add(payload, arcname="finite_difference_options-0.1.0/PKG-INFO")
+
+    manifest = build_manifest(dist)
+    payload = json.loads(json.dumps(manifest))
+
+    assert payload["schema_version"] == "finite-difference-options.release-manifest.v0"
+    assert payload["source"]["repository"] == "googa27/finite_difference_options"
+    assert {artifact["path"] for artifact in payload["artifacts"]} == {
+        "dist/finite_difference_options-0.1.0-py3-none-any.whl",
+        "dist/finite_difference_options-0.1.0.tar.gz",
+    }
+    assert all(len(artifact["sha256"]) == 64 for artifact in payload["artifacts"])
+    assert "docs/CAPABILITY_MATRIX.md" in {
+        item["path"] for item in payload["governance_inputs"]
+    }
+    assert payload["capability_evidence"]["benchmark_registry_fixture"] == (
+        "tests/fixtures/fd_benchmark_registry_v1.json"
+    )

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -21,6 +21,7 @@ def test_release_manifest_records_artifact_and_governance_hashes(tmp_path: Path)
     dist.mkdir()
     wheel = dist / "finite_difference_options-0.1.0-py3-none-any.whl"
     sdist = dist / "finite_difference_options-0.1.0.tar.gz"
+    stale_manifest = dist / "release-manifest.json"
 
     with zipfile.ZipFile(wheel, "w") as archive:
         archive.writestr("finite_difference_options/__init__.py", "")
@@ -28,6 +29,7 @@ def test_release_manifest_records_artifact_and_governance_hashes(tmp_path: Path)
         payload = tmp_path / "PKG-INFO"
         payload.write_text("Name: finite-difference-options\n", encoding="utf-8")
         archive.add(payload, arcname="finite_difference_options-0.1.0/PKG-INFO")
+    stale_manifest.write_text('{"stale": true}\n', encoding="utf-8")
 
     manifest = build_manifest(dist)
     payload = json.loads(json.dumps(manifest))
@@ -37,6 +39,9 @@ def test_release_manifest_records_artifact_and_governance_hashes(tmp_path: Path)
     assert {artifact["path"] for artifact in payload["artifacts"]} == {
         "dist/finite_difference_options-0.1.0-py3-none-any.whl",
         "dist/finite_difference_options-0.1.0.tar.gz",
+    }
+    assert "dist/release-manifest.json" not in {
+        artifact["path"] for artifact in payload["artifacts"]
     }
     assert all(len(artifact["sha256"]) == 64 for artifact in payload["artifacts"])
     assert "docs/CAPABILITY_MATRIX.md" in {

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
+import importlib.util
 import json
 import tarfile
 import zipfile
 from pathlib import Path
 
-from scripts.write_release_manifest import build_manifest
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_SCRIPT = REPO_ROOT / "scripts" / "write_release_manifest.py"
+
+spec = importlib.util.spec_from_file_location("write_release_manifest", MANIFEST_SCRIPT)
+assert spec is not None and spec.loader is not None
+write_release_manifest = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(write_release_manifest)
+build_manifest = write_release_manifest.build_manifest
 
 
 def test_release_manifest_records_artifact_and_governance_hashes(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Closes googa27/finite_difference_options#67.

- Adds architecture tests that fail on mutable third-party Action refs across all workflows.
- Pins remaining Gemini advisory workflows from `run-gemini-cli@v0` to the reviewed patched SHA already used by issue triage.
- Adds CI job `timeout-minutes`, upload-artifact `retention-days`, Node production-build/audit/SBOM gates when a frontend exists, and release-manifest generation for built Python artifacts.
- Adds `scripts/write_release_manifest.py` plus tests that hash distributions and governance inputs (`pyproject.toml`, requirements/lock files, capability matrix, benchmark registry fixture).
- Updates `docs/CI_POLICY.md` so the CI supply-chain contract is documented under #67.

## Verification

- `uv run --extra validation python -m pytest tests/architecture/test_ci_policy_contracts.py tests/test_release_manifest.py -q`
  - 11 passed
- `uv run --extra validation python -m pytest tests/architecture tests/test_packaging_contract.py tests/test_release_manifest.py -q`
  - 31 passed
- `uv run --extra dev python -m compileall -q src tests scripts && uv run --extra dev ruff check scripts/write_release_manifest.py tests/architecture/test_ci_policy_contracts.py tests/test_release_manifest.py`
  - All checks passed
- `python3 ~/.hermes/skills/productivity/markdown-rendering-standards/scripts/check_markdown_math_diagrams.py --strict docs/CI_POLICY.md`
  - 0 errors / 0 warnings
- `uv run --extra build python -m build --sdist --wheel`
  - built wheel and sdist successfully
- `uv run --extra build python scripts/write_release_manifest.py --dist dist --output dist/release-manifest.json`
  - manifest schema `finite-difference-options.release-manifest.v0`, 2 artifacts, 6 governance inputs
- `uv run --extra build python -m twine check dist/*.whl dist/*.tar.gz`
  - PASSED
- `uv run --extra validation python -m pytest -q`
  - 344 passed, 231 warnings
- `git diff --check`
  - clean

## Note

A direct `twine check dist/*` after generating `dist/release-manifest.json` is intentionally invalid because Twine only accepts Python distribution artifacts. CI runs `twine check dist/*` before manifest generation, and local verification uses `twine check dist/*.whl dist/*.tar.gz` after manifest generation.
