### PR TITLE
feat: register canonical Haircut FD backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,14 +150,16 @@ Nonuniform-grid derivatives use dedicated coefficients and convergence tests. Pa
 
 The Haircut adapter must:
 
-- expose lightweight identity, solver-contract range, maturity and capabilities;
+- expose Haircut's public `BackendIdentity` and `BackendCapabilityManifest` shapes, solver-contract range, maturity and capabilities;
+- publish exactly one canonical `haircut.solver_backends` entry point and no legacy `haircut_engine.solver_backends` FD backend entry point unless a deprecation test explicitly governs a temporary alias;
+- fail closed on solver-contract major mismatch;
 - validate the request before grid or operator work;
 - map generic records into canonical native FD contracts without reinterpretation;
 - reject absent coefficients, unsupported BCs and invalid covariance;
 - use only validated canonical numerical policies;
 - return solution, Greeks and complete diagnostics;
 - work from a clean installed wheel;
-- import no Haircut domain/application, PDP or delivery modules.
+- import only Haircut's public solver protocol seam and no Haircut domain/application, PDP or delivery modules.
 
 Advertise only capabilities backed by repository-local tests and shared parity evidence.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -315,7 +315,7 @@ Black-Scholes nonuniform-Greek evidence is split between `FD-GREEKS-NONUNIFORM-V
 Candidate entry point:
 
 ```toml
-[project.entry-points."haircut_engine.solver_backends"]
+[project.entry-points."haircut.solver_backends"]
 finite_difference_options = "finite_difference_options.integrations.haircut_backend:create_backend"
 ```
 
@@ -329,7 +329,7 @@ Adapter lifecycle:
 6. Solve and normalize values, Greeks and diagnostics.
 7. Record package, contract, benchmark-registry and environment identity.
 
-The adapter imports no Haircut domain/application, PDP or delivery modules and advertises only tested capabilities.
+The adapter imports only Haircut's public solver protocol seam (`haircut.solvers.backend_protocol` and `haircut.solvers.contracts`), no Haircut domain/application, PDP or delivery modules, and advertises only tested capabilities. Contract-major drift fails closed before a backend object is returned.
 
 Issue #79 adds `src/finite_difference_options/contracts/backend_capabilities.py` as the first executable FD adapter contract. It owns the data-only `FDCapabilityManifest`, `FDRouteRequest`, and `UnsupportedRouteDiagnostic` records used to screen QuantProblemSpec-style payloads before grid, operator, or ADI allocation. The default manifest intentionally advertises only validated FD/ADI capabilities: 1D/2D/3D uniform or log-uniform parabolic routes, drift/diffusion/reaction/source/mixed-derivative terms, Dirichlet/Neumann/Robin/second-derivative boundaries, European exercise, value/Delta/Gamma outputs, and theta/Crank-Nicolson/Rannacher/explicit/ADI controls.
 
@@ -339,7 +339,11 @@ Issue #80 adds the public-synthetic Black-Scholes call parity fixture in `src/fi
 
 Issue #76 extends the adapter tests to consume the same public-synthetic `QuantProblemSpec` vanilla-call JSON fixture validated by `haircut-engine` #91. The fixture is vendored under `tests/fixtures/quant_problem_specs/` as a data contract, not as a Python import, and the adapter must preserve schema version, measure, numeraire, units, valuation/vintage timing, boundary details, and requested outputs before route support is claimed. Issue #59 keeps that Haircut-origin fixture as a screening/fail-closed compatibility fixture: it is not executed unless its canonical fields match this repository's executable Black-Scholes oracle fixture.
 
-Issue #59 adds the `finite_difference_options.integrations.haircut_backend` factory as the current executable Haircut backend seam. The adapter exposes backend identity, a serializable capability manifest, pre-solve route screening, explicit unsupported-route diagnostics, and an executable public-synthetic Black-Scholes evidence bundle using `BS-CALL-PARITY-V0` and `QPS-VANILLA-CALL-V0`. It deliberately refuses supported-looking private, unknown, or merely label-compatible payloads unless they match the canonical executable problem spec exported by `public_black_scholes_problem_spec()`, so no coefficients, boundaries, grids, or fallback routes are fabricated. The wheel publishes the same factory through the `haircut_engine.solver_backends` entry-point group.
+Issue #59 adds the `finite_difference_options.integrations.haircut_backend` factory as the current executable Haircut backend seam. The adapter exposes backend identity, a serializable capability manifest, pre-solve route screening, explicit unsupported-route diagnostics, and an executable public-synthetic Black-Scholes evidence bundle using `BS-CALL-PARITY-V0` and `QPS-VANILLA-CALL-V0`. It deliberately refuses supported-looking private, unknown, or merely label-compatible payloads unless they match the canonical executable problem spec exported by `public_black_scholes_problem_spec()`, so no coefficients, boundaries, grids, or fallback routes are fabricated.
+
+Issue #140 replaces the legacy `haircut_engine.solver_backends` group with the canonical `haircut.solver_backends` group. A built FD wheel now declares exactly one `finite_difference_options` backend entry point under the canonical group and no FD backend entry point under the legacy group. The executable screen/solve adapter remains in `integrations/haircut_backend.py`, while `integrations/haircut_protocol.py` is the single optional boundary that maps the native FD capability manifest into Haircut's public `BackendIdentity` and `BackendCapabilityManifest` dataclasses when a released Haircut wheel is installed. Neither module redefines Haircut generic protocol shapes or adds a production local-path/VCS dependency.
+
+The issue #140 repository-wide mypy gate also records a scoped legacy no-growth exception in `mypy.ini`. It suppresses only the pre-existing error-code categories in the exact named legacy modules; `integrations/haircut_backend.py`, `integrations/haircut_protocol.py`, and every unlisted module remain fully checked. The pre-existing global missing-stub policy is unchanged and is now pinned by the same fitness test so broader global suppressions cannot appear silently. Owner: finite_difference_options maintainers. Risk: a same-category error inside a listed legacy module can be masked. Refactoring trigger: any feature change to a suppressed function/module must remove the relevant code suppression, or the portfolio typing initiative must retire the baseline. `tests/architecture/test_mypy_ratchet.py` prevents the exception set from broadening silently.
 
 Project #17 adds `finite_difference_options.integrations.solve_public_quant_problem_spec` and `released_fd_solver_contract()` as the released public-synthetic FD solver contract API for Pinares fixed-price proxy parity. The API consumes exact checked-in QuantProblemSpec fixtures, preserves measure/numeraire/units/date conventions through `FDRouteRequest`, executes only the validated Black-Scholes/Pinares public-synthetic routes, and accepts an optional `BandedOperatorCache` so repeated 1D solves reuse theta-system operators and Thomas factorizations without caching RHS values or boundary data.
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -112,7 +112,7 @@ A single endpoint price comparison is insufficient.
 
 ### FR-FD-012 — Haircut backend plugin
 
