### PR TITLE
provider(manifest): export Pinares FD evidence sidecar

### DIFF
--- a/scripts/export_pinares_fixed_price_proxy_fixture.py
+++ b/scripts/export_pinares_fixed_price_proxy_fixture.py
@@ -6,24 +6,33 @@ import json
 from pathlib import Path
 
 from finite_difference_options.validation.pinares_fixed_price_proxy import (
+    build_pinares_fd_provider_evidence_manifest,
     export_public_pinares_fixed_price_proxy_fixture_json,
     public_pinares_fixed_price_problem_spec,
+    run_public_pinares_fixed_price_proxy_fixture,
 )
 
 DEFAULT_RESULT_FIXTURE_PATH = Path("tests/fixtures/pinares_fd_fixed_price_proxy_v1.json")
 DEFAULT_QPS_FIXTURE_PATH = Path("tests/fixtures/quant_problem_specs/pinares_fixed_price_proxy.json")
+DEFAULT_PROVIDER_MANIFEST_PATH = Path("tests/fixtures/pinares_fd_provider_evidence_manifest_v1.json")
 
 
 def main() -> None:
     """Regenerate checked-in public-synthetic Pinares fixture JSON files."""
 
     result_output = export_public_pinares_fixed_price_proxy_fixture_json(path=DEFAULT_RESULT_FIXTURE_PATH)
