### PR TITLE
chore: adopt portfolio engineering constitution

### DIFF
--- a/.github/workflows/portfolio-architecture.yml
+++ b/.github/workflows/portfolio-architecture.yml
@@ -1,0 +1,20 @@
+name: Portfolio Architecture
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  architecture-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: '3.12'
+      - name: Validate portfolio architecture contract
+        run: python scripts/check_portfolio_architecture.py

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,8 @@ __pycache__/
 .ipynb_checkpoints/
 .venv
 venv
+*.egg-info/
+build/
+.coverage
 node_modules/
 .next/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,3 +279,52 @@ Before review, confirm:
 *This file is the canonical Finite Difference Options contributor and agent contract.*
 
 - Package topology changes must update `docs/architecture_contract.toml`, `docs/ARCHITECTURE.md`, architecture tests, and `scripts/check_architecture_contract.py` architecture contract gate in the same PR.
+
+<!-- PORTFOLIO-CONSTITUTION:START -->
+## Portfolio engineering constitution
+
+This repository follows [Portfolio Project #24](https://github.com/users/googa27/projects/24) and [finite_difference_options rollout issue](https://github.com/googa27/finite_difference_options/issues/139). A repository-specific, evidence-backed exception in `docs/ARCHITECTURE.yaml` may specialize a rule; undocumented drift is not an exception.
+
+### Research and maintained-library preference
+
+- Research domain theory, maintained libraries, standards, interfaces, datasets, licenses, adjacent repositories, and probable extension paths before design or implementation.
+- **Maintained-library preference:** use well-maintained libraries for solved algorithms, protocols, parsers, persistence, orchestration, dataframes, numerical methods, and security controls instead of implementing them from scratch. Record capability, selected library, alternatives, maintenance/API/license evidence, adapter boundary, and any custom-code justification.
+- Custom code belongs to domain semantics, composition, adapters/contracts, or genuinely missing algorithms and must be tested against an oracle/reference.
+- Turn reusable findings into maintained Hermes skills and concise support files. Add a plugin or MCP server only when stable CLI/contracts have multiple measured consumers or real interoperable external-tool needs.
+
+### Clean and evolutionary architecture
+
+After the dependency route is sound, apply SOLID, DRY knowledge ownership, suitable design patterns, explicit dependencies, low coupling, cohesive modules, extensibility, maintainability, and technical-debt minimization. Design for probable extensions, not speculative frameworks. Every meaningful change reduces named debt or adds an executable fitness function.
+
+`docs/ARCHITECTURE.yaml` is the machine-readable source of truth. Update it in the same change as architecture, public API, test, CI, data, AI-interface, or exception changes.
+
+- At each Python `src/` level, count immediate runtime `.py` files and package directories, excluding `__init__.py` and architecture/readme/typing metadata. Default maximum: 10. Deepen hierarchy around stable responsibilities instead of widening it.
+- Default Python module maximum: 500 physical lines. Larger legacy files are exact no-growth exceptions with reason, owner/context, risk, accepted ceiling, and refactoring trigger.
+- Keep `tests/unit`, `tests/integration`, `tests/e2e`, and `tests/architecture`; mirror source where useful. Empty suites document their intended boundary and activation trigger.
+- Architecture tests enforce the YAML contract, source fan-out, module-size ratchets, exception metadata, required docs/suites, and repository-specific import/public-API rules.
+
+### Two first-class users
+
+1. **Hermes Agent and compatible agents:** this concise root file, deterministic CLI/public contracts, exact verification commands, and capability discovery are the baseline. Skills encode recurring procedures. Plugins/MCP are optional escalation layers, never substitutes for a stable public interface; mutation tools must be explicit, typed, least-privileged, and separately verifiable.
+2. **Human programmer/notebook user:** provide a typed, documented importable API independent of CLI/UI internals and deterministic public-synthetic notebook examples where the repository is a library. Use only lawful Python protocols: compact `__repr__`, value equality/hash for deeply immutable objects, true collection/context/NumPy protocols, and pure IPython display hooks. Prefer named methods for policy, configuration, I/O, diagnostics, expensive/stateful behavior, or ambiguous mathematics. Test every claimed algebraic law and named-method/operator parity.
+
+### Data and core-repository boundaries
+
+For data-consuming work, design `source registry -> typed acquisition -> immutable Bronze -> canonical Silver -> curated Gold/features -> formulation/model -> governed output -> read-only UI/API/notebook` before implementation. Record grain, units, classification, lineage, quality, freshness/vintage/effective time, identity, replay, and validation.
+
+- `PDP` owns reusable/public data acquisition and products.
+- `financial_problem_formulations` owns general problem/formulation/formula/workflow semantics.
+- `ui_and_artifacts` owns reusable audience-aware rendering and artifact QA.
+- Consume stable public contracts/CLIs, not repository internals. Keep canonical names theoretical/general rather than deal/product-specific.
+
+Repository posture: Consume FPF contracts; avoid PDP/UI runtime dependencies; emit SolverRunEvidence/ModelOutput bundles. Data posture: No data ownership; fixture inputs are public-synthetic and content-addressed.
+
+### Exact commands
+
+- Setup: `python -m pip install -e '.[dev]'`
+- Tests: `python -m pytest -q`
+- Lint/format: `ruff check . && ruff format --check .`
+- Portfolio architecture: `python scripts/check_portfolio_architecture.py`
+
+If a command is declared unavailable, the activation trigger and replacement command belong in `docs/ARCHITECTURE.yaml`; do not fabricate successful output.
+<!-- PORTFOLIO-CONSTITUTION:END -->

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -533,3 +533,43 @@ No compatibility shim may become a second implementation. The policy below is th
 ---
 
 *End of canonical Finite Difference Options architecture specification.*
+
+<!-- PORTFOLIO-CONSTITUTION:START -->
+## Portfolio architecture baseline
+
+Source of truth: `docs/ARCHITECTURE.yaml`. Tracking: [Project #24](https://github.com/users/googa27/projects/24), [finite_difference_options issue](https://github.com/googa27/finite_difference_options/issues/139). Profile: `strict`; enforcement: `Blocking`.
+
+### Research-backed defaults
+
+| Decision | Evidence | Repository application |
+|---|---|---|
+| Agent context | [Hermes context files](https://hermes-agent.nousresearch.com/docs/user-guide/features/context-files), [AGENTS.md](https://agents.md/) | Root `AGENTS.md`; progressive detail stays in linked docs. |
+| AI tool escalation | [MCP tools specification](https://modelcontextprotocol.io/specification/2025-06-18/server/tools) | Stable CLI/contracts and skills first; plugin/MCP only after measured need and least-privilege review. |
+| Python source layout | [PyPA src layout](https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/) | Declared Python roots: `src`. |
+| Test layout | [pytest good practices](https://docs.pytest.org/en/stable/explanation/goodpractices.html) | Unit/integration/e2e/architecture boundaries are explicit. |
+| Module budget | [Pylint too-many-lines rationale](https://pylint.readthedocs.io/en/latest/user_guide/messages/convention/too-many-lines.html) plus AI review locality | 500 physical lines is stricter than Pylint's broad default; existing excess is a no-growth ratchet. |
+| Evolution | [Evolutionary architecture](https://evolutionaryarchitecture.com/precis.html) | Architecture characteristics have executable fitness functions and incremental exceptions. |
+| Data layers | [Medallion architecture](https://learn.microsoft.com/en-us/azure/databricks/lakehouse/medallion) | Applied only where data is consumed; simple repos record an explicit non-use decision. |
+| Python protocols | [Python data model](https://docs.python.org/3/reference/datamodel.html), [NumPy dispatch](https://numpy.org/doc/stable/user/basics.dispatch.html) | Dunders express true protocols/laws; named methods own policy and effects. |
+
+### Maintained-library decision table
+
+| Capability | Selected route | Alternatives | Boundary / custom-code rule |
+|---|---|---|---|
+| Existing runtime stack | `findiff`, `numpy`, `pydantic`, `scipy` | Reimplementation from scratch | Preserve public adapters; research maintenance/API/license before additions. |
+| Architecture contract bootstrap | Python standard-library JSON parser over the JSON subset of YAML 1.2 | Hand-written YAML parser; mandatory platform service | Repo-local dependency-free structural gate; richer maintained tools remain repo-specific. |
+| Import/dependency rules | Existing repo lint/import tools where configured; declarative YAML boundary is authoritative | Custom import framework | Keep custom AST checks narrow; use maintained Import Linter/Tach/Ruff/deptry when warranted. |
+| AI interaction | AGENTS + deterministic CLI/contracts + capability discovery + skills | MCP/plugin in every repo | Escalate only after measured interoperability/lifecycle need. |
+
+### Two-user design
+
+- AI: AGENTS + solver CLI/capability matrix + maintained Hermes skill; MCP only for demonstrated cross-client dispatch.
+- Human/notebook: Typed solver API and notebook examples; array/grid protocols only when NumPy semantics are exact; named solve/price/validate methods remain primary.
+- Planned Python protocols: Immutable grids/specs/results: deterministic __repr__ and value equality where arrays are compared explicitly.; Grid/result collections may use __iter__/__len__; pure payoff/operator objects may use __call__.; Solving, calibration, boundary policy, I/O, and diagnostics stay named methods; avoid lossy array coercion.
+- Core posture: Consume FPF contracts; avoid PDP/UI runtime dependencies; emit SolverRunEvidence/ModelOutput bundles.
+- Data posture: No data ownership; fixture inputs are public-synthetic and content-addressed.
+
+### Extension and exception discipline
+
+Probable extensions must cross named ports/capability registries rather than adding sibling modules indefinitely. Every exception is exact, risk-bearing, no-growth, and has a refactoring trigger. Generated/vendor/migration/resource paths are declared explicitly; they do not silently weaken runtime rules.
+<!-- PORTFOLIO-CONSTITUTION:END -->

--- a/docs/ARCHITECTURE.yaml
+++ b/docs/ARCHITECTURE.yaml
@@ -1,0 +1,277 @@
+{
+  "schema_version": "1.0.0",
+  "repository": {
+    "owner": "googa27",
+    "name": "finite_difference_options",
+    "profile": "strict",
+    "status": "Solver Library",
+    "project": "https://github.com/users/googa27/projects/24",
+    "issue": "https://github.com/googa27/finite_difference_options/issues/139"
+  },
+  "architecture": {
+    "style": "evolutionary, contract-first, repository-specific",
+    "layers": [],
+    "import_boundaries": {
+      "authority": "repository-specific existing gates plus this contract",
+      "forbidden": [],
+      "cycle_policy": "acyclic runtime layers unless an exact exception is recorded"
+    },
+    "public_api_paths": [
+      "src/finite_difference_options"
+    ],
+    "extension_points": [
+      "typed public APIs",
+      "deterministic CLI/contracts",
+      "capability registry",
+      "adapters behind explicit protocols"
+    ]
+  },
+  "source_layout": {
+    "python_rules_applicable": true,
+    "python_source_roots": [
+      "src"
+    ],
+    "metadata_names": [
+      "ARCHITECTURE.md",
+      "ARCHITECTURE.yaml",
+      "README.md",
+      "__init__.py",
+      "py.typed"
+    ],
+    "allowed_non_python_files": [],
+    "future_rule": "Any new Python package uses a src layout unless an evidence-backed exception is approved."
+  },
+  "limits": {
+    "max_immediate_runtime_entries": 10,
+    "max_python_module_lines": 500,
+    "measurement": "physical UTF-8 lines; immediate runtime .py files excluding __init__.py plus runtime package directories"
+  },
+  "libraries": {
+    "selection_policy": "Prefer well-maintained libraries; record maintenance/API/license evidence and adapter boundary before custom implementation.",
+    "decisions": [
+      {
+        "capability": "existing runtime stack",
+        "selected": [
+          "findiff",
+          "numpy",
+          "pydantic",
+          "scipy"
+        ],
+        "alternatives": [
+          "custom reimplementation"
+        ],
+        "evidence": "pyproject.toml/package.json/requirements and docs/ARCHITECTURE.md",
+        "adapter_boundary": "repository public ports",
+        "custom_code_reason": "domain semantics, composition, adapters, or genuinely missing algorithms only"
+      },
+      {
+        "capability": "portfolio architecture bootstrap",
+        "selected": [
+          "Python standard library JSON parser",
+          "JSON-compatible YAML 1.2 contract"
+        ],
+        "alternatives": [
+          "hand-written YAML parser",
+          "mandatory remote governance service"
+        ],
+        "evidence": "docs/ARCHITECTURE.md",
+        "adapter_boundary": "scripts/check_portfolio_architecture.py",
+        "custom_code_reason": "narrow repository-specific fitness function not supplied by a maintained generic package"
+      }
+    ]
+  },
+  "interfaces": {
+    "ai": {
+      "primary_agent": "Hermes Agent",
+      "context_file": "AGENTS.md",
+      "interaction": "AGENTS + solver CLI/capability matrix + maintained Hermes skill; MCP only for demonstrated cross-client dispatch.",
+      "capability_discovery": "Existing deterministic entrypoints: fd-options",
+      "skills": "Use/update a repo or class-level Hermes skill for recurring non-trivial workflows",
+      "plugin_mcp_policy": "deferred unless stable interfaces and measured multi-client/tool interoperability justify it",
+      "declared_entrypoints": [
+        "fd-options"
+      ],
+      "decision_ladder": [
+        "AGENTS.md and linked contracts",
+        "typed importable API and deterministic CLI/capability manifest",
+        "Hermes skill for recurring procedures",
+        "plugin only for measured shared lifecycle/tool needs",
+        "MCP only for measured interoperable multi-client remote discovery"
+      ],
+      "mutation_safety": "Mutation is explicit, typed, least-privileged, human-reviewable, and independently verified; no autonomous public side effects by default."
+    },
+    "human": {
+      "interaction": "Typed solver API and notebook examples; array/grid protocols only when NumPy semantics are exact; named solve/price/validate methods remain primary.",
+      "public_api_paths": [
+        "src/finite_difference_options"
+      ],
+      "notebook_policy": "deterministic public-synthetic notebook/example for active libraries; explicit inapplicable/revival decision otherwise",
+      "dunder_policy": "Only documented lawful Python/NumPy/IPython protocols with algebraic/parity tests; named methods for policy, effects, diagnostics, I/O, or ambiguity",
+      "dunder_plan": [
+        "Immutable grids/specs/results: deterministic __repr__ and value equality where arrays are compared explicitly.",
+        "Grid/result collections may use __iter__/__len__; pure payoff/operator objects may use __call__.",
+        "Solving, calibration, boundary policy, I/O, and diagnostics stay named methods; avoid lossy array coercion."
+      ],
+      "forbidden_dunders": [
+        "Ambiguous arithmetic/order",
+        "Stateful or effectful operators",
+        "Lossy implicit conversion",
+        "Dunders that hide policy, I/O, diagnostics, or failure modes"
+      ]
+    }
+  },
+  "tests": {
+    "required_suites": [
+      "unit",
+      "integration",
+      "e2e",
+      "architecture"
+    ],
+    "commands": {
+      "setup": "python -m pip install -e '.[dev]'",
+      "test": "python -m pytest -q",
+      "lint": "ruff check . && ruff format --check .",
+      "architecture": "python scripts/check_portfolio_architecture.py"
+    },
+    "ci_workflow": ".github/workflows/portfolio-architecture.yml",
+    "mirror_source": "where pertinent"
+  },
+  "data": {
+    "consumes_data": true,
+    "architecture": "No data ownership; fixture inputs are public-synthetic and content-addressed.",
+    "required_controls": [
+      "source registry",
+      "typed contracts",
+      "classification",
+      "lineage",
+      "quality",
+      "freshness/vintage/effective time",
+      "content identity",
+      "replay",
+      "validation"
+    ],
+    "core_repositories": {
+      "PDP": "Consume FPF contracts; avoid PDP/UI runtime dependencies; emit SolverRunEvidence/ModelOutput bundles.",
+      "financial_problem_formulations": "Consume FPF contracts; avoid PDP/UI runtime dependencies; emit SolverRunEvidence/ModelOutput bundles.",
+      "ui_and_artifacts": "Consume FPF contracts; avoid PDP/UI runtime dependencies; emit SolverRunEvidence/ModelOutput bundles."
+    },
+    "source_registry_plan": [
+      "typed solver requests and public-synthetic oracle/convergence fixtures"
+    ],
+    "flow": "source registry -> typed acquisition -> immutable Bronze -> canonical Silver -> curated Gold/features -> formulation/model -> governed output -> read-only UI/API/notebook",
+    "storage_and_replay": "Immutable raw/content-addressed inputs; canonical typed products; idempotent replay by source identity and effective/vintage time where applicable.",
+    "quality_and_lineage": "Validate schema, grain, units, classification, lineage, freshness, licence, and content identity before consumption; fail closed on missing evidence."
+  },
+  "governance": {
+    "architecture_source": "docs/ARCHITECTURE.yaml",
+    "update_rule": "Update contract, prose, AGENTS, tests, CI, AI/human interfaces, and public API in the same change.",
+    "checker": "scripts/check_portfolio_architecture.py",
+    "required_documents": [
+      "AGENTS.md",
+      "docs/ARCHITECTURE.yaml",
+      "docs/ARCHITECTURE.md"
+    ],
+    "exception_policy": "exact scope, reason, owner, risk, accepted ceiling, and refactoring trigger; no-growth ratchet"
+  },
+  "exceptions": [
+    {
+      "rule": "source_fanout",
+      "path": "src/finite_difference_options",
+      "reason": "Legacy package fan-out predates the portfolio ratchet; immediate restructuring would create broad compatibility risk.",
+      "owner": "googa27 Portfolio Project #24",
+      "risk": "Navigation and coupling remain higher until cohesive subpackages are extracted.",
+      "accepted_ceiling": 17,
+      "refactoring_trigger": "The next feature that would add an immediate runtime entry must first reduce this level to 10 or document a narrower approved replacement exception."
+    },
+    {
+      "rule": "python_module_max_lines",
+      "path": "src/finite_difference_options/api/main.py",
+      "reason": "Legacy cohesive/compatibility surface exceeds the new maintainability budget and requires staged extraction rather than a blind split.",
+      "owner": "googa27 Portfolio Project #24",
+      "risk": "Large context increases change blast radius, review cost, and AI/human navigation burden.",
+      "accepted_ceiling": 1448,
+      "refactoring_trigger": "The file may not grow; the next behavioral change must extract a cohesive responsibility behind compatibility tests or reduce the accepted ceiling."
+    },
+    {
+      "rule": "python_module_max_lines",
+      "path": "src/finite_difference_options/contracts/backend_capabilities.py",
+      "reason": "Legacy cohesive/compatibility surface exceeds the new maintainability budget and requires staged extraction rather than a blind split.",
+      "owner": "googa27 Portfolio Project #24",
+      "risk": "Large context increases change blast radius, review cost, and AI/human navigation burden.",
+      "accepted_ceiling": 546,
+      "refactoring_trigger": "The file may not grow; the next behavioral change must extract a cohesive responsibility behind compatibility tests or reduce the accepted ceiling."
+    },
+    {
+      "rule": "python_module_max_lines",
+      "path": "src/finite_difference_options/pricing/engines/finite_difference.py",
+      "reason": "Legacy cohesive/compatibility surface exceeds the new maintainability budget and requires staged extraction rather than a blind split.",
+      "owner": "googa27 Portfolio Project #24",
+      "risk": "Large context increases change blast radius, review cost, and AI/human navigation burden.",
+      "accepted_ceiling": 713,
+      "refactoring_trigger": "The file may not grow; the next behavioral change must extract a cohesive responsibility behind compatibility tests or reduce the accepted ceiling."
+    },
+    {
+      "rule": "python_module_max_lines",
+      "path": "src/finite_difference_options/pricing/instruments/options.py",
+      "reason": "Legacy cohesive/compatibility surface exceeds the new maintainability budget and requires staged extraction rather than a blind split.",
+      "owner": "googa27 Portfolio Project #24",
+      "risk": "Large context increases change blast radius, review cost, and AI/human navigation burden.",
+      "accepted_ceiling": 539,
+      "refactoring_trigger": "The file may not grow; the next behavioral change must extract a cohesive responsibility behind compatibility tests or reduce the accepted ceiling."
+    },
+    {
+      "rule": "python_module_max_lines",
+      "path": "src/finite_difference_options/processes/base.py",
+      "reason": "Legacy cohesive/compatibility surface exceeds the new maintainability budget and requires staged extraction rather than a blind split.",
+      "owner": "googa27 Portfolio Project #24",
+      "risk": "Large context increases change blast radius, review cost, and AI/human navigation burden.",
+      "accepted_ceiling": 641,
+      "refactoring_trigger": "The file may not grow; the next behavioral change must extract a cohesive responsibility behind compatibility tests or reduce the accepted ceiling."
+    },
+    {
+      "rule": "python_module_max_lines",
+      "path": "src/finite_difference_options/solvers/adi.py",
+      "reason": "Legacy cohesive/compatibility surface exceeds the new maintainability budget and requires staged extraction rather than a blind split.",
+      "owner": "googa27 Portfolio Project #24",
+      "risk": "Large context increases change blast radius, review cost, and AI/human navigation burden.",
+      "accepted_ceiling": 627,
+      "refactoring_trigger": "The file may not grow; the next behavioral change must extract a cohesive responsibility behind compatibility tests or reduce the accepted ceiling."
+    },
+    {
+      "rule": "python_module_max_lines",
+      "path": "src/finite_difference_options/solvers/finite_difference.py",
+      "reason": "Legacy cohesive/compatibility surface exceeds the new maintainability budget and requires staged extraction rather than a blind split.",
+      "owner": "googa27 Portfolio Project #24",
+      "risk": "Large context increases change blast radius, review cost, and AI/human navigation burden.",
+      "accepted_ceiling": 749,
+      "refactoring_trigger": "The file may not grow; the next behavioral change must extract a cohesive responsibility behind compatibility tests or reduce the accepted ceiling."
+    },
+    {
+      "rule": "python_module_max_lines",
+      "path": "src/finite_difference_options/validation/benchmark_registry.py",
+      "reason": "Legacy cohesive/compatibility surface exceeds the new maintainability budget and requires staged extraction rather than a blind split.",
+      "owner": "googa27 Portfolio Project #24",
+      "risk": "Large context increases change blast radius, review cost, and AI/human navigation burden.",
+      "accepted_ceiling": 1570,
+      "refactoring_trigger": "The file may not grow; the next behavioral change must extract a cohesive responsibility behind compatibility tests or reduce the accepted ceiling."
+    },
+    {
+      "rule": "python_module_max_lines",
+      "path": "src/finite_difference_options/validation/black_scholes_parity.py",
+      "reason": "Legacy cohesive/compatibility surface exceeds the new maintainability budget and requires staged extraction rather than a blind split.",
+      "owner": "googa27 Portfolio Project #24",
+      "risk": "Large context increases change blast radius, review cost, and AI/human navigation burden.",
+      "accepted_ceiling": 611,
+      "refactoring_trigger": "The file may not grow; the next behavioral change must extract a cohesive responsibility behind compatibility tests or reduce the accepted ceiling."
+    },
+    {
+      "rule": "python_module_max_lines",
+      "path": "src/finite_difference_options/validation/pinares_fixed_price_proxy.py",
+      "reason": "Legacy cohesive/compatibility surface exceeds the new maintainability budget and requires staged extraction rather than a blind split.",
+      "owner": "googa27 Portfolio Project #24",
+      "risk": "Large context increases change blast radius, review cost, and AI/human navigation burden.",
+      "accepted_ceiling": 641,
+      "refactoring_trigger": "The file may not grow; the next behavioral change must extract a cohesive responsibility behind compatibility tests or reduce the accepted ceiling."
+    }
+  ]
+}

--- a/docs/ARCHITECTURE.yaml
+++ b/docs/ARCHITECTURE.yaml
@@ -222,11 +222,11 @@
     {
       "rule": "python_module_max_lines",
       "path": "src/finite_difference_options/processes/base.py",
-      "reason": "Legacy cohesive/compatibility surface exceeds the new maintainability budget and requires staged extraction rather than a blind split.",
+      "reason": "No-growth baseline refreshed to current main after concurrent solver-contract work landed before Project #24 merge; this PR does not add lines to the module.",
       "owner": "googa27 Portfolio Project #24",
       "risk": "Large context increases change blast radius, review cost, and AI/human navigation burden.",
-      "accepted_ceiling": 641,
-      "refactoring_trigger": "The file may not grow; the next behavioral change must extract a cohesive responsibility behind compatibility tests or reduce the accepted ceiling."
+      "accepted_ceiling": 653,
+      "refactoring_trigger": "Any further growth or the next process-base feature must extract one cohesive responsibility before merge."
     },
     {
       "rule": "python_module_max_lines",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,9 @@ Issues = "https://github.com/googa27/finite_difference_options/issues"
 [project.scripts]
 fd-options = "finite_difference_options.cli.main:app"
 
+[project.entry-points."haircut.solver_backends"]
+finite_difference_options = "finite_difference_options.integrations.haircut_backend:create_backend"
+
 [project.entry-points."haircut_engine.solver_backends"]
 finite_difference_options = "finite_difference_options.integrations.haircut_backend:create_backend"
 

--- a/scripts/check_portfolio_architecture.py
+++ b/scripts/check_portfolio_architecture.py
@@ -2,9 +2,9 @@
 """Validate the portfolio architecture contract without third-party dependencies.
 
 `docs/ARCHITECTURE.yaml` is deliberately written in the JSON subset of YAML 1.2,
-so the standard-library JSON parser is sufficient for the bootstrap gate. Repos
-may use PyYAML/check-jsonschema in richer gates; this checker never attempts to
-reimplement a YAML parser.
+so the standard-library JSON parser is sufficient for the bootstrap gate. Richer
+repository gates may add PyYAML or check-jsonschema; this checker never attempts
+to reimplement a YAML parser.
 """
 
 from __future__ import annotations
@@ -17,6 +17,8 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 CONTRACT = ROOT / "docs" / "ARCHITECTURE.yaml"
+DEFAULT_MAX_ENTRIES = 10
+DEFAULT_MAX_LINES = 500
 REQUIRED_TOP_LEVEL = {
     "schema_version",
     "repository",
@@ -60,6 +62,28 @@ DEFAULT_METADATA = {
 }
 
 
+class ContractLoadError(ValueError):
+    """Architecture contract could not be loaded."""
+
+    @classmethod
+    def missing(cls, relative_path: Path) -> ContractLoadError:
+        return cls(f"missing {relative_path}")
+
+    @classmethod
+    def invalid_json_subset(cls, error: json.JSONDecodeError) -> ContractLoadError:
+        return cls(
+            "docs/ARCHITECTURE.yaml must remain in the JSON-compatible YAML 1.2 "
+            f"subset for the dependency-free bootstrap checker: {error}"
+        )
+
+
+class ContractShapeError(TypeError):
+    """Architecture contract has an invalid root shape."""
+
+    def __init__(self) -> None:
+        super().__init__("architecture contract root must be an object")
+
+
 def ignored_name(name: str) -> bool:
     return name in IGNORED_DIRS or name.endswith(".egg-info")
 
@@ -72,20 +96,15 @@ def load_contract() -> dict[str, Any]:
     try:
         payload = json.loads(CONTRACT.read_text(encoding="utf-8"))
     except FileNotFoundError as exc:
-        raise ValueError(f"missing {CONTRACT.relative_to(ROOT)}") from exc
+        raise ContractLoadError.missing(CONTRACT.relative_to(ROOT)) from exc
     except json.JSONDecodeError as exc:
-        raise ValueError(
-            "docs/ARCHITECTURE.yaml must remain in the JSON-compatible YAML 1.2 subset "
-            f"for the dependency-free bootstrap checker: {exc}"
-        ) from exc
+        raise ContractLoadError.invalid_json_subset(exc) from exc
     if not isinstance(payload, dict):
-        raise ValueError("architecture contract root must be an object")
+        raise ContractShapeError
     return payload
 
 
-def exception_map(
-    contract: dict[str, Any], errors: list[str]
-) -> dict[tuple[str, str], dict[str, Any]]:
+def exception_map(contract: dict[str, Any], errors: list[str]) -> dict[tuple[str, str], dict[str, Any]]:
     result: dict[tuple[str, str], dict[str, Any]] = {}
     for index, item in enumerate(contract.get("exceptions", [])):
         if not isinstance(item, dict):
@@ -122,13 +141,15 @@ def require_exception(
 
 def runtime_dir(path: Path) -> bool:
     try:
-        return any(p.suffix == ".py" for p in path.rglob("*.py") if not ignored_path(p))
+        return any(candidate.suffix == ".py" for candidate in path.rglob("*.py") if not ignored_path(candidate))
     except OSError:
         return False
 
 
 def validate_source(
-    contract: dict[str, Any], exceptions: dict[tuple[str, str], dict[str, Any]], errors: list[str]
+    contract: dict[str, Any],
+    exceptions: dict[tuple[str, str], dict[str, Any]],
+    errors: list[str],
 ) -> None:
     layout = contract["source_layout"]
     if not layout.get("python_rules_applicable", True):
@@ -137,30 +158,26 @@ def validate_source(
     max_lines = int(contract["limits"]["max_python_module_lines"])
     allowed_non_python = set(layout.get("allowed_non_python_files", []))
     metadata = DEFAULT_METADATA | set(layout.get("metadata_names", []))
-    roots = [ROOT / p for p in layout.get("python_source_roots", [])]
+    roots = [ROOT / path for path in layout.get("python_source_roots", [])]
     for source_root in roots:
         rel_root = source_root.relative_to(ROOT).as_posix()
         if not source_root.is_dir():
             errors.append(f"declared Python source root is missing: {rel_root}")
             continue
         for current, dirs, files in os.walk(source_root):
-            dirs[:] = sorted(d for d in dirs if not ignored_name(d) and not d.startswith("."))
+            dirs[:] = sorted(name for name in dirs if not ignored_name(name) and not name.startswith("."))
             current_path = Path(current)
             rel_dir = current_path.relative_to(ROOT).as_posix()
-            runtime_dirs = [d for d in dirs if runtime_dir(current_path / d)]
-            runtime_files = [f for f in files if f.endswith(".py") and f != "__init__.py"]
+            runtime_dirs = [name for name in dirs if runtime_dir(current_path / name)]
+            runtime_files = [name for name in files if name.endswith(".py") and name != "__init__.py"]
             count = len(runtime_dirs) + len(runtime_files)
             if count > max_entries:
                 require_exception(exceptions, "source_fanout", rel_dir, count, errors)
             for filename in files:
                 rel = (current_path / filename).relative_to(ROOT).as_posix()
-                if (
-                    filename.endswith((".py", ".pyi"))
-                    or filename in metadata
-                    or rel in allowed_non_python
-                ):
-                    continue
-                require_exception(exceptions, "source_entry_type", rel, 1, errors)
+                allowed = filename.endswith((".py", ".pyi")) or filename in metadata or rel in allowed_non_python
+                if not allowed:
+                    require_exception(exceptions, "source_entry_type", rel, 1, errors)
         for module in sorted(source_root.rglob("*.py")):
             if ignored_path(module):
                 continue
@@ -179,36 +196,35 @@ def validate_source(
                 )
 
 
-def validate_contract(contract: dict[str, Any]) -> list[str]:
-    errors: list[str] = []
-    missing = REQUIRED_TOP_LEVEL - set(contract)
-    if missing:
-        errors.append(f"contract missing top-level keys: {sorted(missing)}")
-        return errors
-    exceptions = exception_map(contract, errors)
-    repo = contract["repository"]
+def validate_repository(contract: dict[str, Any], errors: list[str]) -> None:
+    repository = contract["repository"]
     for key in ("owner", "name", "profile", "status"):
-        if not repo.get(key):
+        if not repository.get(key):
             errors.append(f"repository.{key} is required")
-    if contract["limits"].get("max_immediate_runtime_entries") != 10:
+
+
+def validate_limits(contract: dict[str, Any], errors: list[str]) -> None:
+    limits = contract["limits"]
+    if limits.get("max_immediate_runtime_entries") != DEFAULT_MAX_ENTRIES:
         errors.append(
-            "default max_immediate_runtime_entries must be 10; "
-            "repo override belongs in a documented exception"
+            "default max_immediate_runtime_entries must be 10; repo override belongs in a documented exception"
         )
-    if contract["limits"].get("max_python_module_lines") != 500:
-        errors.append(
-            "default max_python_module_lines must be 500; "
-            "repo override belongs in a documented exception"
-        )
-    required_docs = contract["governance"].get("required_documents", [])
-    for rel in required_docs:
+    if limits.get("max_python_module_lines") != DEFAULT_MAX_LINES:
+        errors.append("default max_python_module_lines must be 500; repo override belongs in a documented exception")
+
+
+def validate_documents_and_tests(contract: dict[str, Any], errors: list[str]) -> None:
+    for rel in contract["governance"].get("required_documents", []):
         path = ROOT / rel
-        if not path.is_file() or not path.read_text(encoding="utf-8", errors="ignore").strip():
+        exists_with_content = path.is_file() and bool(path.read_text(encoding="utf-8", errors="ignore").strip())
+        if not exists_with_content:
             errors.append(f"required document missing or empty: {rel}")
     for suite in contract["tests"].get("required_suites", []):
-        path = ROOT / "tests" / suite
-        if not path.is_dir():
+        if not (ROOT / "tests" / suite).is_dir():
             errors.append(f"required test suite directory missing: tests/{suite}")
+
+
+def validate_interfaces(contract: dict[str, Any], errors: list[str]) -> None:
     ai = contract["interfaces"].get("ai", {})
     human = contract["interfaces"].get("human", {})
     if ai.get("context_file") != "AGENTS.md":
@@ -217,35 +233,53 @@ def validate_contract(contract: dict[str, Any]) -> list[str]:
         errors.append("AI interaction and capability discovery decisions are required")
     if not human.get("interaction") or not human.get("dunder_policy"):
         errors.append("human interaction and dunder policy decisions are required")
-    if not contract["libraries"].get("selection_policy"):
+
+
+def validate_libraries_and_data(contract: dict[str, Any], errors: list[str]) -> None:
+    libraries = contract["libraries"]
+    if not libraries.get("selection_policy"):
         errors.append("maintained-library selection policy is required")
-    if not isinstance(contract["libraries"].get("decisions"), list):
+    if not isinstance(libraries.get("decisions"), list):
         errors.append("libraries.decisions must be a list")
     core = contract["data"].get("core_repositories", {})
     for name in ("PDP", "financial_problem_formulations", "ui_and_artifacts"):
         if name not in core:
             errors.append(f"data.core_repositories must decide {name} posture")
+
+
+def validate_contract(contract: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    missing = REQUIRED_TOP_LEVEL - set(contract)
+    if missing:
+        return [f"contract missing top-level keys: {sorted(missing)}"]
+    exceptions = exception_map(contract, errors)
+    validate_repository(contract, errors)
+    validate_limits(contract, errors)
+    validate_documents_and_tests(contract, errors)
+    validate_interfaces(contract, errors)
+    validate_libraries_and_data(contract, errors)
     validate_source(contract, exceptions, errors)
     return errors
+
+
+def write_line(message: str) -> None:
+    sys.stdout.write(f"{message}\n")
 
 
 def main() -> int:
     try:
         contract = load_contract()
-    except ValueError as exc:
-        print(f"architecture contract FAILED\n- {exc}")
+    except (ContractLoadError, ContractShapeError) as exc:
+        write_line(f"architecture contract FAILED\n- {exc}")
         return 1
     errors = validate_contract(contract)
     if errors:
-        print("architecture contract FAILED")
+        write_line("architecture contract FAILED")
         for error in errors:
-            print(f"- {error}")
+            write_line(f"- {error}")
         return 1
-    print(
-        "architecture contract OK: "
-        f"{contract['repository']['owner']}/{contract['repository']['name']} "
-        f"profile={contract['repository']['profile']}"
-    )
+    repository = contract["repository"]
+    write_line(f"architecture contract OK: {repository['owner']}/{repository['name']} profile={repository['profile']}")
     return 0
 
 

--- a/scripts/check_portfolio_architecture.py
+++ b/scripts/check_portfolio_architecture.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Validate the portfolio architecture contract without third-party dependencies.
+
+`docs/ARCHITECTURE.yaml` is deliberately written in the JSON subset of YAML 1.2,
+so the standard-library JSON parser is sufficient for the bootstrap gate. Repos
+may use PyYAML/check-jsonschema in richer gates; this checker never attempts to
+reimplement a YAML parser.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = ROOT / "docs" / "ARCHITECTURE.yaml"
+REQUIRED_TOP_LEVEL = {
+    "schema_version",
+    "repository",
+    "architecture",
+    "source_layout",
+    "limits",
+    "libraries",
+    "interfaces",
+    "tests",
+    "data",
+    "governance",
+    "exceptions",
+}
+REQUIRED_EXCEPTION_FIELDS = {
+    "rule",
+    "path",
+    "reason",
+    "owner",
+    "risk",
+    "accepted_ceiling",
+    "refactoring_trigger",
+}
+IGNORED_DIRS = {
+    ".git",
+    ".venv",
+    "venv",
+    "node_modules",
+    "__pycache__",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".mypy_cache",
+    "build",
+    "dist",
+}
+DEFAULT_METADATA = {
+    "__init__.py",
+    "README.md",
+    "ARCHITECTURE.md",
+    "ARCHITECTURE.yaml",
+    "py.typed",
+}
+
+
+def ignored_name(name: str) -> bool:
+    return name in IGNORED_DIRS or name.endswith(".egg-info")
+
+
+def ignored_path(path: Path) -> bool:
+    return any(ignored_name(part) for part in path.parts)
+
+
+def load_contract() -> dict[str, Any]:
+    try:
+        payload = json.loads(CONTRACT.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"missing {CONTRACT.relative_to(ROOT)}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            "docs/ARCHITECTURE.yaml must remain in the JSON-compatible YAML 1.2 subset "
+            f"for the dependency-free bootstrap checker: {exc}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ValueError("architecture contract root must be an object")
+    return payload
+
+
+def exception_map(
+    contract: dict[str, Any], errors: list[str]
+) -> dict[tuple[str, str], dict[str, Any]]:
+    result: dict[tuple[str, str], dict[str, Any]] = {}
+    for index, item in enumerate(contract.get("exceptions", [])):
+        if not isinstance(item, dict):
+            errors.append(f"exceptions[{index}] must be an object")
+            continue
+        missing = REQUIRED_EXCEPTION_FIELDS - set(item)
+        if missing:
+            errors.append(f"exceptions[{index}] missing metadata: {sorted(missing)}")
+            continue
+        key = (str(item["rule"]), str(item["path"]))
+        if key in result:
+            errors.append(f"duplicate exception for {key[0]}:{key[1]}")
+        result[key] = item
+    return result
+
+
+def require_exception(
+    exceptions: dict[tuple[str, str], dict[str, Any]],
+    rule: str,
+    path: str,
+    actual: int,
+    errors: list[str],
+) -> None:
+    item = exceptions.get((rule, path))
+    if item is None:
+        errors.append(f"{rule} violation at {path}: {actual}; no documented exception")
+        return
+    ceiling = item.get("accepted_ceiling")
+    if not isinstance(ceiling, int):
+        errors.append(f"{rule} exception at {path} must have integer accepted_ceiling")
+    elif actual > ceiling:
+        errors.append(f"{rule} no-growth ratchet exceeded at {path}: {actual}>{ceiling}")
+
+
+def runtime_dir(path: Path) -> bool:
+    try:
+        return any(p.suffix == ".py" for p in path.rglob("*.py") if not ignored_path(p))
+    except OSError:
+        return False
+
+
+def validate_source(
+    contract: dict[str, Any], exceptions: dict[tuple[str, str], dict[str, Any]], errors: list[str]
+) -> None:
+    layout = contract["source_layout"]
+    if not layout.get("python_rules_applicable", True):
+        return
+    max_entries = int(contract["limits"]["max_immediate_runtime_entries"])
+    max_lines = int(contract["limits"]["max_python_module_lines"])
+    allowed_non_python = set(layout.get("allowed_non_python_files", []))
+    metadata = DEFAULT_METADATA | set(layout.get("metadata_names", []))
+    roots = [ROOT / p for p in layout.get("python_source_roots", [])]
+    for source_root in roots:
+        rel_root = source_root.relative_to(ROOT).as_posix()
+        if not source_root.is_dir():
+            errors.append(f"declared Python source root is missing: {rel_root}")
+            continue
+        for current, dirs, files in os.walk(source_root):
+            dirs[:] = sorted(d for d in dirs if not ignored_name(d) and not d.startswith("."))
+            current_path = Path(current)
+            rel_dir = current_path.relative_to(ROOT).as_posix()
+            runtime_dirs = [d for d in dirs if runtime_dir(current_path / d)]
+            runtime_files = [f for f in files if f.endswith(".py") and f != "__init__.py"]
+            count = len(runtime_dirs) + len(runtime_files)
+            if count > max_entries:
+                require_exception(exceptions, "source_fanout", rel_dir, count, errors)
+            for filename in files:
+                rel = (current_path / filename).relative_to(ROOT).as_posix()
+                if (
+                    filename.endswith((".py", ".pyi"))
+                    or filename in metadata
+                    or rel in allowed_non_python
+                ):
+                    continue
+                require_exception(exceptions, "source_entry_type", rel, 1, errors)
+        for module in sorted(source_root.rglob("*.py")):
+            if ignored_path(module):
+                continue
+            try:
+                lines = len(module.read_text(encoding="utf-8").splitlines())
+            except UnicodeDecodeError:
+                errors.append(f"Python module is not UTF-8 text: {module.relative_to(ROOT)}")
+                continue
+            if lines > max_lines:
+                require_exception(
+                    exceptions,
+                    "python_module_max_lines",
+                    module.relative_to(ROOT).as_posix(),
+                    lines,
+                    errors,
+                )
+
+
+def validate_contract(contract: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    missing = REQUIRED_TOP_LEVEL - set(contract)
+    if missing:
+        errors.append(f"contract missing top-level keys: {sorted(missing)}")
+        return errors
+    exceptions = exception_map(contract, errors)
+    repo = contract["repository"]
+    for key in ("owner", "name", "profile", "status"):
+        if not repo.get(key):
+            errors.append(f"repository.{key} is required")
+    if contract["limits"].get("max_immediate_runtime_entries") != 10:
+        errors.append(
+            "default max_immediate_runtime_entries must be 10; "
+            "repo override belongs in a documented exception"
+        )
+    if contract["limits"].get("max_python_module_lines") != 500:
+        errors.append(
+            "default max_python_module_lines must be 500; "
+            "repo override belongs in a documented exception"
+        )
+    required_docs = contract["governance"].get("required_documents", [])
+    for rel in required_docs:
+        path = ROOT / rel
+        if not path.is_file() or not path.read_text(encoding="utf-8", errors="ignore").strip():
+            errors.append(f"required document missing or empty: {rel}")
+    for suite in contract["tests"].get("required_suites", []):
+        path = ROOT / "tests" / suite
+        if not path.is_dir():
+            errors.append(f"required test suite directory missing: tests/{suite}")
+    ai = contract["interfaces"].get("ai", {})
+    human = contract["interfaces"].get("human", {})
+    if ai.get("context_file") != "AGENTS.md":
+        errors.append("interfaces.ai.context_file must be AGENTS.md")
+    if not ai.get("interaction") or not ai.get("capability_discovery"):
+        errors.append("AI interaction and capability discovery decisions are required")
+    if not human.get("interaction") or not human.get("dunder_policy"):
+        errors.append("human interaction and dunder policy decisions are required")
+    if not contract["libraries"].get("selection_policy"):
+        errors.append("maintained-library selection policy is required")
+    if not isinstance(contract["libraries"].get("decisions"), list):
+        errors.append("libraries.decisions must be a list")
+    core = contract["data"].get("core_repositories", {})
+    for name in ("PDP", "financial_problem_formulations", "ui_and_artifacts"):
+        if name not in core:
+            errors.append(f"data.core_repositories must decide {name} posture")
+    validate_source(contract, exceptions, errors)
+    return errors
+
+
+def main() -> int:
+    try:
+        contract = load_contract()
+    except ValueError as exc:
+        print(f"architecture contract FAILED\n- {exc}")
+        return 1
+    errors = validate_contract(contract)
+    if errors:
+        print("architecture contract FAILED")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print(
+        "architecture contract OK: "
+        f"{contract['repository']['owner']}/{contract['repository']['name']} "
+        f"profile={contract['repository']['profile']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/finite_difference_options/grids/__init__.py
+++ b/src/finite_difference_options/grids/__init__.py
@@ -253,6 +253,21 @@ class TensorGrid:
             raise ValidationError("TensorGrid axis names must be unique")
         object.__setattr__(self, "axes", axes)
 
+    def __len__(self) -> int:
+        """Return the number of tensor axes."""
+
+        return len(self.axes)
+
+    def __iter__(self) -> Iterable[AxisGrid]:
+        """Iterate over axes in tensor-index order."""
+
+        return iter(self.axes)
+
+    def __getitem__(self, index: int) -> AxisGrid:
+        """Return one axis by tensor-index position."""
+
+        return self.axes[index]
+
     @property
     def dimension(self) -> int:
         """Tensor dimension."""

--- a/src/finite_difference_options/grids/__init__.py
+++ b/src/finite_difference_options/grids/__init__.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from math import atanh
 from types import MappingProxyType
-from typing import Any, Iterable, Mapping, Sequence
+from typing import Any, Iterator, Mapping, Sequence
 
 import numpy as np
 from numpy.typing import NDArray
@@ -70,7 +70,7 @@ class AxisGrid:
 
         return len(self.coordinates)
 
-    def __iter__(self) -> Iterable[float]:
+    def __iter__(self) -> Iterator[float]:
         """Iterate over solver coordinates."""
 
         return iter(self.coordinates)
@@ -258,7 +258,7 @@ class TensorGrid:
 
         return len(self.axes)
 
-    def __iter__(self) -> Iterable[AxisGrid]:
+    def __iter__(self) -> Iterator[AxisGrid]:
         """Iterate over axes in tensor-index order."""
 
         return iter(self.axes)

--- a/src/finite_difference_options/integrations/haircut_backend.py
+++ b/src/finite_difference_options/integrations/haircut_backend.py
@@ -28,6 +28,14 @@ from finite_difference_options.contracts import (
 
 AdapterStatus = Literal["supported", "unsupported"]
 SolveStatus = Literal["passed", "failed"]
+PREFERRED_ENTRY_POINT_GROUP = "haircut.solver_backends"
+LEGACY_ENTRY_POINT_GROUP = "haircut_engine.solver_backends"
+ENTRY_POINT_DEPRECATION = {
+    "deprecated_group": LEGACY_ENTRY_POINT_GROUP,
+    "preferred_group": PREFERRED_ENTRY_POINT_GROUP,
+    "removal_not_before": "0.3.0",
+    "status": "compatibility_only",
+}
 
 _EXECUTABLE_PUBLIC_BENCHMARKS = {
     "BS-FD-ORACLE-V0",
@@ -114,6 +122,7 @@ class FiniteDifferenceHaircutBackend:
             entry_point="finite_difference_options.integrations.haircut_backend:create_backend",
             issue_refs=(
                 "googa27/finite_difference_options#59",
+                "googa27/finite_difference_options#139",
                 "googa27/haircut-engine#195",
             ),
         )
@@ -229,10 +238,16 @@ class FiniteDifferenceHaircutBackend:
         }
         evidence = {
             **parity_report.evidence.as_dict(),
+            "contract_family": "FPF.solver_result_evidence.v1",
             "adapter_schema_version": self.identity.adapter_schema_version,
             "source_schema_version": request.source_schema_version,
             "problem_id": problem_id,
             "privacy_class": _optional_string(payload.get("privacy_class")),
+            "measure": request.measure,
+            "numeraire": request.numeraire,
+            "units": dict(request.units),
+            "status": "passed" if passed else "failed",
+            "backend_capability_status": self._manifest.status.value,
         }
         return HaircutBackendSolveResult(
             backend_id=self._manifest.backend_id,
@@ -249,9 +264,25 @@ class FiniteDifferenceHaircutBackend:
 def create_backend(
     manifest: FDCapabilityManifest = DEFAULT_FD_CAPABILITY_MANIFEST,
 ) -> FiniteDifferenceHaircutBackend:
-    """Entry-point factory for `haircut_engine.solver_backends` discovery."""
+    """Entry-point factory for ``haircut.solver_backends`` discovery.
+
+    The historical ``haircut_engine.solver_backends`` group remains declared in
+    packaging metadata as a compatibility/deprecation alias so installed older
+    Haircut Engine versions continue to discover this backend.
+    """
 
     return FiniteDifferenceHaircutBackend(manifest=manifest)
+
+
+def solver_backend_entry_point_contract() -> dict[str, object]:
+    """Return the concrete preferred and legacy Haircut entry-point contract."""
+
+    return {
+        "preferred_group": PREFERRED_ENTRY_POINT_GROUP,
+        "legacy_groups": (LEGACY_ENTRY_POINT_GROUP,),
+        "object": "finite_difference_options.integrations.haircut_backend:create_backend",
+        "deprecations": (dict(ENTRY_POINT_DEPRECATION),),
+    }
 
 
 def _execution_diagnostics(
@@ -394,5 +425,8 @@ __all__ = [
     "FiniteDifferenceHaircutBackend",
     "HaircutBackendIdentity",
     "HaircutBackendSolveResult",
+    "LEGACY_ENTRY_POINT_GROUP",
+    "PREFERRED_ENTRY_POINT_GROUP",
     "create_backend",
+    "solver_backend_entry_point_contract",
 ]

--- a/src/finite_difference_options/integrations/haircut_backend.py
+++ b/src/finite_difference_options/integrations/haircut_backend.py
@@ -197,6 +197,7 @@ class FiniteDifferenceHaircutBackend:
             run_public_pinares_fixed_price_proxy_fixture,
         )
 
+        parity_report: Any
         if problem_id == PINARES_FIXED_PRICE_PROXY_PROBLEM_ID:
             parity_report = run_public_pinares_fixed_price_proxy_fixture()
             values = {

--- a/src/finite_difference_options/integrations/public_solver_contract.py
+++ b/src/finite_difference_options/integrations/public_solver_contract.py
@@ -133,6 +133,7 @@ def solve_public_quant_problem_spec(
             )
         )
 
+    report: Any
     if problem_id == "pinares.fixed_price_option_proxy.v1":
         from finite_difference_options.validation.pinares_fixed_price_proxy import (
             run_public_pinares_fixed_price_proxy_fixture,

--- a/src/finite_difference_options/integrations/public_solver_contract.py
+++ b/src/finite_difference_options/integrations/public_solver_contract.py
@@ -38,6 +38,7 @@ class ReleasedFDSolverContract:
     supported_privacy_classes: tuple[str, ...]
     capability_manifest: dict[str, Any]
     entry_points: tuple[str, ...]
+    entry_point_groups: tuple[str, ...]
     issue_refs: tuple[str, ...]
 
     def as_dict(self) -> dict[str, Any]:
@@ -89,9 +90,11 @@ def released_fd_solver_contract(
             "finite_difference_options.integrations.public_solver_contract:solve_public_quant_problem_spec",
             "finite_difference_options.integrations.haircut_backend:create_backend",
         ),
+        entry_point_groups=("haircut.solver_backends", "haircut_engine.solver_backends"),
         issue_refs=(
             "googa27/finite_difference_options#55",
             "googa27/finite_difference_options#130",
+            "googa27/finite_difference_options#139",
         ),
     )
 
@@ -172,10 +175,16 @@ def solve_public_quant_problem_spec(
     }
     evidence = {
         **report.evidence.as_dict(),
+        "contract_family": "FPF.solver_result_evidence.v1",
         "adapter_schema_version": released_fd_solver_contract(manifest).adapter_schema_version,
         "source_schema_version": request.source_schema_version,
         "problem_id": problem_id,
         "privacy_class": privacy_class,
+        "measure": request.measure,
+        "numeraire": request.numeraire,
+        "units": dict(request.units),
+        "status": "passed" if report.converged else "failed",
+        "backend_capability_status": manifest.status.value,
     }
     return PublicFDSolverResult(
         schema_version="finite-difference-options.public-fd-solver-result/v0",

--- a/src/finite_difference_options/processes/base.py
+++ b/src/finite_difference_options/processes/base.py
@@ -25,33 +25,24 @@ from ..utils.state_handling import ensure_state_array, validate_state_dimensions
 
 
 class ProcessDimension(BaseModel):
-    """Container and validator for process dimensionality.
-
-    The dimension is a small strongly typed value object so that process and
-    solver code can reliably branch on state space shape.  A value of ``1``
-    indicates a univariate process while values greater than one indicate
-    multi-dimensional dynamics.
-
-    Parameters
-    ----------
-    value : int
-        Number of state dimensions.
-    """
+    """Validated positive state-space dimension value object."""
 
     value: int
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
+    @field_validator("value", mode="before")
+    @classmethod
+    def reject_bool_value(cls, v: object) -> object:
+        """Reject bool before Pydantic can coerce it to ``0`` or ``1``."""
+        if isinstance(v, bool):
+            raise ValidationError("Process dimension must be an integer, got bool")
+        return v
+
     @field_validator("value")
     @classmethod
-    def validate_value(cls, v):
-        """Validate that process dimension is strictly positive.
-
-        Raises
-        ------
-        ValidationError
-            If ``value < 1``.
-        """
+    def validate_value(cls, v: int) -> int:
+        """Validate that process dimension is strictly positive."""
         if v < 1:
             raise ValidationError(f"Process dimension must be positive, got {v}")
         return v
@@ -79,19 +70,30 @@ class ProcessDimension(BaseModel):
         return self.value > 1
 
     def __eq__(self, other: object) -> bool:
-        if isinstance(other, ProcessDimension):
+        """Compare only with the same value-object type.
+
+        Cross-type equality to ``int`` is deliberately rejected: in Python,
+        ``bool`` is an ``int`` subclass and ``True == 1``.  Keeping equality
+        type-strict avoids a transitivity bridge where
+        ``ProcessDimension(1) == 1`` and ``1 == True`` but
+        ``ProcessDimension(1) != True``.
+        """
+        if type(other) is type(self):
             return self.value == other.value
-        if isinstance(other, int) and not isinstance(other, bool):
-            return self.value == other
         return NotImplemented
 
     def __hash__(self) -> int:
-        """Hash consistently with the lawful integer equality shortcut."""
+        """Hash consistently with type-strict equality."""
 
-        return hash(self.value)
+        return hash((type(self), self.value))
 
     def __int__(self) -> int:
         """Return the validated positive dimension for APIs requiring ``int``."""
+
+        return self.value
+
+    def __index__(self) -> int:
+        """Return the validated positive dimension for index-oriented APIs."""
 
         return self.value
 
@@ -168,8 +170,7 @@ class AffineCovarianceForm:
         linear = np.asarray(self.linear, dtype=float)
         if constant.ndim != 2 or constant.shape[0] != constant.shape[1]:
             raise ValidationError(
-                "constant affine covariance term must be a square matrix, "
-                f"got shape {constant.shape}"
+                f"constant affine covariance term must be a square matrix, got shape {constant.shape}"
             )
         dimension = constant.shape[0]
         if linear.shape != (dimension, dimension, dimension):
@@ -180,9 +181,7 @@ class AffineCovarianceForm:
         if not np.allclose(constant, constant.T, rtol=1e-10, atol=1e-12):
             raise ValidationError("constant affine covariance term must be symmetric")
         if not np.allclose(linear, np.swapaxes(linear, -1, -2), rtol=1e-10, atol=1e-12):
-            raise ValidationError(
-                "linear affine covariance tensor slices must be symmetric"
-            )
+            raise ValidationError("linear affine covariance tensor slices must be symmetric")
         object.__setattr__(self, "constant", constant)
         object.__setattr__(self, "linear", linear)
 
@@ -268,9 +267,7 @@ class StochasticProcess(ABC):
         ...
 
     @abstractmethod
-    def covariance(
-        self, time: float, state: NDArray[np.float64]
-    ) -> NDArray[np.float64]:
+    def covariance(self, time: float, state: NDArray[np.float64]) -> NDArray[np.float64]:
         r"""Compute diffusion covariance matrix :math:`\Sigma(t, x)`.
 
         Parameters
@@ -328,9 +325,7 @@ class StochasticProcess(ABC):
         is_single_point = original.ndim == 1
         states = original.reshape(1, -1) if is_single_point else original
         if not np.all(np.isfinite(states)):
-            raise ValidationError(
-                f"{self.__class__.__name__} state contains non-finite values"
-            )
+            raise ValidationError(f"{self.__class__.__name__} state contains non-finite values")
         return original, states, is_single_point
 
     def discount(self, time: float, state: NDArray[np.float64]) -> NDArray[np.float64]:
@@ -394,9 +389,7 @@ class StochasticProcess(ABC):
         elif array.shape == (1,) and batch_size != 1:
             array = np.full(batch_size, float(array[0]), dtype=float)
         if array.shape != (batch_size,):
-            raise ValidationError(
-                f"{field_name} must have shape ({batch_size},), got {array.shape}"
-            )
+            raise ValidationError(f"{field_name} must have shape ({batch_size},), got {array.shape}")
         if not np.all(np.isfinite(array)):
             raise ValidationError(f"{field_name} contains non-finite values")
         return array
@@ -410,15 +403,9 @@ class StochasticProcess(ABC):
 
         original, states, is_single_point = self._canonical_state_batch(state)
         batch_size = states.shape[0]
-        drift = self._normalise_vector_field(
-            self.drift(time, original), "drift", batch_size
-        )
-        covariance = self._normalise_matrix_field(
-            self.covariance(time, original), "covariance", batch_size
-        )
-        discount = self._normalise_scalar_field(
-            self.discount(time, original), "discount", batch_size
-        )
+        drift = self._normalise_vector_field(self.drift(time, original), "drift", batch_size)
+        covariance = self._normalise_matrix_field(self.covariance(time, original), "covariance", batch_size)
+        discount = self._normalise_scalar_field(self.discount(time, original), "discount", batch_size)
         return ProcessCoefficientEvaluation(
             time=time,
             states=states,
@@ -442,14 +429,11 @@ class StochasticProcess(ABC):
         asymmetry = covariance - np.swapaxes(covariance, -1, -2)
         max_asymmetry = float(np.max(np.abs(asymmetry)))
         if max_asymmetry > tolerance:
-            raise ValidationError(
-                f"process covariance must be symmetric; max asymmetry is {max_asymmetry:.2e}"
-            )
+            raise ValidationError(f"process covariance must be symmetric; max asymmetry is {max_asymmetry:.2e}")
         min_eigenvalue = float(np.min(np.linalg.eigvalsh(covariance)))
         if min_eigenvalue < -tolerance:
             raise ValidationError(
-                "process covariance must be positive semi-definite; "
-                f"minimum eigenvalue is {min_eigenvalue:.2e}"
+                f"process covariance must be positive semi-definite; minimum eigenvalue is {min_eigenvalue:.2e}"
             )
         return CovarianceValidationResult(
             min_eigenvalue=min_eigenvalue,
@@ -481,9 +465,7 @@ class StochasticProcess(ABC):
             else self._normalise_scalar_field(discount, "discount", batch_size)
         )
         source_array = self._normalise_scalar_field(source, "source", batch_size)
-        diffusion_term = 0.5 * np.einsum(
-            "nij,nij->n", coefficients.covariance, hessian_array
-        )
+        diffusion_term = 0.5 * np.einsum("nij,nij->n", coefficients.covariance, hessian_array)
         drift_term = np.einsum("ni,ni->n", coefficients.drift, gradient_array)
         return diffusion_term + drift_term - discount_array * value_array + source_array
 
@@ -540,9 +522,7 @@ class AffineProcess(StochasticProcess):
         return ProcessType.AFFINE
 
     @abstractmethod
-    def affine_drift_coefficients(
-        self, time: float = 0.0
-    ) -> Tuple[NDArray[np.float64], NDArray[np.float64]]:
+    def affine_drift_coefficients(self, time: float = 0.0) -> Tuple[NDArray[np.float64], NDArray[np.float64]]:
         """Get affine drift coefficients α(t), β(t).
 
         Returns
@@ -553,9 +533,7 @@ class AffineProcess(StochasticProcess):
         ...
 
     @abstractmethod
-    def affine_covariance_coefficients(
-        self, time: float = 0.0
-    ) -> Tuple[NDArray[np.float64], NDArray[np.float64]]:
+    def affine_covariance_coefficients(self, time: float = 0.0) -> Tuple[NDArray[np.float64], NDArray[np.float64]]:
         r"""Get affine covariance coefficients ``a0(t), a_linear(t)``.
 
         Returns
@@ -612,9 +590,7 @@ class AffineProcess(StochasticProcess):
         beta = np.asarray(beta, dtype=float)
         dimension = self.dimension.value
         if alpha.shape != (dimension,):
-            raise ValidationError(
-                f"affine drift alpha must have shape ({dimension},), got {alpha.shape}"
-            )
+            raise ValidationError(f"affine drift alpha must have shape ({dimension},), got {alpha.shape}")
         if beta.shape == (dimension,):
             if dimension != 1:
                 raise ValidationError(
@@ -622,17 +598,13 @@ class AffineProcess(StochasticProcess):
                 )
             beta = beta.reshape(1, 1)
         if beta.shape != (dimension, dimension):
-            raise ValidationError(
-                f"affine drift beta must have shape ({dimension}, {dimension}), got {beta.shape}"
-            )
+            raise ValidationError(f"affine drift beta must have shape ({dimension}, {dimension}), got {beta.shape}")
 
         if state.ndim == 1:
             return alpha + beta @ state
         return state @ beta.T + alpha
 
-    def covariance(
-        self, time: float, state: NDArray[np.float64]
-    ) -> NDArray[np.float64]:
+    def covariance(self, time: float, state: NDArray[np.float64]) -> NDArray[np.float64]:
         r"""Compute affine covariance ``a0(t)+sum_k x_k a_k(t)``."""
         state = ensure_state_array(state)
         self.validate_state(state)

--- a/src/finite_difference_options/processes/base.py
+++ b/src/finite_difference_options/processes/base.py
@@ -78,10 +78,22 @@ class ProcessDimension(BaseModel):
         """
         return self.value > 1
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, ProcessDimension):
             return self.value == other.value
-        return self.value == other
+        if isinstance(other, int) and not isinstance(other, bool):
+            return self.value == other
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        """Hash consistently with the lawful integer equality shortcut."""
+
+        return hash(self.value)
+
+    def __int__(self) -> int:
+        """Return the validated positive dimension for APIs requiring ``int``."""
+
+        return self.value
 
     def __repr__(self) -> str:
         return f"ProcessDimension(value={self.value})"

--- a/tests/architecture/README.md
+++ b/tests/architecture/README.md
@@ -1,0 +1,7 @@
+# Architecture tests
+
+Repository: `finite_difference_options`.
+
+Executable fitness functions sourced from docs/ARCHITECTURE.yaml.
+
+If no executable tests exist here yet, this README is the boundary contract: add the first test when a change introduces behavior in this tier.

--- a/tests/architecture/test_portfolio_architecture.py
+++ b/tests/architecture/test_portfolio_architecture.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_portfolio_architecture_contract() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/check_portfolio_architecture.py"],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,7 @@
+# E2e tests
+
+Repository: `finite_difference_options`.
+
+Installed public CLI/API golden paths using public-synthetic or sanitized fixtures.
+
+If no executable tests exist here yet, this README is the boundary contract: add the first test when a change introduces behavior in this tier.

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,7 @@
+# Integration tests
+
+Repository: `finite_difference_options`.
+
+Adapter, persistence, library, and contract-boundary tests with controlled fixtures.
+
+If no executable tests exist here yet, this README is the boundary contract: add the first test when a change introduces behavior in this tier.

--- a/tests/test_grid_contracts.py
+++ b/tests/test_grid_contracts.py
@@ -34,6 +34,19 @@ def test_axis_grid_rejects_invalid_coordinates_and_reports_spacing() -> None:
     assert grid.to_public_dict()["family"] == "custom"
 
 
+def test_axis_grid_sequence_dunders_match_coordinate_contract() -> None:
+    grid = AxisGrid(name="x", coordinates=(0.0, 0.25, 1.0), family="custom")
+
+    assert len(grid) == grid.node_count == 3
+    assert tuple(grid) == grid.coordinates
+    assert grid[0] == pytest.approx(grid.lower)
+    assert grid[-1] == pytest.approx(grid.upper)
+
+    exported = np.asarray(grid)
+    exported[0] = 99.0
+    assert grid[0] == pytest.approx(0.0)
+
+
 def test_nonuniform_axis_derivatives_are_quadratic_exact() -> None:
     grid = AxisGrid(name="x", coordinates=(-1.0, -0.3, 0.2, 0.9, 2.0), family="custom")
     x = grid.coordinates_array
@@ -89,6 +102,18 @@ def test_tensor_grid_diagnostics_track_axis_local_metrics() -> None:
     assert public["shape"] == [9, 5]
     assert public["axes"][0]["uniform"] is False
     assert public["axes"][1]["uniform"] is True
+
+
+def test_tensor_grid_collection_dunders_match_axis_contract() -> None:
+    spot = uniform_axis(name="spot", lower=0.0, upper=2.0, nodes=5)
+    variance = uniform_axis(name="variance", lower=0.0, upper=0.5, nodes=3)
+    tensor = TensorGrid(axes=(spot, variance))
+
+    assert len(tensor) == tensor.dimension == 2
+    assert tuple(tensor) == tensor.axes
+    assert tensor[0] is spot
+    assert tensor[-1] is variance
+    assert tensor.shape == (len(spot), len(variance))
 
 
 def test_adi_accepts_axis_grid_objects_and_reports_grid_identity() -> None:

--- a/tests/test_haircut_backend_adapter.py
+++ b/tests/test_haircut_backend_adapter.py
@@ -44,6 +44,7 @@ def test_haircut_backend_identity_and_manifest_are_lightweight() -> None:
     assert backend.identity.maturity == "validated_public_synthetic"
     assert backend.identity.issue_refs == (
         "googa27/finite_difference_options#59",
+        "googa27/finite_difference_options#139",
         "googa27/haircut-engine#195",
     )
     manifest = backend.capability_manifest()

--- a/tests/test_haircut_backend_adapter.py
+++ b/tests/test_haircut_backend_adapter.py
@@ -5,11 +5,17 @@ from __future__ import annotations
 import ast
 import json
 import pathlib
+import tomllib
 
 import pytest
 
 from finite_difference_options.contracts import UnsupportedRouteError
-from finite_difference_options.integrations.haircut_backend import create_backend
+from finite_difference_options.integrations.haircut_backend import (
+    LEGACY_ENTRY_POINT_GROUP,
+    PREFERRED_ENTRY_POINT_GROUP,
+    create_backend,
+    solver_backend_entry_point_contract,
+)
 
 FIXTURE_DIR = pathlib.Path(__file__).parent / "fixtures" / "quant_problem_specs"
 
@@ -159,7 +165,9 @@ def test_haircut_backend_module_keeps_validation_runners_lazy() -> None:
     top_level_imports = [node for node in tree.body if isinstance(node, ast.ImportFrom) and node.module is not None]
 
     assert not [
-        node.module for node in top_level_imports if node.module.startswith("finite_difference_options.validation")
+        node.module
+        for node in top_level_imports
+        if node.module is not None and node.module.startswith("finite_difference_options.validation")
     ]
 
 
@@ -174,10 +182,29 @@ def test_haircut_backend_solve_executes_only_validated_public_synthetic_fixture(
     assert result.values["price"] == pytest.approx(result.values["oracle_price"], abs=1.0e-2)
     assert result.diagnostics["fallbacks"] == ()
     assert result.evidence["privacy_class"] == "public_synthetic"
+    assert result.evidence["contract_family"] == "FPF.solver_result_evidence.v1"
+    assert result.evidence["status"] == "passed"
+    assert result.evidence["measure"] == result.request["measure"]
     assert result.evidence["valuation_date"] == result.request["valuation_date"]
     assert result.evidence["numeraire"] == result.request["numeraire"]
     assert result.evidence["units"] == result.request["units"]
     assert result.request["boundary_conditions"] == ("dirichlet",)
+
+
+def test_haircut_entry_point_group_mismatch_has_preferred_and_legacy_alias() -> None:
+    pyproject = tomllib.loads(pathlib.Path("pyproject.toml").read_text(encoding="utf-8"))
+    entry_points = pyproject["project"]["entry-points"]
+    target = "finite_difference_options.integrations.haircut_backend:create_backend"
+
+    assert entry_points[PREFERRED_ENTRY_POINT_GROUP]["finite_difference_options"] == target
+    assert entry_points[LEGACY_ENTRY_POINT_GROUP]["finite_difference_options"] == target
+
+    contract = solver_backend_entry_point_contract()
+    assert contract["preferred_group"] == "haircut.solver_backends"
+    assert contract["legacy_groups"] == ("haircut_engine.solver_backends",)
+    deprecations = contract["deprecations"]
+    assert isinstance(deprecations, tuple)
+    assert deprecations[0]["status"] == "compatibility_only"
 
 
 def test_haircut_backend_rejects_public_benchmark_on_private_payload() -> None:

--- a/tests/test_unified_processes.py
+++ b/tests/test_unified_processes.py
@@ -1,5 +1,7 @@
 """Tests for unified stochastic processes."""
 
+import operator
+
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
@@ -46,6 +48,72 @@ class TestProcessDimension:
 
         with pytest.raises(ValidationError, match="Process dimension must be positive"):
             ProcessDimension(value=-1)
+
+    def test_dimension_value_dunders_are_lawful_and_hash_consistent(self) -> None:
+        """ProcessDimension exposes integer conversion without integer equality."""
+        dim = ProcessDimension(value=3)
+
+        assert int(dim) == 3
+        assert operator.index(dim) == 3
+        assert dim == ProcessDimension(value=3)
+        assert dim != ProcessDimension(value=2)
+        assert dim != 3
+        assert 3 != dim
+        assert dim != True  # noqa: E712 - bool must not act as an accepted dimension int.
+        assert True != dim  # noqa: E712 - bool must not act as an accepted dimension int.
+        assert hash(dim) == hash(ProcessDimension(value=3))
+        assert len({dim, ProcessDimension(value=3)}) == 1
+        assert len({dim, 3}) == 2
+        assert repr(dim) == "ProcessDimension(value=3)"
+
+    def test_bool_dimension_construction_is_rejected(self) -> None:
+        """Bool inputs must not be coerced into dimensions 0 or 1."""
+        for value in (True, False):
+            with pytest.raises(ValidationError, match="Process dimension must be an integer, got bool"):
+                ProcessDimension(value=value)
+
+    def test_dimension_equality_laws_for_sampled_values(self) -> None:
+        """Sample equality/hash laws over dimensions and bool/int bridge values."""
+        values = [
+            ProcessDimension(value=1),
+            ProcessDimension(value=1),
+            ProcessDimension(value=2),
+            1,
+            True,
+            2,
+            False,
+            "1",
+            object(),
+        ]
+
+        for left in values:
+            assert left == left
+            for right in values:
+                assert (left == right) == (right == left)
+                if left == right:
+                    assert hash(left) == hash(right)
+                for third in values:
+                    if left == right and right == third:
+                        assert left == third
+
+    def test_dimension_dict_and_set_semantics_do_not_alias_int_or_bool(self) -> None:
+        """ProcessDimension(1) remains a distinct dict/set key from 1/True."""
+        dim = ProcessDimension(value=1)
+        mapping = {dim: "dimension", 1: "integer"}
+
+        assert mapping[dim] == "dimension"
+        assert mapping[1] == "integer"
+        assert len(mapping) == 2
+
+        mapping[True] = "bool-overwrites-int"
+        assert mapping[dim] == "dimension"
+        assert mapping[1] == "bool-overwrites-int"
+        assert len(mapping) == 2
+
+        assert len({dim, 1}) == 2
+        dimension_set = {dim, 1}
+        dimension_set.add(True)
+        assert len(dimension_set) == 2
 
 
 class TestGeometricBrownianMotion:

--- a/tests/unit/README.md
+++ b/tests/unit/README.md
@@ -1,0 +1,7 @@
+# Unit tests
+
+Repository: `finite_difference_options`.
+
+Fast isolated behavior and mathematical-law tests; mirror source packages where useful.
+
+If no executable tests exist here yet, this README is the boundary contract: add the first test when a change introduces behavior in this tier.


### PR DESCRIPTION
## Summary

- installs the repository-local `AGENTS.md` portfolio constitution (maintained-library first; SOLID/DRY/modular follow-through; probable extension planning)
- makes `docs/ARCHITECTURE.yaml` the machine-readable authority and records the repository-specific library, source-layout, test, AI, human/dunder, data, PDP/FPF/UI, and exception decisions
- adds unit/integration/e2e/architecture suite boundaries plus a dependency-free no-growth checker
- enforces 10 immediate Python runtime entries and 500 physical lines under declared Python `src` roots, with exact current-debt ceilings instead of hidden grandfathering
- uses AGENTS + deterministic commands/contracts as the default AI interface; skills are preferred for recurring workflows and MCP/plugin work remains evidence-triggered

## Enforcement profile

`blocking ratchet`. Forks/legacy/reference repositories record revival triggers rather than pretending upstream or historical source was modernized.

## Verification

- `python scripts/check_portfolio_architecture.py`
- 1,473 pytest tests passed after pinning Actions by immutable SHA.

## Discovered debt resolved

Pinned checkout/setup-python Actions to immutable SHAs after the repository security test rejected floating tags.

## Research basis

The architecture prose cites official Hermes context-file precedence, AGENTS.md guidance, Python packaging/pytest/data-model guidance, MCP security boundaries, Pylint’s file-size baseline, evolutionary fitness functions, and medallion/data-contract sources. Portfolio defaults are deliberately stricter than Pylint’s 1,000-line default: 500 physical lines and 10 immediate runtime entries, both exception-ratcheted.

Project: https://github.com/users/googa27/projects/24

Closes #139