-After package, consolidation and correctness blockers pass, publish an optional `haircut_engine.solver_backends` entry point. The adapter exposes identity/version/maturity/capabilities, preserves conventions, rejects unsupported requests before operator work, returns complete diagnostics, uses canonical public FD APIs and imports no Haircut domain/application, PDP or delivery modules. Owner: #59. Current wheel entry point maps `finite_difference_options` to `finite_difference_options.integrations.haircut_backend:create_backend`.
+After package, consolidation and correctness blockers pass, publish exactly one optional canonical `haircut.solver_backends` entry point. The adapter returns Haircut's public `BackendIdentity` and `BackendCapabilityManifest` shapes, preserves conventions, rejects unsupported requests before operator work, fails closed on contract-major mismatch, returns complete diagnostics, uses canonical public FD APIs, and imports only Haircut's public solver protocol seam rather than domain/application, PDP or delivery modules. Owner: #59/#140. Current wheel entry point maps `finite_difference_options` to `finite_difference_options.integrations.haircut_backend:create_backend`; the legacy `haircut_engine.solver_backends` group is not advertised by FD.
 
 ### FR-FD-013 — Canonical implementation
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,3 +3,46 @@ python_version = 3.12
 mypy_path = src
 disallow_untyped_defs = True
 ignore_missing_imports = True
+
+# Legacy no-growth ratchet. These scoped code suppressions reflect errors present
+# before issue #140; new modules, including integrations.*, remain fully checked.
+# Owner: finite_difference_options maintainers. Removal trigger: touch the named
+# function/module for feature work or complete the portfolio typing initiative.
+[mypy-finite_difference_options.plotting.base,finite_difference_options.plotting.config_manager,finite_difference_options.processes.base,finite_difference_options.processes.nonaffine,finite_difference_options.processes.affine]
+disable_error_code = no-untyped-def
+
+[mypy-finite_difference_options.plotting]
+disable_error_code = misc,assignment
+
+[mypy-finite_difference_options.utils.state_handling]
+disable_error_code = assignment,no-untyped-def
+
+[mypy-finite_difference_options.boundary_conditions.builder]
+disable_error_code = assignment
+
+[mypy-finite_difference_options.greeks.finite_difference]
+disable_error_code = call-overload,assignment
+
+[mypy-finite_difference_options.instruments.base]
+disable_error_code = no-untyped-def,arg-type
+
+[mypy-finite_difference_options.solvers.base]
+disable_error_code = arg-type,no-untyped-def
+
+[mypy-finite_difference_options.pricing.engines.unified]
+disable_error_code = union-attr
+
+[mypy-finite_difference_options.pricing.engines.finite_difference]
+disable_error_code = assignment,arg-type
+
+[mypy-finite_difference_options.integrations.public_solver_contract]
+disable_error_code = assignment,attr-defined
+
+[mypy-finite_difference_options.pricing.workflows.option_pricer]
+disable_error_code = no-untyped-def,override,union-attr
+
+[mypy-finite_difference_options.pricing.instruments.options]
+disable_error_code = assignment,no-untyped-def
+
+[mypy-finite_difference_options.api.main]
+disable_error_code = arg-type,no-untyped-def

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ Issues = "https://github.com/googa27/finite_difference_options/issues"
 [project.scripts]
 fd-options = "finite_difference_options.cli.main:app"
 
-[project.entry-points."haircut_engine.solver_backends"]
+[project.entry-points."haircut.solver_backends"]
 finite_difference_options = "finite_difference_options.integrations.haircut_backend:create_backend"
 
 [tool.setuptools.packages.find]
@@ -100,6 +100,7 @@ finite_difference_options = ["py.typed"]
 [tool.ruff]
 line-length = 120
 target-version = "py312"
+extend-exclude = [".agent_workspace", "build"]
 
 [tool.ruff.lint]
 select = ["E", "F", "B"]

--- a/src/finite_difference_options/boundary_conditions/builder.py
+++ b/src/finite_difference_options/boundary_conditions/builder.py
@@ -14,7 +14,7 @@ from typing import Any, Literal
 
 import findiff as fd
 import numpy as np
-from findiff import BoundaryConditions, FinDiff
+from findiff import BoundaryConditions
 from numpy.typing import NDArray
 
 from finite_difference_options.exceptions import BoundaryConditionError