+    report = run_public_pinares_fixed_price_proxy_fixture()
     DEFAULT_QPS_FIXTURE_PATH.write_text(
         json.dumps(public_pinares_fixed_price_problem_spec(), indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
+    DEFAULT_PROVIDER_MANIFEST_PATH.write_text(
+        json.dumps(build_pinares_fd_provider_evidence_manifest(report), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
     print(result_output)
     print(DEFAULT_QPS_FIXTURE_PATH)
+    print(DEFAULT_PROVIDER_MANIFEST_PATH)
 
 
 if __name__ == "__main__":

--- a/src/finite_difference_options/validation/pinares_fixed_price_proxy.py
+++ b/src/finite_difference_options/validation/pinares_fixed_price_proxy.py
@@ -510,6 +510,98 @@ def export_public_pinares_fixed_price_proxy_fixture_json(
     return output_path
 
 
+def build_pinares_fd_provider_evidence_manifest(
+    report: PinaresFixedPriceProxyReport | None = None,
+) -> dict[str, Any]:
+    """Return dashboard-consumable FD provider evidence for the Pinares proxy route.
+
+    The manifest is intentionally route evidence only: it summarizes the public-
+    synthetic deterministic fixed-price option proxy, exposes accuracy/resource
+    budgets, and states fail-closed boundaries for the real Pinares family deal.
+    """
+
+    active_report = report or run_public_pinares_fixed_price_proxy_fixture()
+    manifest = DEFAULT_FD_CAPABILITY_MANIFEST
+    case = active_report.case
+    resource_controls = dict(active_report.evidence.resource_controls)
+    error_budgets = {
+        "price_abs_uf": case.price_abs_tolerance_uf,
+        "delta_abs": case.delta_abs_tolerance,
+        "gamma_abs": case.gamma_abs_tolerance,
+    }
+    return {
+        "schema": "pinares.provider_evidence_manifest.v1",
+        "producer": "finite_difference_options",
+        "provider_role": "deterministic-pde-provider",
+        "issue_refs": ["googa27/finite_difference_options#135"],
+        "project_ref": "googa27#19",
+        "privacy_class": "public_synthetic",
+        "evidence_class": "deterministic_proxy_not_full_family_contract_valuation",
+        "problem": {
+            "problem_id": case.problem_id,
+            "problem_hash": case.problem_hash,
+            "fixture_id": case.fixture_id,
+            "measure": "Q*",
+            "numeraire": "UF_money_market_account_proxy",
+            "valuation_date": case.valuation_date,
+            "maturity_date": case.maturity_date,
+            "units": case.normalized_units(),
+        },
+        "fixture_refs": {
+            "quant_problem_spec": "tests/fixtures/quant_problem_specs/pinares_fixed_price_proxy.json",
+            "result_export": "tests/fixtures/pinares_fd_fixed_price_proxy_v1.json",
+            "provider_evidence_manifest": "tests/fixtures/pinares_fd_provider_evidence_manifest_v1.json",
+        },
+        "capability_manifest": {
+            "backend_id": manifest.backend_id,
+            "contract_version": manifest.contract_version,
+            "status": manifest.status.value,
+            "feature_support": dict(manifest.feature_support),
+            "diagnostics": list(manifest.diagnostics),
+        },
+        "route": {
+            "route_id": case.route_id,
+            "method_kind": "finite_difference",
+            "grid_type": "uniform",
+            "time_integrator": "theta_crank_nicolson",
+            "theta": 0.5,
+            "boundary_convention": "Dirichlet at S=0; linear-growth far-field at S_max",
+            "state_dimension": 1,
+            "requested_outputs": ["value", "delta", "gamma"],
+        },
+        "resource_controls": resource_controls,
+        "error_budgets": error_budgets,
+        "parity_metrics": {
+            "price_abs_uf": active_report.errors["price_abs"],
+            "price_rel": active_report.errors["price_rel"],
+            "delta_abs": active_report.errors["delta_abs"],
+            "gamma_abs": active_report.errors["gamma_abs"],
+            "converged": active_report.converged,
+            "no_arbitrage": active_report.no_arbitrage,
+        },
+        "performance_sidecar": {
+            "runtime": {"seconds": None, "policy": "deterministic fixture omits wall-clock timing"},
+            "operator_factorization_cache": manifest.resource_controls.get("operator_factorization_cache"),
+            "max_grid": {
+                "s_steps": max(level[0] for level in active_report.grid_levels),
+                "t_steps": max(level[1] for level in active_report.grid_levels),
+            },
+        },
+        "unsupported_routes": {
+            "rofr": "fail_closed",
+            "full_family_contract": "fail_closed",
+            "legal_tax_conclusion": "fail_closed",
+            "liquidity_default": "fail_closed",
+            "market_rent_alternative": "fail_closed",
+        },
+        "limitations": [
+            "fixed-price proxy only; ROFR is not a vanilla call",
+            "public-synthetic fixture only; no private family facts or PDP rows",
+            "FD backend supplies numerical route evidence, not legal/tax advice",
+        ],
+    }
+
+
 def _config_hash(case: PinaresFixedPriceProxyCase, grid_levels: tuple[tuple[int, int], ...]) -> str:
     payload = {
         "fixture_id": case.fixture_id,
@@ -541,6 +633,7 @@ __all__ = [
     "PINARES_QPS_CONTRACT_BENCHMARK_ID",
     "PinaresFixedPriceProxyCase",
     "PinaresFixedPriceProxyReport",
+    "build_pinares_fd_provider_evidence_manifest",
     "export_public_pinares_fixed_price_proxy_fixture_json",
     "public_pinares_fixed_price_problem_spec",
     "public_pinares_full_deal_unsupported_problem_spec",

--- a/tests/fixtures/pinares_fd_provider_evidence_manifest_v1.json
+++ b/tests/fixtures/pinares_fd_provider_evidence_manifest_v1.json
@@ -1,0 +1,124 @@
+{
+  "capability_manifest": {
+    "backend_id": "finite_difference_options.fd_backend.v0",
+    "contract_version": "0.1.0",
+    "diagnostics": [
+      "unsupported dimension",
+      "unsupported PDE term",
+      "unsupported boundary condition",
+      "unsupported exercise style",
+      "obstacle/complementarity diagnostics",
+      "missing measure/numeraire/units/date convention"
+    ],
+    "feature_support": {
+      "american_black_scholes_lcp": "validated",
+      "bermudan_black_scholes_lcp": "validated",
+      "hjb_control": "unsupported",
+      "jump_integral": "unsupported",
+      "mixed_derivative": "experimental",
+      "multidimensional_american_lcp": "experimental",
+      "obstacle_lcp": "validated",
+      "one_dimensional_generator_pde": "validated",
+      "operator_factorization_cache": "validated",
+      "pinares_fixed_price_proxy": "validated",
+      "released_public_solver_contract": "validated",
+      "rofr_full_family_contract": "unsupported"
+    },
+    "status": "validated"
+  },
+  "error_budgets": {
+    "delta_abs": 0.001,
+    "gamma_abs": 5e-06,
+    "price_abs_uf": 1.0
+  },
+  "evidence_class": "deterministic_proxy_not_full_family_contract_valuation",
+  "fixture_refs": {
+    "provider_evidence_manifest": "tests/fixtures/pinares_fd_provider_evidence_manifest_v1.json",
+    "quant_problem_spec": "tests/fixtures/quant_problem_specs/pinares_fixed_price_proxy.json",
+    "result_export": "tests/fixtures/pinares_fd_fixed_price_proxy_v1.json"
+  },
+  "issue_refs": [
+    "googa27/finite_difference_options#135"
+  ],
+  "limitations": [
+    "fixed-price proxy only; ROFR is not a vanilla call",
+    "public-synthetic fixture only; no private family facts or PDP rows",
+    "FD backend supplies numerical route evidence, not legal/tax advice"
+  ],
+  "parity_metrics": {
+    "converged": true,
+    "delta_abs": 8.842159257821391e-05,
+    "gamma_abs": 1.7468969201214594e-06,
+    "no_arbitrage": {
+      "delta_lower_bound_ok": true,
+      "delta_upper_bound_ok": true,
+      "gamma_non_negative_ok": true,
+      "survival_scale_ok": true,
+      "upper_bound_ok": true,
+      "upper_gap_uf": 5587.899061209176,
+      "value_bound_ok": true,
+      "value_minus_intrinsic_uf": 232.10093879082405
+    },
+    "price_abs_uf": 0.3014449648889274,
+    "price_rel": 0.0013004556649950714
+  },
+  "performance_sidecar": {
+    "max_grid": {
+      "s_steps": 180,
+      "t_steps": 240
+    },
+    "operator_factorization_cache": "enabled_for_public_black_scholes_and_pinares_proxy",
+    "runtime": {
+      "policy": "deterministic fixture omits wall-clock timing",
+      "seconds": null
+    }
+  },
+  "privacy_class": "public_synthetic",
+  "problem": {
+    "fixture_id": "public-synthetic.pinares-fixed-price-proxy.v1",
+    "maturity_date": "2027-06-30",
+    "measure": "Q*",
+    "numeraire": "UF_money_market_account_proxy",
+    "problem_hash": "publicsyntheticpinares001",
+    "problem_id": "pinares.fixed_price_option_proxy.v1",
+    "units": {
+      "S": "UF",
+      "rate": "1/year",
+      "time": "year",
+      "underlying": "UF",
+      "value": "UF"
+    },
+    "valuation_date": "2026-06-30"
+  },
+  "producer": "finite_difference_options",
+  "project_ref": "googa27#19",
+  "provider_role": "deterministic-pde-provider",
+  "resource_controls": {
+    "deterministic": "true",
+    "grid_levels": 3,
+    "max_s_steps": 180,
+    "max_t_steps": 240
+  },
+  "route": {
+    "boundary_convention": "Dirichlet at S=0; linear-growth far-field at S_max",
+    "grid_type": "uniform",
+    "method_kind": "finite_difference",
+    "requested_outputs": [
+      "value",
+      "delta",
+      "gamma"
+    ],
+    "route_id": "fd.pinares_fixed_price_proxy.crank_nicolson",
+    "state_dimension": 1,
+    "theta": 0.5,
+    "time_integrator": "theta_crank_nicolson"
+  },
+  "schema": "pinares.provider_evidence_manifest.v1",
+  "unsupported_routes": {
+    "full_family_contract": "fail_closed",
+    "legal_tax_conclusion": "fail_closed",
+    "liquidity_default": "fail_closed",
+    "market_rent_alternative": "fail_closed",
+    "rofr": "fail_closed"
+  }
+}

--- a/tests/test_pinares_fd_proxy.py
+++ b/tests/test_pinares_fd_proxy.py
@@ -24,6 +24,7 @@ from finite_difference_options.validation.pinares_fixed_price_proxy import (
     PINARES_FIXED_PRICE_PROXY_ROUTE_ID,
     PINARES_QPS_CONTRACT_BENCHMARK_ID,
     PinaresFixedPriceProxyCase,
+    build_pinares_fd_provider_evidence_manifest,
     public_pinares_fixed_price_problem_spec,
     public_pinares_full_deal_unsupported_problem_spec,
     run_public_pinares_fixed_price_proxy_fixture,
@@ -32,6 +33,7 @@ from finite_difference_options.validation.pinares_fixed_price_proxy import (
 FIXTURE_DIR = pathlib.Path(__file__).resolve().parent / "fixtures"
 QPS_FIXTURE = FIXTURE_DIR / "quant_problem_specs" / "pinares_fixed_price_proxy.json"
 RESULT_FIXTURE = FIXTURE_DIR / "pinares_fd_fixed_price_proxy_v1.json"
+PROVIDER_MANIFEST_FIXTURE = FIXTURE_DIR / "pinares_fd_provider_evidence_manifest_v1.json"
 
 
 def _load_qps_fixture() -> dict[str, Any]:
@@ -128,16 +130,41 @@ def test_pinares_problem_spec_uses_requested_grid_levels_in_resource_controls() 
 def test_pinares_static_fixtures_match_generated_contracts() -> None:
     qps_cached = _load_qps_fixture()
     result_cached = json.loads(RESULT_FIXTURE.read_text(encoding="utf-8"))
+    provider_manifest_cached = json.loads(PROVIDER_MANIFEST_FIXTURE.read_text(encoding="utf-8"))
     report = run_public_pinares_fixed_price_proxy_fixture()
 
     assert qps_cached == public_pinares_fixed_price_problem_spec()
     assert result_cached == json.loads(json.dumps(report.as_dict()))
+    assert provider_manifest_cached == build_pinares_fd_provider_evidence_manifest(report)
     assert qps_cached["solver_plan"]["error_budgets"] == {
         "delta_abs": 1.0e-3,
         "gamma_abs": 5.0e-6,
         "price_abs_uf": 1.0,
     }
     assert result_cached["unsupported_scope"]["rofr"].startswith("unsupported")
+
+
+def test_pinares_fd_provider_evidence_manifest_reports_dashboard_sidecar_fields() -> None:
+    report = run_public_pinares_fixed_price_proxy_fixture()
+    manifest = build_pinares_fd_provider_evidence_manifest(report)
+
+    assert manifest["schema"] == "pinares.provider_evidence_manifest.v1"
+    assert manifest["producer"] == "finite_difference_options"
+    assert manifest["privacy_class"] == "public_synthetic"
+    assert manifest["issue_refs"] == ["googa27/finite_difference_options#135"]
+    assert manifest["evidence_class"] == "deterministic_proxy_not_full_family_contract_valuation"
+    assert manifest["capability_manifest"]["backend_id"] == DEFAULT_FD_CAPABILITY_MANIFEST.backend_id
+    assert manifest["capability_manifest"]["contract_version"] == DEFAULT_FD_CAPABILITY_MANIFEST.contract_version
+    assert manifest["route"]["route_id"] == PINARES_FIXED_PRICE_PROXY_ROUTE_ID
+    assert manifest["route"]["method_kind"] == "finite_difference"
+    assert manifest["route"]["boundary_convention"] == "Dirichlet at S=0; linear-growth far-field at S_max"
+    assert manifest["resource_controls"]["max_s_steps"] == 180
+    assert manifest["performance_sidecar"]["runtime"]["seconds"] is None
+    assert manifest["performance_sidecar"]["operator_factorization_cache"] == (
+        "enabled_for_public_black_scholes_and_pinares_proxy"
+    )
+    assert manifest["parity_metrics"]["price_abs_uf"] <= manifest["error_budgets"]["price_abs_uf"]
+    assert manifest["unsupported_routes"]["full_family_contract"] == "fail_closed"
 
 
 def test_pinares_registered_benchmarks_execute_and_fail_closed() -> None:


### PR DESCRIPTION
## Summary
- add `build_pinares_fd_provider_evidence_manifest()` for the deterministic FD Pinares fixed-price proxy
- export `tests/fixtures/pinares_fd_provider_evidence_manifest_v1.json`
- include capability-manifest summary, route/boundary convention, resource controls, parity metrics, performance sidecar, and fail-closed unsupported routes

## Scope guard
- public-synthetic fixed-price option proxy only
- ROFR, full family contract, legal/tax conclusion, liquidity/default, and market-rent alternatives remain fail-closed

## Verification
- `uv run pytest -q tests/test_pinares_fd_proxy.py` -> 11 passed, 54 warnings
- targeted `uv run ruff check scripts/export_pinares_fixed_price_proxy_fixture.py src/finite_difference_options/validation/pinares_fixed_price_proxy.py tests/test_pinares_fd_proxy.py` -> passed
- targeted `uv run ruff format --check ...` after formatting -> passed
- `uv run pytest -q` -> 378 passed, 247 warnings

## Known pre-existing repo gate
- full `uv run ruff check .` still reports unrelated pre-existing lint in `.agent_workspace/`, `build/lib/`, and older tests/source; this PR's changed files pass targeted ruff.

Closes #135