@@ -248,7 +248,7 @@ class BlackScholesBoundaryBuilder:
             and getattr(model, "mu", None) is not None
         ):
             return (
-                self._finite_rate(getattr(model, "mu"), "legacy model.mu"),
+                self._finite_rate(model.mu, "legacy model.mu"),
                 "legacy model.mu",
             )
         raise BoundaryConditionError(

--- a/src/finite_difference_options/instruments/operators.py
+++ b/src/finite_difference_options/instruments/operators.py
@@ -63,7 +63,7 @@ class SpatialOperator:
                 rate = float(model_rate)
                 source = "model.risk_free_rate"
             elif getattr(self.model, "mu", None) is not None:
-                rate = float(getattr(self.model, "mu"))
+                rate = float(self.model.mu)
                 source = "legacy model.mu"
             else:
                 rate = 0.0

--- a/src/finite_difference_options/integrations/__init__.py
+++ b/src/finite_difference_options/integrations/__init__.py
@@ -1,10 +1,11 @@
 """Cross-repository integration adapters for finite_difference_options."""
 
 from .haircut_backend import (
+    ContractMajorMismatchError,
     FDBackendScreeningResult,
     FiniteDifferenceHaircutBackend,
-    HaircutBackendIdentity,
     HaircutBackendSolveResult,
+    HaircutProtocolUnavailableError,
     create_backend,
 )
 from .public_solver_contract import (
@@ -15,10 +16,11 @@ from .public_solver_contract import (
 )
 
 __all__ = [
+    "ContractMajorMismatchError",
     "FDBackendScreeningResult",
     "FiniteDifferenceHaircutBackend",
-    "HaircutBackendIdentity",
     "HaircutBackendSolveResult",
+    "HaircutProtocolUnavailableError",
     "PublicFDSolverResult",
     "ReleasedFDSolverContract",
     "create_backend",

--- a/src/finite_difference_options/integrations/haircut_backend.py
+++ b/src/finite_difference_options/integrations/haircut_backend.py
@@ -1,12 +1,11 @@
 """Haircut Engine finite-difference backend adapter.
 
 This module is deliberately thin and domain-neutral. It exposes a Haircut-style
-backend object without importing Haircut Engine, PDP, API, CLI, UI, plotting, or
-frontend packages. The adapter first screens a shared QuantProblemSpec-like
-payload through the FD capability manifest. It executes only validated public-
-synthetic fixtures that this repository owns as evidence (currently Black-Scholes
-and the Pinares fixed-price proxy); all other supported-looking requests fail
-closed until a concrete native route is proven.
+backend object without importing Haircut Engine domain/application/PDP/delivery
+packages. The adapter imports only Haircut's public solver protocol seam at
+factory time, maps the repository-local FD capability manifest into Haircut's
+public BackendIdentity/BackendCapabilityManifest shapes, and fails closed on
+contract-major drift. Numerical validation runners remain lazy.
 """
 
 from __future__ import annotations
@@ -24,6 +23,12 @@ from finite_difference_options.contracts import (
     UnsupportedRouteError,
     diagnose_unsupported_route,
     ensure_route_supported,
+)
+from finite_difference_options.integrations.haircut_protocol import (
+    HAIRCUT_PUBLIC_CONTRACT_VERSION,
+    ContractMajorMismatchError,
+    HaircutProtocolUnavailableError,
+    build_haircut_contracts,
 )
 
 AdapterStatus = Literal["supported", "unsupported"]
@@ -43,22 +48,6 @@ _EXECUTED_REGISTRY_BENCHMARKS_BY_PROBLEM = {
     ),
 }
 _PUBLIC_SYNTHETIC_PROBLEM_IDS = frozenset(_EXECUTED_REGISTRY_BENCHMARKS_BY_PROBLEM)
-
-
-@dataclass(frozen=True)
-class HaircutBackendIdentity:
-    """Lightweight backend identity suitable for plugin discovery."""
-
-    backend_id: str
-    name: str
-    adapter_schema_version: str
-    contract_version: str
-    maturity: str
-    entry_point: str
-    issue_refs: tuple[str, ...]
-
-    def as_dict(self) -> dict[str, Any]:
-        return asdict(self)
 
 
 @dataclass(frozen=True)
@@ -101,37 +90,44 @@ class HaircutBackendSolveResult:
 
 
 class FiniteDifferenceHaircutBackend:
-    """Thin fail-closed adapter implementing the current FD backend contract."""
+    """Thin fail-closed adapter implementing Haircut's public backend contract."""
 
-    def __init__(self, manifest: FDCapabilityManifest = DEFAULT_FD_CAPABILITY_MANIFEST) -> None:
-        self._manifest = manifest
-        self._identity = HaircutBackendIdentity(
-            backend_id=manifest.backend_id,
-            name="finite_difference_options",
-            adapter_schema_version="haircut-fd-backend-adapter/v0",
-            contract_version=manifest.contract_version,
-            maturity="validated_public_synthetic",
-            entry_point="finite_difference_options.integrations.haircut_backend:create_backend",
-            issue_refs=(
-                "googa27/finite_difference_options#59",
-                "googa27/haircut-engine#195",
-            ),
+    def __init__(
+        self,
+        manifest: FDCapabilityManifest = DEFAULT_FD_CAPABILITY_MANIFEST,
+        *,
+        expected_contract_version: str = HAIRCUT_PUBLIC_CONTRACT_VERSION,
+    ) -> None:
+        contracts = build_haircut_contracts(
+            manifest,
+            expected_contract_version=expected_contract_version,
         )
+        self._manifest = manifest
+        self._identity = contracts.identity
+        self._capability_manifest = contracts.capability_manifest
 
     @property
-    def identity(self) -> HaircutBackendIdentity:
+    def identity(self) -> Any:
+        """Return Haircut's public ``BackendIdentity`` shape."""
+
         return self._identity
 
     @property
     def manifest(self) -> FDCapabilityManifest:
+        """Return the native FD capability manifest used for request screening."""
+
         return self._manifest
 
-    def capability_manifest(self) -> dict[str, Any]:
-        """Return data-only capability metadata without importing numerical routes."""
+    @property
+    def capability_manifest(self) -> Any:
+        """Return Haircut's public ``BackendCapabilityManifest`` shape."""
 
-        manifest = asdict(self._manifest)
-        manifest["status"] = self._manifest.status.value
-        return manifest
+        return self._capability_manifest
+
+    def fd_capability_manifest(self) -> dict[str, Any]:
+        """Return the repository-local FD manifest for adapter diagnostics."""
+
+        return _fd_manifest_as_dict(self._manifest)
 
     def screen(self, payload: Mapping[str, Any]) -> FDBackendScreeningResult:
         """Map and validate a QuantProblemSpec-like payload before numerical work."""
@@ -145,16 +141,15 @@ class FiniteDifferenceHaircutBackend:
             status="unsupported" if diagnostics else "supported",
             request=asdict(request),
             diagnostics=tuple(_diagnostic_as_dict(diagnostic) for diagnostic in diagnostics),
-            manifest=self.capability_manifest(),
+            manifest=self.fd_capability_manifest(),
         )
 
     def solve(self, payload: Mapping[str, Any]) -> HaircutBackendSolveResult:
-        """Execute the validated public-synthetic Black-Scholes fixture.
+        """Execute the validated public-synthetic fixture.
 
-        The method intentionally refuses generic supported-looking payloads until
-        they carry an executable benchmark/fixture that this repository validates.
-        This prevents silent fallback to placeholder coefficients or hard-coded
-        route semantics.
+        Generic supported-looking payloads are refused until they carry an
+        executable benchmark/fixture that this repository validates. This avoids
+        silent fallback to placeholder coefficients or hard-coded route semantics.
         """
 
         request = FDRouteRequest.from_quant_problem_spec(payload)
@@ -177,17 +172,14 @@ class FiniteDifferenceHaircutBackend:
                 )
             )
 
-        from finite_difference_options.validation.benchmark_registry import (
-            run_registered_benchmark,
-        )
-        from finite_difference_options.validation.black_scholes_parity import (
-            run_public_black_scholes_parity_fixture,
-        )
+        from finite_difference_options.validation.benchmark_registry import run_registered_benchmark
+        from finite_difference_options.validation.black_scholes_parity import run_public_black_scholes_parity_fixture
         from finite_difference_options.validation.pinares_fixed_price_proxy import (
             PINARES_FIXED_PRICE_PROXY_PROBLEM_ID,
             run_public_pinares_fixed_price_proxy_fixture,
         )
 
+        parity_report: Any
         if problem_id == PINARES_FIXED_PRICE_PROXY_PROBLEM_ID:
             parity_report = run_public_pinares_fixed_price_proxy_fixture()
             values = {
@@ -229,7 +221,7 @@ class FiniteDifferenceHaircutBackend:
         }
         evidence = {
             **parity_report.evidence.as_dict(),
-            "adapter_schema_version": self.identity.adapter_schema_version,
+            "adapter_schema_version": "haircut-fd-backend-adapter/v0",
             "source_schema_version": request.source_schema_version,
             "problem_id": problem_id,
             "privacy_class": _optional_string(payload.get("privacy_class")),
@@ -248,15 +240,21 @@ class FiniteDifferenceHaircutBackend:
 
 def create_backend(
     manifest: FDCapabilityManifest = DEFAULT_FD_CAPABILITY_MANIFEST,
+    *,
+    expected_contract_version: str = HAIRCUT_PUBLIC_CONTRACT_VERSION,
 ) -> FiniteDifferenceHaircutBackend:
-    """Entry-point factory for `haircut_engine.solver_backends` discovery."""
+    """Entry-point factory for canonical ``haircut.solver_backends`` discovery."""
 
-    return FiniteDifferenceHaircutBackend(manifest=manifest)
+    return FiniteDifferenceHaircutBackend(manifest=manifest, expected_contract_version=expected_contract_version)
 
 
-def _execution_diagnostics(
-    payload: Mapping[str, Any],
-) -> tuple[UnsupportedRouteDiagnostic, ...]:
+def _fd_manifest_as_dict(manifest: FDCapabilityManifest) -> dict[str, Any]:
+    payload = asdict(manifest)
+    payload["status"] = manifest.status.value
+    return payload
+
+
+def _execution_diagnostics(payload: Mapping[str, Any]) -> tuple[UnsupportedRouteDiagnostic, ...]:
     benchmark_ids = _benchmark_ids(payload)
     problem_id = _optional_string(payload.get("problem_id"))
     if _is_executable_public_synthetic_payload(problem_id, benchmark_ids, payload):
@@ -332,9 +330,7 @@ def _matches_public_fixture(problem_id: str | None, payload: Mapping[str, Any]) 
 
 
 def _matches_public_vanilla_call_fixture(payload: Mapping[str, Any]) -> bool:
-    from finite_difference_options.validation.black_scholes_parity import (
-        public_black_scholes_problem_spec,
-    )
+    from finite_difference_options.validation.black_scholes_parity import public_black_scholes_problem_spec
 
     expected = _canonical_fixture_shape(public_black_scholes_problem_spec())
     actual = _canonical_fixture_shape(payload)
@@ -342,9 +338,7 @@ def _matches_public_vanilla_call_fixture(payload: Mapping[str, Any]) -> bool:
 
 
 def _matches_public_pinares_fixed_price_proxy_fixture(payload: Mapping[str, Any]) -> bool:
-    from finite_difference_options.validation.pinares_fixed_price_proxy import (
-        public_pinares_fixed_price_problem_spec,
-    )
+    from finite_difference_options.validation.pinares_fixed_price_proxy import public_pinares_fixed_price_problem_spec
 
     expected = _canonical_fixture_shape(public_pinares_fixed_price_problem_spec())
     actual = _canonical_fixture_shape(payload)
@@ -390,9 +384,10 @@ def _optional_string(value: Any) -> str | None:
 
 
 __all__ = [
+    "ContractMajorMismatchError",
     "FDBackendScreeningResult",
     "FiniteDifferenceHaircutBackend",
-    "HaircutBackendIdentity",
     "HaircutBackendSolveResult",
+    "HaircutProtocolUnavailableError",
     "create_backend",
 ]

--- a/src/finite_difference_options/integrations/haircut_protocol.py
+++ b/src/finite_difference_options/integrations/haircut_protocol.py
@@ -1,0 +1,145 @@
+"""Adapter from FD capabilities to Haircut's public solver protocol.
+
+This optional boundary imports only ``haircut.solvers.backend_protocol`` and
+``haircut.solvers.contracts`` at factory time.  It owns no generic protocol
+shapes and fails closed when Haircut is unavailable or contract majors drift.
+"""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from importlib import metadata
+from typing import Any
+
+from finite_difference_options.contracts import FDCapabilityManifest
+
+HAIRCUT_BACKEND_ENTRY_POINT_GROUP = "haircut.solver_backends"
+HAIRCUT_BACKEND_ENTRY_POINT = "finite_difference_options.integrations.haircut_backend:create_backend"
+HAIRCUT_PUBLIC_CONTRACT_VERSION = "0.1.0"
+_DISTRIBUTION_NAME = "finite-difference-options"
+_ISSUE_REFS = (
+    "googa27/finite_difference_options#59",
+    "googa27/finite_difference_options#140",
+    "googa27/haircut-engine#217",
+)
+
+
+class HaircutProtocolUnavailableError(RuntimeError):
+    """Raised when Haircut's public solver protocol seam is not installed."""
+
+
+class ContractMajorMismatchError(RuntimeError):
+    """Raised when FD and Haircut backend contract majors are incompatible."""
+
+
+@dataclass(frozen=True)
+class HaircutContracts:
+    """Haircut-owned identity and capability objects for one FD plugin."""
+
+    identity: Any
+    capability_manifest: Any
+
+
+@dataclass(frozen=True)
+class _HaircutPublicSolverSeam:
+    ContractVersion: Any
+    BackendMaturity: Any
+    BackendIdentity: Any
+    MethodMaturity: Any
+    MethodCapability: Any
+    BackendCapabilityManifest: Any
+
+
+def build_haircut_contracts(
+    manifest: FDCapabilityManifest,
+    *,
+    expected_contract_version: str = HAIRCUT_PUBLIC_CONTRACT_VERSION,
+) -> HaircutContracts:
+    """Construct Haircut-owned protocol values from an FD-owned manifest."""
+
+    seam = _load_public_solver_seam()
+    _ensure_contract_major_compatible(seam, manifest.contract_version, expected_contract_version)
+    distribution_version = _distribution_version()
+    identity = seam.BackendIdentity(
+        distribution_name=_DISTRIBUTION_NAME,
+        distribution_version=distribution_version,
+        implementation_id=manifest.backend_id,
+        implementation_version=distribution_version,
+        contract_version=seam.ContractVersion.parse(manifest.contract_version),
+        maturity=seam.BackendMaturity.VALIDATED,
+        license_identifier="MIT",
+        build_metadata={
+            "entry_point_group": HAIRCUT_BACKEND_ENTRY_POINT_GROUP,
+            "entry_point": HAIRCUT_BACKEND_ENTRY_POINT,
+            "issue_refs": ",".join(_ISSUE_REFS),
+            "privacy_class": "public-synthetic",
+        },
+    )
+    method = seam.MethodCapability(
+        method_id="finite_difference_options.public_synthetic_fd.v0",
+        backend_id=manifest.backend_id,
+        family="finite_difference",
+        exactness="approximation",
+        maturity=seam.MethodMaturity.VALIDATED,
+        equation_families=("black_scholes", "linear_parabolic", "feynman_kac"),
+        dimensions=manifest.supported_dimensions,
+        state_variables=("tradable_spot", "variance", "auxiliary_state"),
+        boundary_conditions=manifest.boundary_conditions,
+        smoothness_assumptions=("piecewise_smooth_payoff", "public_synthetic_fixture"),
+        output_types=manifest.outputs,
+        runtime_controls=tuple(str(key) for key in manifest.resource_controls),
+        validation_gates=(
+            "benchmark:BS-CALL-PARITY-V0",
+            "benchmark:QPS-VANILLA-CALL-V0",
+            "benchmark:PINARES-FD-FIXED-PRICE-PROXY-V0",
+            "benchmark:PINARES-QPS-FIXED-PRICE-PROXY-V0",
+        ),
+        failure_modes=manifest.diagnostics,
+        fallback_route_id=None,
+        fallback_triggers=(),
+        fallback_policy="fail_closed_no_fallback",
+        references=("docs/ARCHITECTURE.md", *_ISSUE_REFS),
+    )
+    capability_manifest = seam.BackendCapabilityManifest(
+        backend_id=manifest.backend_id,
+        contract_version=manifest.contract_version,
+        methods=(method,),
+    )
+    return HaircutContracts(identity=identity, capability_manifest=capability_manifest)
+
+
+def _load_public_solver_seam() -> _HaircutPublicSolverSeam:
+    try:
+        backend_protocol = importlib.import_module("haircut.solvers.backend_protocol")
+        contracts = importlib.import_module("haircut.solvers.contracts")
+    except ImportError as exc:
+        raise HaircutProtocolUnavailableError(
+            "Haircut public solver protocol seam is required to instantiate the FD backend. "
+            "Install a released haircut-engine wheel; local source-tree imports are not used."
+        ) from exc
+    return _HaircutPublicSolverSeam(
+        ContractVersion=backend_protocol.ContractVersion,
+        BackendMaturity=backend_protocol.BackendMaturity,
+        BackendIdentity=backend_protocol.BackendIdentity,
+        MethodMaturity=contracts.MethodMaturity,
+        MethodCapability=contracts.MethodCapability,
+        BackendCapabilityManifest=contracts.BackendCapabilityManifest,
+    )
+
+
+def _ensure_contract_major_compatible(seam: _HaircutPublicSolverSeam, provider: str, expected: str) -> None:
+    provider_version = seam.ContractVersion.parse(provider)
+    expected_version = seam.ContractVersion.parse(expected)
+    if not provider_version.is_compatible_with(expected_version):
+        raise ContractMajorMismatchError(
+            "contract major mismatch between finite_difference_options and Haircut solver protocol: "
+            f"provider={provider_version}, expected={expected_version}"
+        )
+
+
+def _distribution_version() -> str:
+    try:
+        return metadata.version(_DISTRIBUTION_NAME)
+    except metadata.PackageNotFoundError:
+        return "0.1.0"

--- a/src/finite_difference_options/utils/state_handling.py
+++ b/src/finite_difference_options/utils/state_handling.py
@@ -102,12 +102,12 @@ def validate_positive_state_components(
         component_names = [f"component_{i}" for i in component_indices]
 
     if state.ndim == 1:
-        for idx, name in zip(component_indices, component_names):
+        for idx, name in zip(component_indices, component_names, strict=True):
             if state[idx] < 0:
                 raise ValidationError(f"{name} must be non-negative, got {state[idx]}")
             result[idx] = max(state[idx], min_value)
     else:
-        for idx, name in zip(component_indices, component_names):
+        for idx, name in zip(component_indices, component_names, strict=True):
             if np.any(state[:, idx] < 0):
                 negative_mask = state[:, idx] < 0
                 raise ValidationError(

--- a/src/finite_difference_options/validation/black_scholes_parity.py
+++ b/src/finite_difference_options/validation/black_scholes_parity.py
@@ -283,6 +283,7 @@ def _build_public_problem_spec(
 
     return {
         "schema_version": "quant-problem-spec/v0",
+        "privacy_class": "public_synthetic",
         "artifact_manifest": {
             "schema_version": "artifact-manifest/v0",
             "manifest_id": "public-synthetic-bs-call-oracle-fixture-v0",

--- a/tests/architecture/test_mypy_ratchet.py
+++ b/tests/architecture/test_mypy_ratchet.py
@@ -1,0 +1,58 @@
+"""No-growth guard for legacy mypy suppressions."""
+
+from __future__ import annotations
+
+import configparser
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+EXPECTED = {
+    (
+        "finite_difference_options.plotting.base",
+        "finite_difference_options.plotting.config_manager",
+        "finite_difference_options.processes.base",
+        "finite_difference_options.processes.nonaffine",
+        "finite_difference_options.processes.affine",
+    ): {"no-untyped-def"},
+    ("finite_difference_options.plotting",): {"misc", "assignment"},
+    ("finite_difference_options.utils.state_handling",): {"assignment", "no-untyped-def"},
+    ("finite_difference_options.boundary_conditions.builder",): {"assignment"},
+    ("finite_difference_options.greeks.finite_difference",): {"call-overload", "assignment"},
+    ("finite_difference_options.instruments.base",): {"no-untyped-def", "arg-type"},
+    ("finite_difference_options.solvers.base",): {"arg-type", "no-untyped-def"},
+    ("finite_difference_options.pricing.engines.unified",): {"union-attr"},
+    ("finite_difference_options.pricing.engines.finite_difference",): {"assignment", "arg-type"},
+    ("finite_difference_options.integrations.public_solver_contract",): {"assignment", "attr-defined"},
+    ("finite_difference_options.pricing.workflows.option_pricer",): {
+        "no-untyped-def",
+        "override",
+        "union-attr",
+    },
+    ("finite_difference_options.pricing.instruments.options",): {"assignment", "no-untyped-def"},
+    ("finite_difference_options.api.main",): {"arg-type", "no-untyped-def"},
+}
+
+
+def test_legacy_mypy_suppressions_are_exact_and_exclude_haircut_adapter() -> None:
+    config = configparser.ConfigParser()
+    config.read(ROOT / "mypy.ini")
+    assert dict(config["mypy"]) == {
+        "python_version": "3.12",
+        "mypy_path": "src",
+        "disallow_untyped_defs": "True",
+        "ignore_missing_imports": "True",
+    }
+    actual: dict[tuple[str, ...], set[str]] = {}
+    for section in config.sections():
+        if not section.startswith("mypy-"):
+            continue
+        modules = tuple(section.removeprefix("mypy-").split(","))
+        codes = {item.strip() for item in config[section]["disable_error_code"].split(",")}
+        actual[modules] = codes
+
+    assert actual == EXPECTED
+    assert not any(
+        module.startswith("finite_difference_options.integrations.haircut_")
+        for modules in actual
+        for module in modules
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,132 @@
 """Shared test configuration and fixtures for the finite difference options library."""
 
-import pytest
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
 import numpy as np
+import pytest
 from numpy.typing import NDArray
+
+
+@dataclass(frozen=True, order=True)
+class _FakeContractVersion:
+    major: int
+    minor: int
+    patch: int
+
+    @classmethod
+    def parse(cls, value: object) -> "_FakeContractVersion":
+        if isinstance(value, _FakeContractVersion):
+            return value
+        major, minor, patch = (int(part) for part in str(value).split("."))
+        return cls(major=major, minor=minor, patch=patch)
+
+    def is_compatible_with(self, other: object) -> bool:
+        return self.major == self.parse(other).major
+
+    def __str__(self) -> str:
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+
+class _FakeBackendMaturity(Enum):
+    EXPERIMENTAL = "experimental"
+    VALIDATED = "validated"
+    PRODUCTION = "production"
+    DEPRECATED = "deprecated"
+    UNSUPPORTED = "unsupported"
+
+
+class _FakeMethodMaturity(Enum):
+    DRAFT = "draft"
+    VALIDATED = "validated"
+    EXPERIMENTAL = "experimental"
+    PRODUCTION_GATED = "production_gated"
+
+
+@dataclass(frozen=True)
+class _FakeBackendIdentity:
+    distribution_name: str
+    distribution_version: str
+    implementation_id: str
+    implementation_version: str
+    contract_version: _FakeContractVersion
+    maturity: _FakeBackendMaturity
+    license_identifier: str = "UNKNOWN"
+    build_metadata: dict[str, str] = field(default_factory=dict)
+    schema_version: str = "solver-backend-identity/v0"
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "distribution_name": self.distribution_name,
+            "distribution_version": self.distribution_version,
+            "implementation_id": self.implementation_id,
+            "implementation_version": self.implementation_version,
+            "contract_version": str(self.contract_version),
+            "maturity": self.maturity.value,
+            "license_identifier": self.license_identifier,
+            "build_metadata": dict(self.build_metadata),
+        }
+
+
+@dataclass(frozen=True)
+class _FakeMethodCapability:
+    method_id: str
+    backend_id: str
+    family: str
+    exactness: str
+    maturity: _FakeMethodMaturity
+    equation_families: tuple[str, ...]
+    dimensions: tuple[int, ...]
+    state_variables: tuple[str, ...]
+    boundary_conditions: tuple[str, ...]
+    smoothness_assumptions: tuple[str, ...]
+    output_types: tuple[str, ...]
+    runtime_controls: tuple[str, ...]
+    validation_gates: tuple[str, ...]
+    failure_modes: tuple[str, ...]
+    fallback_route_id: str | None
+    fallback_triggers: tuple[str, ...]
+    fallback_policy: str
+    references: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _FakeBackendCapabilityManifest:
+    backend_id: str
+    contract_version: str
+    methods: tuple[_FakeMethodCapability, ...]
+
+    def validate(self) -> tuple[str, ...]:
+        return ()
+
+
+@pytest.fixture
+def haircut_public_solver_seam(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide Haircut's public solver seam shape without a source-tree dependency."""
+
+    haircut = types.ModuleType("haircut")
+    solvers = types.ModuleType("haircut.solvers")
+    backend_protocol = types.ModuleType("haircut.solvers.backend_protocol")
+    contracts = types.ModuleType("haircut.solvers.contracts")
+
+    backend_protocol.__dict__["ContractVersion"] = _FakeContractVersion
+    backend_protocol.__dict__["BackendMaturity"] = _FakeBackendMaturity
+    backend_protocol.__dict__["BackendIdentity"] = _FakeBackendIdentity
+    backend_protocol.__dict__["SOLVER_BACKEND_ENTRY_POINT_GROUP"] = "haircut.solver_backends"
+    contracts.__dict__["MethodMaturity"] = _FakeMethodMaturity
+    contracts.__dict__["MethodCapability"] = _FakeMethodCapability
+    contracts.__dict__["BackendCapabilityManifest"] = _FakeBackendCapabilityManifest
+
+    monkeypatch.setitem(sys.modules, "haircut", haircut)
+    monkeypatch.setitem(sys.modules, "haircut.solvers", solvers)
+    monkeypatch.setitem(sys.modules, "haircut.solvers.backend_protocol", backend_protocol)
+    monkeypatch.setitem(sys.modules, "haircut.solvers.contracts", contracts)
 
 
 # Common test data and fixtures
@@ -25,19 +149,19 @@ def sample_spatial_grid() -> NDArray[np.float64]:
 
 
 @pytest.fixture
-def standard_option_params() -> dict:
+def standard_option_params() -> dict[str, float]:
     """Standard option parameters for testing."""
     return {"strike": 100.0, "maturity": 1.0, "rate": 0.05, "sigma": 0.2}
 
 
 @pytest.fixture
-def heston_params() -> dict:
-    """Standard Heston model parameters for testing."""
+def heston_params() -> dict[str, float]:
+    """Standard Heston model parameters."""
     return {"r": 0.05, "kappa": 2.0, "theta": 0.04, "sigma_v": 0.3, "rho": -0.7}
 
 
 @pytest.fixture
-def small_grid_2d() -> tuple:
+def small_grid_2d() -> tuple[NDArray[np.float64], NDArray[np.float64]]:
     """Small 2D grid for testing."""
     s_grid = np.linspace(0.0, 200.0, 11)
     v_grid = np.linspace(0.0, 0.5, 6)
@@ -45,6 +169,6 @@ def small_grid_2d() -> tuple:
 
 
 @pytest.fixture
-def tolerance() -> dict:
+def tolerance() -> dict[str, float]:
     """Standard tolerances for numerical tests."""
     return {"rtol": 1e-10, "atol": 1e-12}

--- a/tests/test_boundary_conditions.py
+++ b/tests/test_boundary_conditions.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import math
-import pathlib
-import sys
 from types import SimpleNamespace
 
 

--- a/tests/test_fd_black_scholes_parity_fixture.py
+++ b/tests/test_fd_black_scholes_parity_fixture.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import pathlib
-import sys
 
 
 from finite_difference_options.contracts import SolverEvidence  # noqa: E402

--- a/tests/test_finite_difference_greeks.py
+++ b/tests/test_finite_difference_greeks.py
@@ -1,7 +1,5 @@
 """Unit tests for FiniteDifferenceGreeks."""
 
-import pathlib
-import sys
 
 
 import numpy as np

--- a/tests/test_greeks.py
+++ b/tests/test_greeks.py
@@ -1,7 +1,5 @@
 """Tests for finite difference Greek calculations."""
 
-import pathlib
-import sys
 
 
 import numpy as np

--- a/tests/test_haircut_backend_adapter.py
+++ b/tests/test_haircut_backend_adapter.py
@@ -3,13 +3,18 @@
 from __future__ import annotations
 
 import ast
+from dataclasses import replace
+import importlib.metadata as metadata
 import json
 import pathlib
 
 import pytest
 
-from finite_difference_options.contracts import UnsupportedRouteError
-from finite_difference_options.integrations.haircut_backend import create_backend
+from finite_difference_options.contracts import DEFAULT_FD_CAPABILITY_MANIFEST, UnsupportedRouteError
+from finite_difference_options.integrations import haircut_protocol
+from finite_difference_options.integrations.haircut_backend import ContractMajorMismatchError, create_backend
+
+pytestmark = pytest.mark.usefixtures("haircut_public_solver_seam")
 
 FIXTURE_DIR = pathlib.Path(__file__).parent / "fixtures" / "quant_problem_specs"
 
@@ -25,9 +30,7 @@ def _executable_payload() -> dict[str, object]:
         public_black_scholes_problem_spec,
     )
 
-    payload = public_black_scholes_problem_spec()
-    payload["privacy_class"] = "public_synthetic"
-    return payload
+    return public_black_scholes_problem_spec()
 
 
 def _section(payload: dict[str, object], name: str) -> dict[str, object]:
@@ -36,19 +39,73 @@ def _section(payload: dict[str, object], name: str) -> dict[str, object]:
     return section
 
 
-def test_haircut_backend_identity_and_manifest_are_lightweight() -> None:
+def test_haircut_backend_identity_and_manifest_use_haircut_public_shapes() -> None:
+    from haircut.solvers.backend_protocol import BackendIdentity, BackendMaturity
+    from haircut.solvers.contracts import BackendCapabilityManifest, MethodMaturity
+
     backend = create_backend()
 
-    assert backend.identity.backend_id == "finite_difference_options.fd_backend.v0"
-    assert backend.identity.contract_version == backend.manifest.contract_version
-    assert backend.identity.maturity == "validated_public_synthetic"
-    assert backend.identity.issue_refs == (
-        "googa27/finite_difference_options#59",
-        "googa27/haircut-engine#195",
+    assert isinstance(backend.identity, BackendIdentity)
+    assert backend.identity.distribution_name == "finite-difference-options"
+    assert backend.identity.implementation_id == "finite_difference_options.fd_backend.v0"
+    assert str(backend.identity.contract_version) == backend.manifest.contract_version
+    assert backend.identity.maturity is BackendMaturity.VALIDATED
+    assert backend.identity.build_metadata["entry_point_group"] == "haircut.solver_backends"
+    assert backend.identity.build_metadata["issue_refs"] == (
+        "googa27/finite_difference_options#59,googa27/finite_difference_options#140,googa27/haircut-engine#217"
     )
-    manifest = backend.capability_manifest()
-    assert manifest["backend_id"] == "finite_difference_options.fd_backend.v0"
-    assert manifest["status"] == "validated"
+
+    manifest = backend.capability_manifest
+    assert isinstance(manifest, BackendCapabilityManifest)
+    assert manifest.backend_id == "finite_difference_options.fd_backend.v0"
+    assert manifest.contract_version == backend.manifest.contract_version
+    assert len(manifest.methods) == 1
+    method = manifest.methods[0]
+    assert method.backend_id == manifest.backend_id
+    assert method.maturity is MethodMaturity.VALIDATED
+    assert method.fallback_policy == "fail_closed_no_fallback"
+    assert "value" in method.output_types
+
+    fd_manifest = backend.fd_capability_manifest()
+    assert fd_manifest["backend_id"] == "finite_difference_options.fd_backend.v0"
+    assert fd_manifest["status"] == "validated"
+
+
+def test_haircut_backend_imports_only_public_solver_protocol_seam(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[str] = []
+    original_import_module = haircut_protocol.importlib.import_module
+
+    def _spy_import_module(name: str):
+        if name.startswith("haircut"):
+            seen.append(name)
+        return original_import_module(name)
+
+    monkeypatch.setattr(haircut_protocol.importlib, "import_module", _spy_import_module)
+
+    create_backend()
+
+    assert set(seen) <= {"haircut.solvers.backend_protocol", "haircut.solvers.contracts"}
+
+
+def test_haircut_backend_fails_closed_on_contract_major_mismatch() -> None:
+    manifest = replace(DEFAULT_FD_CAPABILITY_MANIFEST, contract_version="1.0.0")
+
+    with pytest.raises(ContractMajorMismatchError, match="contract major mismatch"):
+        create_backend(manifest=manifest, expected_contract_version="0.1.0")
+
+
+def test_built_distribution_declares_exactly_one_canonical_haircut_entry_point() -> None:
+    canonical = metadata.entry_points(group="haircut.solver_backends")
+    legacy = metadata.entry_points(group="haircut_engine.solver_backends")
+
+    matches = [
+        ep
+        for ep in canonical
+        if ep.name == "finite_difference_options"
+        and ep.value == "finite_difference_options.integrations.haircut_backend:create_backend"
+    ]
+    assert len(matches) == 1
+    assert not [ep for ep in legacy if ep.name == "finite_difference_options"]
 
 
 def test_haircut_backend_screen_preserves_quant_problem_spec_without_solving() -> None:

--- a/tests/test_model_aware_reaction_terms.py
+++ b/tests/test_model_aware_reaction_terms.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import pathlib
-import sys
 
 
 import numpy as np

--- a/tests/test_multidimensional_adapter_coefficients.py
+++ b/tests/test_multidimensional_adapter_coefficients.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import inspect
-import pathlib
-import sys
 
 
 import numpy as np

--- a/tests/test_option_pricer.py
+++ b/tests/test_option_pricer.py
@@ -1,7 +1,5 @@
 """Tests for OptionPricer.compute_grid."""
 
-import pathlib
-import sys
 
 
 import numpy as np

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,11 +1,8 @@
 """Tests for option base class and subclasses."""
 
-import pathlib
-import sys
 
 
 import numpy as np
-import pytest
 
 from finite_difference_options.processes.affine import GeometricBrownianMotion
 from finite_difference_options.instruments.base import (

--- a/tests/test_packaging_contract.py
+++ b/tests/test_packaging_contract.py
@@ -130,13 +130,19 @@ def test_entry_points_advertise_cli_and_haircut_backend() -> None:
         for ep in console_scripts
     )
 
-    solver_backends = metadata.entry_points(group="haircut_engine.solver_backends")
-    assert any(
-        ep.name == "finite_difference_options"
-        and ep.value
-        == "finite_difference_options.integrations.haircut_backend:create_backend"
+    solver_backends = metadata.entry_points(group="haircut.solver_backends")
+    matches = [
+        ep
         for ep in solver_backends
-    )
+        if ep.name == "finite_difference_options"
+        and ep.value == "finite_difference_options.integrations.haircut_backend:create_backend"
+    ]
+    assert len(matches) == 1
+    assert not [
+        ep
+        for ep in metadata.entry_points(group="haircut_engine.solver_backends")
+        if ep.name == "finite_difference_options"
+    ]
 
 
 def test_python_sources_do_not_mutate_sys_path_for_checkout_only_imports() -> None:

--- a/tests/test_pde_pricer.py
+++ b/tests/test_pde_pricer.py
@@ -1,7 +1,5 @@
 """Tests for the finite difference Black--Scholes pricer."""
 
-import pathlib
-import sys
 
 
 import numpy as np

--- a/tests/test_pinares_fd_proxy.py
+++ b/tests/test_pinares_fd_proxy.py
@@ -30,6 +30,8 @@ from finite_difference_options.validation.pinares_fixed_price_proxy import (
     run_public_pinares_fixed_price_proxy_fixture,
 )
 
+pytestmark = pytest.mark.usefixtures("haircut_public_solver_seam")
+
 FIXTURE_DIR = pathlib.Path(__file__).resolve().parent / "fixtures"
 QPS_FIXTURE = FIXTURE_DIR / "quant_problem_specs" / "pinares_fixed_price_proxy.json"
 RESULT_FIXTURE = FIXTURE_DIR / "pinares_fd_fixed_price_proxy_v1.json"

--- a/tests/test_pricing_engine_imports.py
+++ b/tests/test_pricing_engine_imports.py
@@ -1,7 +1,5 @@
 """Tests covering the finite difference pricing engine import surface."""
 
-import pathlib
-import sys
 
 
 from finite_difference_options.pricing import (

--- a/tests/test_rannacher_startup.py
+++ b/tests/test_rannacher_startup.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import pathlib
-import sys
 
 import numpy as np
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,7 +1,5 @@
 """Tests for input validation functionality."""
 
-import pathlib
-import sys
 
 
 import numpy as np


### PR DESCRIPTION
## Summary

- replace the legacy `haircut_engine.solver_backends` registration with exactly one canonical `haircut.solver_backends` entry point
- map the native FD capability manifest into Haircut-owned `BackendIdentity` and `BackendCapabilityManifest` objects through a lazy public-protocol boundary
- fail closed when Haircut's public seam is unavailable or the contract major drifts; no local-path/VCS/runtime Haircut dependency or generic protocol redefinition
- preserve the executable public-synthetic Black-Scholes/Pinares routes, make fixture privacy metadata canonical, and reject private/unsupported routes before numerical imports
- split the optional protocol mapping out of the executable adapter so both runtime modules stay below 500 physical lines
- make repository-wide Ruff/mypy gates green; scope and ratchet pre-existing mypy debt instead of suppressing the new adapter

## Verification

- `uv run ruff check .` — passed
- `uv run mypy src` — `Success: no issues found in 68 source files`
- `uv run pytest -q` — `385 passed`
- `uv run pytest tests/architecture -q` — `25 passed`
- wheel build — passed
- exact clean Python 3.12 metadata-only install from `dist/` — passed
- installed metadata — one canonical entry point, zero legacy entries
- installed alongside real Haircut wheel — discovery registered `finite_difference_options.fd_backend.v0`, no issues, native Haircut identity/capability types, manifest validation `()`
- canonical Black-Scholes fixture screens as supported without test mutation

## Dependency boundary

The provider wheel deliberately does not depend on Haircut. Haircut is the host and owns the generic discovery/protocol contracts. Metadata can be inspected with `--no-deps`; factory instantiation fails closed unless the host supplies Haircut's released public protocol seam.

Closes #140

Predecessor: googa27/haircut-engine#217 / PR #222
Project: https://github.com/users/googa27/projects/26
